### PR TITLE
Object#== and Self as type

### DIFF
--- a/foo/lang/array.foo
+++ b/foo/lang/array.foo
@@ -4,9 +4,14 @@ extend Array
     is Collection
 
     class method new: size value: init
-        let new = self withCapacity: size.
+        let new = Self withCapacity: size.
         1 to: size do: { |_| new push: init }.
         new
+
+    method bytes
+        let bytes = ByteArray new: self size.
+        1 to: self size do: { |i| bytes put: (self at: i) at: i }.
+        bytes
 
     method _emitOn: stream using: block
         stream print: "[".

--- a/foo/lang/boolean.foo
+++ b/foo/lang/boolean.foo
@@ -1,4 +1,14 @@
+import .object.Object
+
 extend Boolean
+    is Object
+
+    method == other
+        self is other
+
+    method isEquivalent: other
+        self is other
+
     method and: other::Boolean
         self
            ifTrue: { other }
@@ -18,9 +28,6 @@ extend Boolean
         self
            ifTrue: { True }
            ifFalse: { other }
-
-    method == other
-        self is other
 
     method not
         self

--- a/foo/lang/collection.foo
+++ b/foo/lang/collection.foo
@@ -1,9 +1,9 @@
+import .object.Object
 
 interface Collection
+    is Object
 
-    method == other
-        (Collection includes: other)
-            ifFalse: { return False }.
+    method isEquivalent: other
         let size = self size.
         size is other size
             ifFalse: { return False }.

--- a/foo/lang/filestream.foo
+++ b/foo/lang/filestream.foo
@@ -70,7 +70,7 @@ class TestFileStream { assert dir foopath foodata }
             createOrOpen: { |f| f writeString: newdata }.
         assert that: { newpath forRead
                            open: { |f| f readBytes } }
-               equals: [13, 13, 10, 10]
+               equals: [13, 13, 10, 10] bytes
                testing: "FileStream#readBytes".
         newpath deleteFile
 
@@ -106,14 +106,14 @@ class TestFileStream { assert dir foopath foodata }
                            open: { |f| f tryRead: 4 bytesInto: buf at: 2 } }
                is: 4
                testing: "FileStream#tryRead:bytesInto:at: (return)".
-        assert that: { [101, 13, 10, 13, 10, 106] }
+        assert that: { [101, 13, 10, 13, 10, 106] bytes }
                equals: buf
                testing: "FileStream#tryRead:bytesInto:at: (data)".
         assert that: { newpath forRead
                            open: { |f| f tryRead: 6 bytesInto: buf at: 1 } }
                is: 4
                testing: "FileStream#tryRead:bytesInto:at: (short return)".
-        assert that: { [13, 10, 13, 10, 10, 106] }
+        assert that: { [13, 10, 13, 10, 10, 106] bytes }
                equals: buf
                testing: "FileStream#tryRead:bytesInto:at: (short data)".
         newpath deleteFile
@@ -136,7 +136,7 @@ class TestFileStream { assert dir foopath foodata }
                            open: { |f| f tryRead: data size bytesInto: data at: 1 } }
                is: 10
                testing: "FileStream#tryWrite:bytesFrom:at: (wrote length)".
-        assert that: { [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0] }
+        assert that: { [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0] bytes }
                equals: data
                testing: "FileStream#tryWrite:bytesFrom:at: (wrote data)".
         newpath deleteFile

--- a/foo/lang/number.foo
+++ b/foo/lang/number.foo
@@ -1,6 +1,14 @@
 import .interval.Interval
+import .object.Object
 
 interface Number
+    is Object
+
+    method == right
+        self is right
+
+    method isEquivalent: right
+        self is right
 
     method broadcast: block to: collection
         collection collect: { |x| block value: x value: self }
@@ -17,9 +25,6 @@ interface Number
     method / right
         right divNumber: self
 
-    method == right
-        (Number includes: right)
-            ifTrue: { right eqNumber: self }
     method < right
         right ltNumber: self
     method > right

--- a/foo/lang/object.foo
+++ b/foo/lang/object.foo
@@ -1,0 +1,8 @@
+-- Should this be "Standard" or "StandardObject" instead?
+interface Object
+    method == other
+        (Self includes: other)
+            ifTrue: { self isEquivalent: other }
+            ifFalse: { False }
+    required method isEquivalent: other
+end

--- a/foo/lang/string.foo
+++ b/foo/lang/string.foo
@@ -1,4 +1,8 @@
+import .object.Object
+
 extend String
+    is Object
+
     method append: other
        other appendToString: self
     method newline
@@ -19,9 +23,6 @@ extend String
         stream writeString: "\"".
         self do: { |c| c _escapeOn: stream }.
         stream writeString: "\""
