### PR TITLE
design: no indexed classes in Self

### DIFF
--- a/docs/design/wip-indexed-classes.md
+++ b/docs/design/wip-indexed-classes.md
@@ -9,7 +9,6 @@
 **Prior Art**:
 - Smalltalk indexed instance variables
 - C structs with tailing arrays
-- Self?
 
 **History**:
 - 2020-03-21: initial version by Nikodemus


### PR DESCRIPTION
(Self uses system provided prototypes for vectors instead.)
