### PR TITLE
design: missing performance impacts, some additions

### DIFF
--- a/docs/design/003-sorting-floats.md
+++ b/docs/design/003-sorting-floats.md
@@ -84,6 +84,10 @@ None.
 Positive: sorting is easier, different behaviours are accessible. Aestherics
 are good.
 
+### Performance
+
+None.
+
 #### Uniformity
 
 None.

--- a/docs/design/004-reified-types-without-reflection.md
+++ b/docs/design/004-reified-types-without-reflection.md
@@ -14,6 +14,7 @@
 
 **History**:
 - 2020-03-01: initial version by Nikodemus
+- 2020-06-06: additional performance note by Nikodemus
 
 ## Problem Description
 
@@ -98,11 +99,22 @@ Minimal. If something becomes harder or impossible without `classOf`, that's
 obviously a negative&mdash;and may lead to reconsideration of this position, but
 I believe most of the time it is just smelly code.
 
+#### Performance
+
+None. Code that wants to special case a concrete type can already do so:
+
+```
+method foo: arg::Number
+    (SmallInteger includes: arg)
+       ifTrue: [ fast case ]
+       ifFalse: [ slow case ]
+```
+
 #### Uniformity
 
-Negative: built-in code definitely needs to be able to access the class of an
-object, making this a violation of the Uniformity principle. (This is actually
-the strongest argument in favor of `classOf` so far.)
+Negative: internals do need to be able to access the class of an object, making
+this a violation of the Uniformity principle. (This is actually the strongest
+argument in favor of `classOf` so far.)
 
 #### Implementation
 

--- a/docs/design/005-program-definition-and-refinement.md
+++ b/docs/design/005-program-definition-and-refinement.md
@@ -50,7 +50,7 @@ associated source code, and constructing the objects it describes:
 2. The compiler processes all associated source code, creating the declaratively
    defined objects in the environment under their own names, adding the
    constructively defined names to the environment as placeholders containing
-   their associted constructive definitions without executing them yet.
+   their associated constructive definitions without executing them yet.
 
 3. The compiler executes all constructive definitions in the environment,
    replacing the plaholder defitions with the constructed objects. Accessing a
@@ -89,7 +89,7 @@ In development mode the immutability constraint of a program environment is
 relaxed, allowing its refinement via patching:
 - Mutation of global objects to add, remove, and redefine methods, and change
   layouts of classes.
-- Addition of new gobal objects.
+- Addition of new global objects.
 - Removal of global objects.
 
 Patching a program is equivalent to sending a message to the program environment
@@ -118,6 +118,10 @@ None.
 
 Good: constructive definitions are convenient, declarative definitions are
 clean.
+
+#### Performance
+
+None.
 
 #### Uniformity
 

--- a/docs/design/006-integer-types.md
+++ b/docs/design/006-integer-types.md
@@ -15,6 +15,7 @@
 
 **History**:
 - 2020-03-02: initial version by Nikodemus
+- 2020-06-06: performance notes by Nikodemus
 
 ## Problem Description
 
@@ -77,7 +78,8 @@ Named integer subtypes such as `I8` are simply names given to intervals. This
 makes it clear that addition of `U8` and `I32` is just a regular integer
 addition.
 
-One of the major downsides is that `U64` is potentially a BigInt.
+Given a fat pointer implementation `U64` is always an `Int`, but that probably
+should not be required at language level.
 
 Arithmetic is implemented through triple dispatch: `+` -> `addInteger:` ->
 `addInt:` | `addBigInt:`. This way classes which want to participate in
@@ -143,6 +145,24 @@ No impact.
 #### Ergonomics
 
 Good.
+
+#### Performance
+
+Average: potential BigInt allocation is impossible to avoid even if types are
+fully declared. Having `I8` and like as distinct classes using modular
+arithmetic would be clearly better for performance. However, this design allows
+that to be implemented in user space:
+
+```
+class Mod32 { value::Int }
+    method + other::Mod32 -> Mod32
+        Mod32 value: (value add32: other)
+```
+
+Assuming fat pointer implementation of classes this should carry zero overhead
+if types are known.
+
+(Methods supporting modular arithmetic need to be in place, of course.)
 
 #### Uniformity
 

--- a/docs/design/007-definitions-and-expressions.md
+++ b/docs/design/007-definitions-and-expressions.md
@@ -12,6 +12,7 @@
 **History**:
 - 2020-03-15: initial version by Nikodemus
 - 2020-03-19: implementation notes by Nikodemus
+- 2020-06-06: impact clarified by Nikodemus
 
 ## Problem Description
 
@@ -102,12 +103,16 @@ None.
 
 #### Ergonomics
 
-Improved clarity.
+"Absolutely everything is an expression" elegance is lost, but separate
+syntactic categories otherwise clarify parsing.
+
+#### Performance
+
+None.
 
 #### Uniformity
 
-"Absolutely everything is an expression" elegance is lost, but separate
-syntactic categories otherwise clarify parsing.
+None.
 
 #### Implementation
 

--- a/docs/design/wip-design-note-template.md
+++ b/docs/design/wip-design-note-template.md
@@ -41,9 +41,14 @@ Impact on safety: memory safety, concurrency, authority, fault tolerance, etc.
 
 Impact on ergonomics & (user) aesthetics.
 
-#### Uniformity
+#### Performance
 
 Impact on performance, including impact on future compiler optimizations.
+
+#### Uniformity
+
+Impact on language uniformity: built-in types should not be privileged over
+user defined types.
 
 #### Implementation
 

--- a/docs/design/wip-indexed-classes.md
+++ b/docs/design/wip-indexed-classes.md
@@ -13,6 +13,7 @@
 
 **History**:
 - 2020-03-21: initial version by Nikodemus
+- 2020-06-06: list of alternatives by Nikodemus
 
 ## Problem Description
 
@@ -49,35 +50,51 @@ methods of the instances directly access the indexed part, and the constructor
 fragments don't have a prefix, and start with lowercase letters.
 
 Allowing references to `<indexed>` reifies it as a special object, allowing
-direct access to it as if a collection.
+direct access to it as if a collection. (XXX: not collection, since cannot add
+or remove items.)
 
 ### Summary
 
-Why this proposal is a good idea.
+TODO: Why this proposal is a good idea.
 
 #### Safety
 
-Impact on safety: memory safety, concurrency, authority, fault tolerance, etc.
+No safety impact.
 
 #### Ergonomics
 
-Impact on ergonomics & (user) aesthetics.
+TODO: Impact on ergonomics & (user) aesthetics.
+
+#### Performance
+
+TODO: Impact on performance, including impact on future compiler optimizations.
 
 #### Uniformity
 
-Impact on performance, including impact on future compiler optimizations.
+Improved uniformity.
 
 #### Implementation
 
-Impact on implementation: complexity, amount of work, maintenance burden, etc.
+TODO: Impact on implementation: complexity, amount of work, maintenance burden, etc.
 
 #### Users
 
-Impact on users, including backwards compatibility.
+No users, no impact.
 
 ## Alternatives
 
-Alternatives to the proposal that were considered.
+- Moral equivalent of C++ `new[]`, allowing allocation of blocks of arbitrary
+  type. This seems like a complementary feature more than an alternative -- both
+  can replace the other in terms of what can be done, but what is convenient is
+  different.
+- Allowing arbitrary number of indexed slots per class. This would be nice, but
+  complicates instance access more than I consider desirable right now - and
+  the uses cases are a bit rare.
+- Not naming the slot, but automatically providing the collection-like methods
+  for the class. (Also, no reification of the slot.)
+
+Syntax variations are a dime a dozen. The current one is almost certainly not
+the final one.
 
 ## Implementation Notes
 

--- a/docs/design/wip-tower-of-babel.md
+++ b/docs/design/wip-tower-of-babel.md
@@ -218,6 +218,10 @@ None as of yet.
 
 No impact.
 
+#### Performance
+
+No impact.
+
 #### Ergonomics
 
 No impact.


### PR DESCRIPTION
The design note template had gotten performance and uniformity sections mangled. Fixed that and tried to sort out the same in existing notes.
