### PR TITLE
CI: explicitly install rustfmt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ steps:
       echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     displayName: Windows install rust
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  - script: rustup component add rustfmt
+    displayName: Rustup install rustfmt
   - script: cargo fmt -- --check
     displayName: Cargo fmt check
   - script: cargo build --all


### PR DESCRIPTION
For some reason it wasn't part of the default installation on Apple anymore,
causing tests to fail.
