### PR TITLE
implement Array#sort and friends in Foolang

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -59,6 +59,10 @@ _block_ with each element of the receiver. See also: `with:collect:`.
 
 Returns concatenation of receiver and the _array_.
 
+#### **method** `copy`
+
+Returns a shallow copy of the receiver.
+
 #### **method** `displayOn:` _stream_
 
 Displays the receiver on _stream_, sending the `displayOn:` message to
@@ -141,18 +145,26 @@ Returns the number of elements in the array.
 
 #### **method** `sort`
 
-Sorts the array in place into ascending order using `<`. 
-
-!> Errors from `<` are currently mishandled: they are ignored and cause
-elements to compare equal.
+Sorts the array in place into ascending, order using `<`. Returns the receiver.
 
 #### **method** `sort:` _sortBlock_
 
-Sorts the array in place into ascending order using _sortBlock_ as comparator:
-it should return true if first argument is less than second argument.
+Sorts the array in place into using _sortBlock_ as comparator: it should return
+true if first argument should be placed before the second argument. Returns the
+receiver.
 
-!> Errors from _sortBlock_ are currently mishandled: they are ignored and cause
-elements to compare equal.
+#### **method** `sorted`
+
+Returns a sorted copy of the array in ascending, order using `<`.
+
+#### **method** `sorted:` _sortBlock_
+
+Returns a sorted copy of the using _sortBlock_ as comparator: it should return
+true if first argument should be placed before the second argument.
+
+#### **method** `swap:` _index1_ `with:` _index2_
+
+Swaps the receiver's elements at _index1_ and _index2_. Returns the receiver.
 
 #### **method** `vectorProjection:` _otherArray_
 

--- a/foo/lang/array.foo
+++ b/foo/lang/array.foo
@@ -33,6 +33,11 @@ extend Array
                 result push: (block value: (self at: i)) }.
         result
 
+    method copy
+        let copy = Array withCapacity: self size.
+        self do: { |elt| copy push: elt }.
+        copy
+
     method with: array collect: block
         let size = self checkSize: array.
         let result = Array withCapacity: size.
@@ -47,6 +52,47 @@ extend Array
                    (block value: elt) is True
                        ifTrue: { selection push: elt } }.
         selection
+
+    method sorted
+        self copy sort
+
+    method sorted: block
+        self copy sort: block
+
+    method sort
+        self sort: { |a b| a < b }
+
+    method sort: block
+        -- Unfortunate a straigthforward rust-side wrapper for Vec::sort_by()
+        -- cannot propagate errors from the comparison function, so instead
+        -- here's a quick and dirty quicksort. O(N^2) worst case, since I
+        -- was too lazy to do the center pivot.
+        self _quicksort: 1 to: self size by: block.
+
+    method _quicksort: left to: right by: block
+        left < right
+            ifTrue: { let p = self _partition: left to: right by: block.
+                      self _quicksort: left to: p - 1 by: block.
+                      self _quicksort: p + 1 to: right by: block }.
+        self
+
+    method _partition: left to: right by: block
+        let pivot = self at: right.
+        let i = left.
+        left to: right
+                 do: { |j|
+                       let x = self at: j.
+                       (block value: x value: pivot)
+                           ifTrue: { self swap: i with: j.
+                                     i = i + 1 } }.
+        self swap: i with: right.
+        i
+
+    method swap: i with: j
+        let tmp = self at: i.
+        self put: (self at: j) at: i.
+        self put: tmp at: j.
+        self
 
     method + x
         x broadcast: {|a b| a + b} to: self
@@ -107,6 +153,33 @@ class TestArray {}
                testing: "Array#== (false 1)".
         assert false: { [1, 2, 3, 4] == [1, 2, 3] }
                testing: "Array#== (false 2)"
+    class method testSort: assert
+        assert that: { [] sort }
+               equals: []
+               testing: "sort, empty".
+        assert that: { [1] sort }
+               equals: [1]
+               testing: "sort, singular".
+        assert that: { [1, 1] sort }
+               equals: [1, 1]
+               testing: "sort, two identical".
+        assert that: { [1, 2] sort }
+               equals: [1, 2]
+               testing: "sort, two in order".
+        assert that: { [2, 1] sort }
+               equals: [1, 2]
+               testing: "sort, two in reverse order".
+        assert that: { [1, 2, 3] sort }
+               equals: [1, 2, 3]
+               testing: "sort, three in order".
+        assert that: { [3, 2, 1] sort }
+               equals: [1, 2, 3]
+               testing: "sort, three in reverse order".
+        assert that: { [9, 2, 1, 8, 7, 3, 5, 4, 6, 0] sort }
+               equals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+               testing: "sort, ten".
     class method runTests: assert
-        self testEquality: assert
+        self testEquality: assert.
+        self testSort: assert
+
 end

--- a/src/classes/array.rs
+++ b/src/classes/array.rs
@@ -1,5 +1,4 @@
 use std::cell::{Ref, RefCell, RefMut};
-use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
@@ -97,8 +96,6 @@ pub fn instance_vtable() -> Vtable {
     vt.add_primitive_method_or_panic("pop", array_pop);
     vt.add_primitive_method_or_panic("push:", array_push);
     vt.add_primitive_method_or_panic("put:at:", array_put_at);
-    vt.add_primitive_method_or_panic("sort", array_sort);
-    vt.add_primitive_method_or_panic("sort:", array_sort_arg);
     vt.add_primitive_method_or_panic("size", array_size);
     vt
 }
@@ -139,40 +136,4 @@ fn array_put_at(receiver: &Object, args: &[Object], _env: &Env) -> Eval {
 
 fn array_size(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
     receiver.as_vec(|vec| Ok(env.foo.make_integer(vec.len() as i64)))
-}
-
-fn array_sort(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
-    // FIXME: Swallows errors from comparison!
-    let t = Ok(env.foo.make_boolean(true));
-    receiver.as_mut_vec(move |mut vec| {
-        vec.sort_by(|a, b| {
-            if a.send("<", std::slice::from_ref(b), env) == t {
-                Ordering::Less
-            } else if b.send("<", std::slice::from_ref(a), env) == t {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        });
-        Ok(())
-    })?;
-    Ok(receiver.clone())
-}
-
-fn array_sort_arg(receiver: &Object, args: &[Object], env: &Env) -> Eval {
-    // FIXME: Swallows errors from comparison!
-    let t = Ok(env.foo.make_boolean(true));
-    receiver.as_mut_vec(move |mut vec| {
-        vec.sort_by(|a, b| {
-            if args[0].send("value:value:", &[a.clone(), b.clone()], env) == t {
-                Ordering::Less
-            } else if args[0].send("value:value:", &[b.clone(), a.clone()], env) == t {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        });
-        Ok(())
-    })?;
-    Ok(receiver.clone())
 }


### PR DESCRIPTION
    Less painful than communicating erros from sort block
    from the rust side.

    Also adds Array#copy and Array#swap:with:
