### PR TITLE
File class, created by FilePath#file

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -123,6 +123,42 @@ To gain access to a _Clock_ use [System#clock](#method-clock).
 
 Returns a [Time](#time) object representing current time.
 
+## File
+
+#### **method** `forAppend` -> _File_
+
+Returns a fresh file similar to receiver, with append-mode set. Overrides
+a previous `forWrite`.
+
+#### **method** `forRead` -> _File_
+
+Returns a fresh file similar to receiver, with read-mode set. Overrides
+a previous `forAppend`.
+
+#### **method** `forWrite` -> _File_
+
+Returns a fresh file similar to receiver, with write-mode set. Overrides
+
+#### **method** `isAppend` -> _Boolean_
+
+Returns true if the receiver has append-mode set.
+
+#### **method** `isRead` -> _Boolean_
+
+Returns true if the receiver has read-mode set.
+
+#### **method** `isTruncate` -> _Boolean_
+
+Returns true if the receiver has truncate-mode set.
+
+#### **method** `isWrite` -> _Boolean_
+
+Returns true if the receiver has write-mode set.
+
+#### **method** `truncateExisting` -> _File_
+
+Returns a fresh file similar to receiver, with truncate-mode set.
+
 ## FilePath
 
 Object representing a point in the filesystem and permission to operate
@@ -133,6 +169,25 @@ or directory exists.
 
 !> Symlinks in the filesystem can provide access to parts outside the
 _FilePath_.
+
+#### **method** `file` -> _File_
+
+Returns a [File](#file) associated with the receiver, with open mode unset.
+
+#### **method** `forAppend` -> _File_
+
+Returns a [File](#file) associated with the receiver, ready to be opened in
+append-mode.
+
+#### **method** `forRead` -> _File_
+
+Returns a [File](#file) associated with the receiver, ready to be opened in
+read-mode.
+
+#### **method** `forWrite` -> _File_
+
+Returns a [File](#file) associated with the receiver, ready to be opened in
+write-mode.
 
 #### **method** `path:` _pathname_ -> _FilePath_
 

--- a/foo/lang/file.foo
+++ b/foo/lang/file.foo
@@ -1,0 +1,4 @@
+extend File
+    method displayOn: stream
+        stream print: self toString
+end

--- a/foo/lang/filepath.foo
+++ b/foo/lang/filepath.foo
@@ -1,4 +1,10 @@
 extend FilePath
+    method forAppend
+        self file forAppend
+    method forRead
+        self file forRead
+    method forWrite
+        self file forWrite
     method displayOn: stream
         stream print: self toString
 end

--- a/foo/prelude.foo
+++ b/foo/prelude.foo
@@ -3,6 +3,7 @@ import .lang.boolean
 import .lang.byteArray
 import .lang.collection
 import .lang.dictionary
+import .lang.file
 import .lang.filepath
 import .lang.float
 import .lang.integer

--- a/foo/tests/test.foo
+++ b/foo/tests/test.foo
@@ -72,7 +72,55 @@ class Main { assert system }
         self testRecord.
         self testDictionary.
         self testRaise.
-        self testFilePath
+        self testFilePath.
+        self testFile
+
+    method testFile
+        let file = system currentDirectory file.
+        assert false: { file isAppend }
+               testing: "FilePath#file creates file without append".
+        assert false: { file isRead }
+               testing: "FilePath#file creates file without read".
+        assert false: { file isTruncate }
+               testing: "FilePath#file creates file without truncate".
+        assert false: { file isWrite }
+               testing: "FilePath#file creates file without write".
+        let readfile = file forRead.
+        assert true: { readfile isRead }
+               testing: "File#forRead sets read".
+        assert false: { readfile isAppend }
+               testing: "File#forRead does not set append".
+        assert false: { readfile isTruncate }
+               testing: "File#forRead does not set truncate".
+        assert false: { readfile isWrite }
+               testing: "File#forRead does not set write".
+        let writefile = file forWrite.
+        assert true: { writefile isWrite }
+               testing: "File#forWrite sets write".
+        assert false: { writefile isAppend }
+               testing: "File#forWrite does not set append".
+        assert false: { writefile isRead }
+               testing: "File#forWrite does not set read".
+        assert false: { writefile isTruncate }
+               testing: "File#forWrite does not set truncate".
+        let appendfile = file forAppend.
+        assert true: { appendfile isAppend }
+               testing: "File#forAppend sets append".
+        assert false: { appendfile isRead }
+               testing: "File#forAppend does not set read".
+        assert false: { appendfile isTruncate }
+               testing: "File#forAppend does not set truncate".
+        assert false: { appendfile isWrite }
+               testing: "File#forWrite does not set write".
+        let truncatefile = file truncateExisting.
+        assert true: { truncatefile isTruncate }
+               testing: "File#truncateExisting sets truncate".
+        assert false: { truncatefile isAppend }
+               testing: "File#truncateExisting does not set append".
+        assert false: { truncatefile isRead }
+               testing: "File#truncateExisting does not set read".
+        assert false: { truncatefile isWrite }
+               testing: "File#forWrite does not set write"
 
     method testIs
         assert true: { 1 is 1 } testing: "integer 'is' integer (match)".

--- a/src/classes/file.rs
+++ b/src/classes/file.rs
@@ -1,0 +1,154 @@
+use std::fmt;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use crate::eval::Env;
+use crate::objects::{Datum, Eval, Object, Vtable};
+use crate::unwind::Unwind;
+
+#[derive(PartialEq, Hash, Clone, Copy)]
+enum WriteMode {
+    None,
+    Append,
+    Write,
+}
+
+#[derive(PartialEq, Hash)]
+pub struct File {
+    path: PathBuf,
+    read: bool,
+    truncate: bool,
+    write_mode: WriteMode,
+}
+
+impl File {
+    fn object(self, env: &Env) -> Object {
+        Object {
+            vtable: env.foo.file_vtable.clone(),
+            datum: Datum::File(Rc::new(self)),
+        }
+    }
+}
+
+impl Eq for File {}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "#<File {:?} (", self.path.to_string_lossy())?;
+        let mut prefix = "";
+        if self.read {
+            write!(f, "{}read", prefix)?;
+            prefix = "|";
+        }
+        if WriteMode::Append == self.write_mode {
+            write!(f, "{}append", prefix)?;
+            prefix = "|";
+        }
+        if WriteMode::Write == self.write_mode {
+            write!(f, "{}write", prefix)?;
+            prefix = "|";
+            if self.truncate {
+                write!(f, "{}truncate", prefix)?;
+            }
+        }
+        if prefix == "" {
+            write!(f, "mode unset")?;
+        }
+        write!(f, ")>")
+    }
+}
+
+pub fn as_file<'a>(obj: &'a Object, ctx: &str) -> Result<&'a File, Unwind> {
+    match &obj.datum {
+        Datum::File(ref file) => Ok(file),
+        _ => Unwind::error(&format!("{:?} is not a File in {}", obj, ctx)),
+    }
+}
+
+pub fn class_vtable() -> Vtable {
+    Vtable::new("class File")
+}
+
+pub fn instance_vtable() -> Vtable {
+    let vt = Vtable::new("File");
+    vt.add_primitive_method_or_panic("forAppend", file_for_append);
+    vt.add_primitive_method_or_panic("forRead", file_for_read);
+    vt.add_primitive_method_or_panic("forWrite", file_for_write);
+    vt.add_primitive_method_or_panic("isAppend", file_is_append);
+    vt.add_primitive_method_or_panic("isRead", file_is_read);
+    vt.add_primitive_method_or_panic("isTruncate", file_is_truncate);
+    vt.add_primitive_method_or_panic("isWrite", file_is_write);
+    vt.add_primitive_method_or_panic("truncateExisting", file_truncate_existing);
+    vt
+}
+
+pub fn make_file(path: &Path, env: &Env) -> Object {
+    File {
+        path: PathBuf::from(path),
+        read: false,
+        truncate: false,
+        write_mode: WriteMode::None,
+    }
+    .object(env)
+}
+
+fn file_for_append(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    let file = receiver.as_file("in File#forAppend")?;
+    Ok(File {
+        path: file.path.clone(),
+        read: file.read,
+        truncate: file.truncate,
+        write_mode: WriteMode::Append,
+    }
+    .object(env))
+}
+
+fn file_for_read(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    let file = receiver.as_file("in File#forRead")?;
+    Ok(File {
+        path: file.path.clone(),
+        read: true,
+        truncate: file.truncate,
+        write_mode: file.write_mode,
+    }
+    .object(env))
+}
+
+fn file_for_write(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    let file = receiver.as_file("in File#forWrite")?;
+    Ok(File {
+        path: file.path.clone(),
+        read: file.read,
+        truncate: file.truncate,
+        write_mode: WriteMode::Write,
+    }
+    .object(env))
+}
+
+fn file_is_append(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_file("in File#isAppend")?.write_mode == WriteMode::Append))
+}
+
+fn file_is_read(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_file("in File#isRead")?.read))
+}
+
+fn file_is_truncate(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_file("in File#isTruncate")?.truncate))
+}
+
+fn file_is_write(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_file("in File#isWrite")?.write_mode == WriteMode::Write))
+}
+
+fn file_truncate_existing(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    let file = receiver.as_file("in File#truncateExisting")?;
+    Ok(File {
+        path: file.path.clone(),
+        read: file.read,
+        truncate: true,
+        write_mode: file.write_mode,
+    }
+    .object(env))
+}

