### PR TITLE
foolang.el: fix indentation in the beginning of line

### DIFF
--- a/elisp/foolang.el
+++ b/elisp/foolang.el
@@ -479,16 +479,17 @@
       (insert "\n"))))
 
 (defun foolang-indent-line ()
+  (interactive)
   (foolang--indent-line-number (line-number-at-pos) nil))
 
 (defun foolang-indent-all ()
+  (interactive)
   (foolang--indent-line-number (line-number-at-pos) t))
 
 (defun foolang--indent-line-number (line-number indent-all)
   (let ((line-move-visual nil))
-    (save-excursion
-      (lexical-let ((base (foolang--find-indent-base)))
-        (foolang--indent-to line-number base base nil nil indent-all)))))
+    (lexical-let ((base (foolang--find-indent-base)))
+      (foolang--indent-to line-number base base nil nil indent-all))))
 
 (defun foolang--find-indent-base ()
   "Search lines up until it find a 'base', meaning


### PR DESCRIPTION
  A stray 'save-excursion' restored point to where it was after indentation
  had been inserted. Due to the way save-excursion work wrt. buffer content
  changes this only mattered when indenting at the beginning of an empty
  line.

   Closes #78.