-    method == other
-        (String includes: other)
-            ifTrue: { other stringEqual: self }
     method startsWith: other
         1 to: other size
           do: { |i|

--- a/foo/lib/si.foo
+++ b/foo/lib/si.foo
@@ -151,6 +151,12 @@ class Prefix {}
 end
 
 interface SI_Unit
+    is Object
+
+    method isEquivalent: right
+        -- Compound unit overrides this, but this is enough for base units
+        (self species) is (right species) and: self power == right power
+
     required method displayOn: stream
 
     method display: value on: stream
@@ -205,15 +211,6 @@ interface SI_Unit
 
     method / right
        right unitDivision: self
-
-    method == right
-        (SI_Unit includes: right)
-            ifFalse: { return False }.
-        -- Compound unit overrides this, but this is enough for base units
-        (self species) is (right species) and: self power == right power
-
-    method isCompound
-        False
 
     method unitProduct: left
         self species is left species
@@ -297,6 +294,21 @@ end
 class CompoundUnit { units }
     is SI_Unit
 
+    method isEquivalent: other
+        let n = other units size.
+        n == units size
+            ifFalse: { return False }.
+        -- This is slooow, should store as a Set at the very least
+        let powers = Dictionary new.
+        other units do: { |unit| powers put: unit power at: unit species }.
+        units do: { |unit|
+                    (powers has: unit species)
+                        ifTrue: { unit power == (powers at: unit species)
+                                      ifFalse: { return False }.
+                                  n = n - 1 }
+                        ifFalse: { return False } }.
+        n is 0
+
     class method of: left multipliedBy: right
         let powers = Dictionary new.
         left powersInto: powers by: 1.
@@ -328,28 +340,6 @@ class CompoundUnit { units }
 
     method powersInto: powers by: mul
         units do: { |unit| unit powersInto: powers by: mul }
-
-    method isCompound
-        True
-
-    method == other
-        (SI_Unit includes: other)
-            ifFalse: { return False }.
-        other isCompound
-            ifFalse: { return False }.
-        let n = other units size.
-        n == units size
-            ifFalse: { return False }.
-        -- This is slooow, should store as a Set at the very least
-        let powers = Dictionary new.
-        other units do: { |unit| powers put: unit power at: unit species }.
-        units do: { |unit|
-                    (powers has: unit species)
-                        ifTrue: { unit power == (powers at: unit species)
-                                      ifFalse: { return False }.
-                                  n = n - 1 }
-                        ifFalse: { return False } }.
-        n is 0
 
     method power
         units ifEmpty: { 0 } ifNotEmpty: { 1 }
@@ -410,6 +400,11 @@ class CompoundUnit { units }
 end
 
 class SI { value::Float _unit::SI_Unit }
+    is Object
+
+    method isEquivalent: right
+        self checkUnit: right operation: "==".
+        self value == right value
 
     class method meters: value
         SI value: value unit: (Meters power: 1)
@@ -444,12 +439,6 @@ class SI { value::Float _unit::SI_Unit }
     method checkUnit: right operation: op
         self unit == right unit
             ifFalse: { panic "Invalid operation: {self} {op} {right}" }
-
-    method == right
-        (SI includes: right)
-            ifFalse: { return False }.
-        self checkUnit: right operation: "==".
-        self value == right value
 
     method < right
         self checkUnit: right operation: "<".

--- a/foo/prelude.foo
+++ b/foo/prelude.foo
@@ -14,6 +14,7 @@ import .lang.float.Float
 import .lang.integer.Integer
 import .lang.interval.Interval
 import .lang.number.Number
+import .lang.object.Object
 import .lang.output.Output
 import .lang.random.Random
 import .lang.record.Record

--- a/src/classes/string.rs
+++ b/src/classes/string.rs
@@ -8,7 +8,7 @@ pub fn instance_vtable() -> Vtable {
     vt.add_primitive_method_or_panic("size", string_size);
     vt.add_primitive_method_or_panic("do:", string_do);
     vt.add_primitive_method_or_panic("at:", string_at);
-    vt.add_primitive_method_or_panic("stringEqual:", string_equal);
+    vt.add_primitive_method_or_panic("isEquivalent:", string_is_equivalent);
     vt
 }
 
@@ -49,6 +49,6 @@ fn string_at(receiver: &Object, args: &[Object], env: &Env) -> Eval {
     Ok(env.foo.make_string(&data[i..i + 1]))
 }
 
-fn string_equal(receiver: &Object, args: &[Object], env: &Env) -> Eval {
+fn string_is_equivalent(receiver: &Object, args: &[Object], env: &Env) -> Eval {
     Ok(env.foo.make_boolean(receiver.string_as_str() == args[0].string_as_str()))
 }

--- a/src/tests/test_float.rs
+++ b/src/tests/test_float.rs
@@ -79,7 +79,7 @@ fn test_float_equals() {
     assert_eq!(eval_ok("2.0 == 1.0").boolean(), false);
     assert_eq!(eval_ok("1.0 == 1.0").boolean(), true);
 
-    assert_eq!(eval_ok("1.0 == 1").boolean(), true);
+    assert_eq!(eval_ok("1.0 == 1").boolean(), false);
     assert_eq!(eval_ok("0.9 == 1").boolean(), false);
     assert_eq!(eval_ok("1.1 == 1").boolean(), false);
 }

--- a/src/tests/test_integer.rs
+++ b/src/tests/test_integer.rs
@@ -104,7 +104,7 @@ fn test_integer_equal() {
     assert_eq!(eval_ok("2 == 1").boolean(), false);
     assert_eq!(eval_ok("1 == 1").boolean(), true);
 
-    assert_eq!(eval_ok("1 == 1.0").boolean(), true);
+    assert_eq!(eval_ok("1 == 1.0").boolean(), false);
     assert_eq!(eval_ok("1 == 1.1").boolean(), false);
     assert_eq!(eval_ok("1 == 0.9").boolean(), false);
 }


### PR DESCRIPTION
- #== is now implemented as part of Object, and is False if class is not the same.
  (This changes behaviour of collections and numbers.)

- classes implementing Object must implement #isEquivalent: instead, which can assume
  that the argument is the same class as the receiver.

- Self in methods denotes actual class of the object, allowing interface methods
   access to the actual class without specifying what it is.

Closes #265