--- a/src/classes/filepath.rs
+++ b/src/classes/filepath.rs
@@ -49,10 +49,11 @@ pub fn class_vtable() -> Vtable {
 
 pub fn instance_vtable() -> Vtable {
     let vt = Vtable::new("FilePath");
-    vt.add_primitive_method_or_panic("path:", filepath_path);
     vt.add_primitive_method_or_panic("exists", filepath_exists);
+    vt.add_primitive_method_or_panic("file", filepath_file);
     vt.add_primitive_method_or_panic("isDirectory", filepath_is_directory);
     vt.add_primitive_method_or_panic("isFile", filepath_is_file);
+    vt.add_primitive_method_or_panic("path:", filepath_path);
     vt
 }
 
@@ -63,6 +64,22 @@ fn into_filepath(path: PathBuf, env: &Env) -> Object {
             path,
         })),
     }
+}
+
+fn filepath_exists(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#exists")?.path.exists()))
+}
+
+fn filepath_file(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(crate::classes::file::make_file(&receiver.as_filepath("in FilePath#file")?.path, env))
+}
+
+fn filepath_is_directory(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#isDirectory")?.path.is_dir()))
+}
+
+fn filepath_is_file(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#isFile")?.path.is_file()))
 }
 
 fn filepath_path(receiver: &Object, args: &[Object], env: &Env) -> Eval {
@@ -80,16 +97,4 @@ fn filepath_path(receiver: &Object, args: &[Object], env: &Env) -> Eval {
     } else {
         Unwind::error(&format!("Cannot extend {:?} with {:?}", filepath, more))
     }
-}
-
-fn filepath_exists(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
-    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#exists")?.path.exists()))
-}
-
-fn filepath_is_directory(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
-    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#isDirectory")?.path.is_dir()))
-}
-
-fn filepath_is_file(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
-    Ok(env.foo.make_boolean(receiver.as_filepath("in FilePath#isFile")?.path.is_file()))
 }

--- a/src/classes/mod.rs
+++ b/src/classes/mod.rs
@@ -5,6 +5,7 @@ pub mod clock;
 pub mod closure;
 pub mod compiler;
 pub mod dictionary;
+pub mod file;
 pub mod filepath;
 pub mod float;
 pub mod input;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -602,6 +602,7 @@ pub enum Datum {
     Closure(Rc<Closure>),
     Compiler(Rc<Compiler>),
     Dictionary(Rc<classes::dictionary::Dictionary>),
+    File(Rc<classes::file::File>),
     FilePath(Rc<classes::filepath::FilePath>),
     Float(f64),
     Input(Rc<Input>),
@@ -634,6 +635,7 @@ impl Hash for Datum {
             Closure(x) => x.hash(state),
             Compiler(x) => x.hash(state),
             Dictionary(x) => x.hash(state),
+            File(x) => x.hash(state),
             FilePath(x) => x.hash(state),
             Float(x) => x.to_bits().hash(state),
             Input(x) => x.hash(state),
@@ -670,6 +672,8 @@ pub struct Foolang {
     pub compiler_vtable: Rc<Vtable>,
     pub dictionary_class_vtable: Rc<Vtable>,
     pub dictionary_vtable: Rc<Vtable>,
+    pub file_class_vtable: Rc<Vtable>,
+    pub file_vtable: Rc<Vtable>,
     pub filepath_class_vtable: Rc<Vtable>,
     pub filepath_vtable: Rc<Vtable>,
     pub float_class_vtable: Rc<Vtable>,
@@ -721,6 +725,7 @@ impl Foolang {
             "Dictionary",
             Class::object(&self.dictionary_class_vtable, &self.dictionary_vtable),
         );
+        env.define("File", Class::object(&self.file_class_vtable, &self.file_vtable));
         env.define("FilePath", Class::object(&self.filepath_class_vtable, &self.filepath_vtable));
         env.define("Float", Class::object(&self.float_class_vtable, &self.float_vtable));
         env.define("Input", Class::object(&self.input_class_vtable, &self.input_vtable));
@@ -760,6 +765,8 @@ impl Foolang {
             compiler_vtable: Rc::new(classes::compiler::instance_vtable()),
             dictionary_class_vtable: Rc::new(classes::dictionary::class_vtable()),
             dictionary_vtable: Rc::new(classes::dictionary::instance_vtable()),
+            file_class_vtable: Rc::new(classes::file::class_vtable()),
+            file_vtable: Rc::new(classes::file::instance_vtable()),
             filepath_class_vtable: Rc::new(classes::filepath::class_vtable()),
             filepath_vtable: Rc::new(classes::filepath::instance_vtable()),
             float_class_vtable: Rc::new(Vtable::new("class Float")),
@@ -1378,6 +1385,10 @@ impl Object {
         classes::dictionary::as_dictionary(self, ctx)
     }
 
+    pub fn as_file(&self, ctx: &str) -> Result<&classes::file::File, Unwind> {
+        classes::file::as_file(self, ctx)
+    }
+
     pub fn as_filepath(&self, ctx: &str) -> Result<&classes::filepath::FilePath, Unwind> {
         classes::filepath::as_filepath(self, ctx)
     }
@@ -1521,6 +1532,7 @@ impl fmt::Display for Object {
             Datum::Closure(x) => write!(f, "#<closure {:?}>", x.params),
             Datum::Compiler(_) => write!(f, "#<Compiler>"),
             Datum::Dictionary(_) => write!(f, "#<Dictionary>"),
+            Datum::File(x) => std::fmt::Debug::fmt(x, f),
             Datum::FilePath(x) => write!(f, "{:?}", x),
             Datum::Float(x) => {
                 if x - x.floor() == 0.0 {


### PR DESCRIPTION
   Including convenience methods forAppend, forRead, forWrite in
   FilePath.

   (This will probably need to be redesigned: it seems wrong to be
   able to _add_ permissions to File after creation, but not remove
   them.)
