### PR TITLE
syntax: methods and definitions end with bang

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ syntax, design notes, aspirations, etc.
 ``` foolang
 class Main {}
     class method run: command in: system
-        system output println: "Hello world!"
+        system output println: "Hello world!"!
 end
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ midnight oil to hit a milestone.
 ``` foolang
 class Main {}
     class method run: command in: system
-        system output println: "Hello world!"
+        system output println: "Hello world!"!
 end
 ```
 

--- a/foo/examples/colorado_puzzle.foo
+++ b/foo/examples/colorado_puzzle.foo
@@ -26,10 +26,10 @@ class Puzzle { height width data frontier paths }
         let puzzle = self height: height
                          width: width
                          data: data
-                         frontier: [coordinate]
+                         frontier: (List from: [coordinate])
                          paths: (Array new: data size value: False).
         puzzle setPath: [] row: coordinate first col: coordinate second.
-        puzzle
+        puzzle!
 
     method solve
         { frontier isEmpty }
@@ -37,12 +37,13 @@ class Puzzle { height width data frontier paths }
                               { |coordinate|
                                 (self try: coordinate)
                                     ifTrue: { return self path: coordinate } } }.
-        [] -- no solution
+        -- no solution
+        []!
 
     method doFrontier: block
         let old = frontier.
         frontier = [].
-        old do: block
+        old do: block!
 
     method try: coordinate
         let row = coordinate first.
@@ -53,7 +54,7 @@ class Puzzle { height width data frontier paths }
         self expandFromRow: row
              col: col
              steps: steps.
-        False
+        False!
 
     method path: coordinate
         let trace = [coordinate].
@@ -66,19 +67,19 @@ class Puzzle { height width data frontier paths }
             trace push: prev.
             coordinate = prev
         }
-            loop
+            loop!
 
     method indexRow: row col: col
-        height * (row - 1) + col
+        height * (row - 1) + col!
 
     method pathRow: row col: col
-        paths at: (self indexRow: row col: col)
+        paths at: (self indexRow: row col: col)!
 
     method setPath: prev row: row col: col
-        paths put: prev at: (self indexRow: row col: col)
+        paths put: prev at: (self indexRow: row col: col)!
 
     method row: row col: col
-        data at: (height * (row - 1) + col)
+        data at: (height * (row - 1) + col)!
 
     method tryRow: row col: col from: prev
         -- Filter out invalid positions
@@ -90,7 +91,7 @@ class Puzzle { height width data frontier paths }
         (self pathRow: row col: col) is False
             ifTrue: { frontier push: [row, col].
                        self setPath: prev row: row col: col }.
-        False
+        False!
 
     method expandFromRow: row col: col steps: steps
         let here = [row, col].
@@ -102,7 +103,7 @@ class Puzzle { height width data frontier paths }
             do: { |row|
                   [left, col, right]
                       do: { |col|
-                            self tryRow: row col: col from: here }}
+                            self tryRow: row col: col from: here }}!
 end
 
 class Main {}
@@ -117,5 +118,5 @@ class Main {}
                                     6, 2, 1, 6, 1, 5, 5 ]
                             start: [ 7, 4 ].
         let path = puzzle solve.
-        system output println: "path length {path size}: {path}".
+        system output println: "path length {path size}: {path}"!
 end

--- a/foo/examples/floating_cube.foo
+++ b/foo/examples/floating_cube.foo
@@ -26,5 +26,5 @@ class Main {}
                   ifFalse: { n = n + 1 }
       }.
       win close.
-      system output println: "Done!"
+      system output println: "Done!"!
 end

--- a/foo/examples/flying.foo
+++ b/foo/examples/flying.foo
@@ -1,21 +1,21 @@
 class PointMass { forces mass gravity acceleration position velocity debug }
   method sumForces
-     forces sum: { |f| f value }
+     forces sum: { |f| f value }!
 
   method tick: dt
-     -- Velocity Verlet integration, should be more accurate than Euler's Method
+     -- Velocity Verlet integration, more accurate than Euler's Method
      -- http://buildnewgames.com/gamephysics/
      -- https://en.wikipedia.org/wiki/Verlet_integration#Velocity_Verlet
      position = position + velocity * dt + (acceleration * (0.5 * dt * dt)).
      let newAcceleration = self sumForces / mass + gravity.
      velocity = velocity + (newAcceleration + acceleration) * (0.5 * dt).
-     acceleration = newAcceleration
+     acceleration = newAcceleration!
 
   method position: pos
-     position = pos
+     position = pos!
 
   method velocity: vel
-     velocity = vel
+     velocity = vel!
 end
 
 class Plane { model noseDirection upDirection maxLift maxSpeed maxThrust throttle debug }
@@ -50,20 +50,20 @@ class Plane { model noseDirection upDirection maxLift maxSpeed maxThrust throttl
      forces push: { plane lift }.
      forces push: { plane thrust }.
 
-     plane
+     plane!
 
    method position
-      model position
+      model position!
 
    method velocity
-      model velocity
+      model velocity!
 
    method throttle: new
-      throttle = new atLeast: 0.0 atMost: 1.0
+      throttle = new atLeast: 0.0 atMost: 1.0!
 
    method tick: time
       model tick: time.
-      self checkGround
+      self checkGround!
 
    method checkGround
       -- Don't allow Z-position to go below zero
@@ -71,16 +71,16 @@ class Plane { model noseDirection upDirection maxLift maxSpeed maxThrust throttl
       (pos at: 3) < 0 ifTrue: {
          model position put: 0.0 at: 3.
          model velocity put: 0.0 at: 3
-      }
+      }!
 
    method crossSection: v
-      2.0 -- FIXME: a box model should not be too hard to calculate, also: should be parameter
+      2.0! -- FIXME: a box model should not be too hard to calculate, also: should be parameter
 
    method dragCoefficient: v
       -- https://en.wikipedia.org/wiki/Drag_coefficient
       -- FIXME: current value is for sphere, box model might be nice
       -- FIXME: should really be a parameter
-      0.47
+      0.47!
       
    method drag
       -- https://en.wikipedia.org/wiki/Drag_equation
@@ -91,17 +91,17 @@ class Plane { model noseDirection upDirection maxLift maxSpeed maxThrust throttl
       let a = self crossSection: direction.
       let c = self dragCoefficient: direction.
       let p = 1.269. -- mass density of air at 5C
-      direction * -0.5 * p * speed * speed * a * c
+      direction * -0.5 * p * speed * speed * a * c!
 
    method lift
       -- FIXME: https://www.grc.nasa.gov/WWW/K-12/WindTunnel/Activities/lift_formula.html
       let airSpeed = model velocity scalarProjectionOn: noseDirection.
       let lift = (airSpeed / maxSpeed) * maxLift.
-      upDirection * lift
+      upDirection * lift!
 
    method thrust
       let thrust = maxThrust * throttle.
-      noseDirection * thrust
+      noseDirection * thrust!
       
 end
 
@@ -142,5 +142,5 @@ class Main {}
           plane tick: step.
           t = t + step
       }.
-      system output println: "TIMEOUT at {t}s"
+      system output println: "TIMEOUT at {t}s"!
 end

--- a/foo/examples/hello.foo
+++ b/foo/examples/hello.foo
@@ -1,4 +1,4 @@
 class Main {}
   class method run: command in: system
-     system output println: "Hello world!"
+     system output println: "Hello world!"!
 end

--- a/foo/examples/hello_x.foo
+++ b/foo/examples/hello_x.foo
@@ -1,5 +1,5 @@
 class Main {}
   class method run: command in: system
      system output println: "What is your name?".
-     system output println: "Hello {system input readline}!"
+     system output println: "Hello {system input readline}!"!
 end

--- a/foo/foolang.foo
+++ b/foo/foolang.foo
@@ -1,12 +1,12 @@
 class Debug {}
     class method println: what
-        Output debug println: what
+        Output debug println: what!
 end
 
 class HostMethod { receiver selector }
     is Object
     method invoke: arguments with: context in: process
-        selector sendTo: receiver with: arguments
+        selector sendTo: receiver with: arguments!
 end
 
 class Process {}
@@ -20,34 +20,34 @@ class InterpreterContext {
     is Object
 
     class method new: size
-        self sender: False frame: (Array new: size value: "<unbound>")
+        self sender: False frame: (Array new: size value: "<unbound>")!
 
     method at: index inFrame: frameNumber
         frameNumber > 1
             ifTrue: { sender at: index inFrame: frameNumber - 1 }
-            ifFalse: { frame at: index }
+            ifFalse: { frame at: index }!
 
     method put: value at: index inFrame: frameNumber
         frameNumber > 1
             ifTrue: { sender put: value at: index inFrame: frameNumber - 1 }
-            ifFalse: { frame put: value at: index }
+            ifFalse: { frame put: value at: index }!
 end
 
 class Binding { name index::Integer }
     is Object
     method referenceInFrame: frame
-        AstLexicalRef name: name frame: frame index: index
+        AstLexicalRef name: name frame: frame index: index!
 end
 
 class FrameAllocation { size::Integer }
     class method new
         -- Debug println: "** frame allocation **".
-        self size: 0
+        self size: 0!
     method nextIndex
         size = size + 1.
-        size
+        size!
     method index
-        size
+        size!
 end
 
 class NullEnvironment {}
@@ -61,14 +61,14 @@ class Environment { bindings parent allocation globals }
             bindings: List new
             parent: NullEnvironment
             allocation: FrameAllocation new
-            globals: Dictionary new
+            globals: Dictionary new!
 
     method newFrame
         Environment
             bindings: List new
             parent: self
             allocation: FrameAllocation new
-            globals: globals
+            globals: globals!
 
     method addVariable: name
         Environment
@@ -78,7 +78,7 @@ class Environment { bindings parent allocation globals }
                                      index: allocation nextIndex))
             parent: parent
             allocation: allocation
-            globals: globals
+            globals: globals!
 
     method addVariables: names
         let newBindings = bindings copy.
@@ -91,11 +91,11 @@ class Environment { bindings parent allocation globals }
             bindings: newBindings
             parent: parent
             allocation: allocation
-            globals: globals
+            globals: globals!
 
     method load: definition
         definition defineIn: self.
-        self
+        self!
 
     method eval: string
         let env = Environment
@@ -105,14 +105,14 @@ class Environment { bindings parent allocation globals }
                       globals: globals.
         ((Parser parse: string) translateIn: env)::AstNode
             evalWith: (InterpreterContext new: env allocation size)
-            in: Process new
+            in: Process new!
 
     method global: name
         globals at: name
-                ifNone: { Error raise: "Unbound variable: {name}" }.
+                ifNone: { Error raise: "Unbound variable: {name}" }!
 
     method reference: name
-        self reference: name inFrame: 1
+        self reference: name inFrame: 1!
 
     method reference: name inFrame: frame::Integer
         let binding = bindings reversed -- SLOW!
@@ -120,38 +120,38 @@ class Environment { bindings parent allocation globals }
                           ifNone: { parent is False
                                         ifTrue: { return self global: name }
                                         ifFalse: { return parent reference: name inFrame: frame + 1 } }.
-        binding referenceInFrame: frame
+        binding referenceInFrame: frame!
 end
 
 interface AstNode
     is Object
     method debug
-        Debug println: "#<AST {self}>".
+        Debug println: "#<AST {self}>"!
 end
 
 class AstConstantRef { value }
     is AstNode
     method evalWith: context in: process
-        value
+        value!
 end
 
 class AstIs { left right }
     is AstNode
     method evalWith: context in: process
         (left evalWith: context in: process)
-            is (right evalWith: context in: process)
+            is (right evalWith: context in: process)!
 end
 
 class AstSeq { first then }
     is AstNode
     method evalWith: context in: process
         first evalWith: context in: process.
-        then evalWith: context in: process
+        then evalWith: context in: process!
 end
 
 extend Object
     method getMethod: selector
-        HostMethod receiver: self selector: selector
+        HostMethod receiver: self selector: selector!
 end
 
 class AstSend {
@@ -167,29 +167,27 @@ class AstSend {
                          collect: { |arg|
                                     arg evalWith: context in: process })
             with: context
-            in: process
+            in: process!
 end
 
 define $context
-    False
-end
+    False!
 
 define $process
-    False
-end
+    False!
 
 class AstMethod { receiver selector }
     is AstNode
     method invoke: arguments with: context in: process
         let $context = context.
         let $process = process.
-        selector sendTo: receiver with: arguments.
+        selector sendTo: receiver with: arguments!
 end
 
 class AstGlobal { name value }
     is AstNode
     method evalWith: context in: process
-        value
+        value!
 end
 
 class AstDefine { name body frameSize }
@@ -199,18 +197,18 @@ class AstDefine { name body frameSize }
             put: (AstGlobal
                       name: name
                       value: self _eval)
-            at: name.
+            at: name!
     method _eval
         body evalWith: (InterpreterContext new: frameSize)
-             in: Process new
+             in: Process new!
 end
 
 class AstBlockClosure { context block }
     is AstNode
     method value
-        self apply: []
+        self apply: []!
     method value: arg
-        self apply: [arg]
+        self apply: [arg]!
     method apply: arguments
         let frame = Array new: block frameSize.
         let nArgs = arguments size.
@@ -222,18 +220,18 @@ class AstBlockClosure { context block }
             evalWith: (InterpreterContext
                            sender: context
                            frame: frame)
-            in: False
+            in: False!
     method getMethod: selector
-        AstMethod receiver: self selector: selector
+        AstMethod receiver: self selector: selector!
 end
 
 class AstBlock { body argumentCount frameSize }
     method evalWith: context in: process
         AstBlockClosure
             context: context
-            block: self
+            block: self!
     method frameSize
-        frameSize
+        frameSize!
 end
 
 class AstBindLexical { name index value body }
@@ -244,7 +242,7 @@ class AstBindLexical { name index value body }
             put: object
             at: index
             inFrame: 1.
-        body evalWith: context in: process.
+        body evalWith: context in: process!
 end
 
 class AstLexicalRef { name
@@ -252,7 +250,7 @@ class AstLexicalRef { name
                       index::Integer }
     is AstNode
     method evalWith: context in: process
-        context at: index inFrame: frame
+        context at: index inFrame: frame!
 end
 
 class AstLexicalSet { name
@@ -264,7 +262,7 @@ class AstLexicalSet { name
         context
             put: (value evalWith: context in: process)
             at: index
-            inFrame: frame.
+            inFrame: frame!
 end
 
 interface Syntax
@@ -273,19 +271,19 @@ interface Syntax
         let env = Environment new.
         (self translateIn: env)
             evalWith: (InterpreterContext new: (env allocation size))
-            in: Process new.
+            in: Process new!
     method load
-        Environment new load: (self translateIn: Environment new)
+        Environment new load: (self translateIn: Environment new)!
 end
 
 class SyntaxLiteral { value }
     is Syntax
     method translateIn: environment
-        AstConstantRef value: value
+        AstConstantRef value: value!
     method isEquivalent: other
-        self value == other value
+        self value == other value!
     method toString
-        value toString
+        value toString!
 end
 
 class SyntaxSeq { first then }
@@ -294,12 +292,12 @@ class SyntaxSeq { first then }
         -- FIXME: Would be nicer to flatten this out.
         AstSeq
             first: (first translateIn: environment)
-            then: (then translateIn: environment).
+            then: (then translateIn: environment)!
     method checkEqualInternal: other
         self first checkEqual: other first.
-        self then checkEqual: other then.
+        self then checkEqual: other then!
     method toString
-        "{first}. {then}"
+        "{first}. {then}"!
 end
 
 class SyntaxPrefix { receiver selector }
@@ -307,12 +305,12 @@ class SyntaxPrefix { receiver selector }
     method translateIn: environment
         AstSend receiver: (receiver translateIn: environment)
                 selector: (Selector name: "prefix{selector name}")
-                arguments: []
+                arguments: []!
     method checkEqualInternal: other
         receiver checkEqual: other receiver.
-        selector checkEqual: other selector.
+        selector checkEqual: other selector!
     method toString
-        "{selector name}{receiver}"
+        "{selector name}{receiver}"!
 end
 
 class SyntaxUnary { receiver selector }
@@ -320,12 +318,12 @@ class SyntaxUnary { receiver selector }
     method translateIn: environment
         AstSend receiver: (receiver translateIn: environment)
                 selector: selector
-                arguments: []
+                arguments: []!
     method checkEqualInternal: other
         receiver checkEqual: other receiver.
-        selector checkEqual: other selector.
+        selector checkEqual: other selector!
     method toString
-        "{receiver} {selector name}"
+        "{receiver} {selector name}"!
 end
 
 class SyntaxBinary { receiver selector argument }
@@ -333,13 +331,13 @@ class SyntaxBinary { receiver selector argument }
     method translateIn: environment
         AstSend receiver: (receiver translateIn: environment)
                 selector: selector
-                arguments: [argument translateIn: environment]
+                arguments: [argument translateIn: environment]!
     method checkEqualInternal: other
         receiver checkEqual: other receiver.
         selector checkEqual: other selector.
-        argument checkEqual: other argument
+        argument checkEqual: other argument!
     method toString
-        "{receiver} {selector name} {argument}"
+        "{receiver} {selector name} {argument}"!
 end
 
 class SyntaxKeyword { receiver selector arguments }
@@ -349,7 +347,7 @@ class SyntaxKeyword { receiver selector arguments }
                 selector: selector
                 arguments: (arguments
                                 collect: { |arg|
-                                           arg translateIn: environment })
+                                           arg translateIn: environment })!
     method checkEqualInternal: other
         receiver checkEqual: other receiver.
         selector checkEqual: other selector.
@@ -357,25 +355,25 @@ class SyntaxKeyword { receiver selector arguments }
         List typecheck: other arguments.
         arguments
             with: other arguments
-            do: { |arg1 arg2| arg1 checkEqual: arg2 }
+            do: { |arg1 arg2| arg1 checkEqual: arg2 }!
     method toString
         let string = StringOutput new: "{receiver} ".
         selector parts with: arguments
                        do: { |part arg|
                              string print: "{part} {arg}" }.
-        string content
+        string content!
 end
 
 class SyntaxIs { left right }
     is Syntax
     method translateIn: environment
         AstIs left: (left translateIn: environment)
-              right: (right translateIn: environment)
+              right: (right translateIn: environment)!
     method checkEqualInternal: other
         left checkEqual: other left.
-        right checkEqual: other right.
+        right checkEqual: other right!
     method toString
-        "{left} is {right}"
+        "{left} is {right}"!
 end
 
 class SyntaxLet { name value body }
@@ -386,23 +384,23 @@ class SyntaxLet { name value body }
             name: name
             index: environment allocation index
             value: (value translateIn: environment)
-            body: (body translateIn: bindEnv)
+            body: (body translateIn: bindEnv)!
     method checkEqualInternal: other
         value checkEqual: other value.
         name checkEqual: other name.
-        body checkEqual: other body.
+        body checkEqual: other body!
     method toString
-        "let {name} = {value}. {body}"
+        "let {name} = {value}. {body}"!
 end
 
 class SyntaxVariable { name }
     is Syntax
     method translateIn: environment
-        environment reference: name
+        environment reference: name!
     method isEquivalent: other
-        name == other name
+        name == other name!
     method toString
-        name
+        name!
 end
 
 class SyntaxAssign { variable value }
@@ -413,22 +411,22 @@ class SyntaxAssign { variable value }
             name: variable name
             frame: binding frame :: Integer
             index: binding index :: Integer
-            value: (value translateIn: environment).
+            value: (value translateIn: environment)!
     method checkEqualInternal: other
         variable checkEqual: other variable.
-        value checkEqual: other value.
+        value checkEqual: other value!
     method toString
-        "{variable} = {value}".
+        "{variable} = {value}"!
 end
 
 class SyntaxParens { body }
     is Syntax
     method translateIn: environment
-        body translateIn: environment
+        body translateIn: environment!
     method checkEqualInternal: other
-        body checkEqual: other body
+        body checkEqual: other body!
     method toString
-        "({body})"
+        "({body})"!
 end
 
 class SyntaxBlock { arguments body }
@@ -438,10 +436,10 @@ class SyntaxBlock { arguments body }
         AstBlock
             body: (body translateIn: bodyEnv)
             argumentCount: arguments size
-            frameSize: arguments size + bodyEnv allocation size.
+            frameSize: arguments size + bodyEnv allocation size!
     method checkEqualInternal: other
         arguments checkEqual: other arguments.
-        body checkEqual: other body.
+        body checkEqual: other body!
     method toString
         let args = StringOutput new: "".
         arguments
@@ -449,7 +447,7 @@ class SyntaxBlock { arguments body }
                           arguments do: { |arg| args print: "{arg}" }
                                     interleaving: { args print: " " }.
                           args print: "| " }.
-        "\{ {args content}{body} }"
+        "\{ {args content}{body} }"!
 end
 
 class SyntaxDefine { name body }
@@ -458,33 +456,28 @@ class SyntaxDefine { name body }
         AstDefine
             name: name
             body: (body translateIn: environment)
-            frameSize: environment allocation size.
+            frameSize: environment allocation size!
     method checkEqualInternal: other
         name checkEqual: other name.
-        body checkEqual: other body.
+        body checkEqual: other body!
     method toString
-        "define {name} {body} end"
+        "define {name} {body}!"!
 end
 
 define SeqPrecedence
-    1
-end
+    1!
 
 define SingleExpressionPrecedence
-    2 -- dot has precedence 2
-end
+    2! -- dot has precedence 2
 
 define KeywordPrecedence
-    9
-end
+    9!
 
 define UnknownOperatorPrecedence
-    10
-end
+    10!
 
 define PrefixPrecedence
-    1000
-end
+    1000!
 
 define TokenPrecedence
     let tokens = Dictionary new.
@@ -498,12 +491,12 @@ define TokenPrecedence
     tokens put: 3 at: "(".
     tokens put: 3 at: "\{".
     tokens put: 2 at: ".".
+    tokens put: 1 at: "!".
     tokens put: 0 at: ")".
     tokens put: 0 at: "}".
     tokens put: 0 at: "define".
     tokens put: 0 at: "end".
-    tokens
-end
+    tokens!
 
 interface Token
     is Object
@@ -511,19 +504,19 @@ interface Token
     class method from: first to: last in: parser
         self
             string: (parser source from: first to: last)
-            first: first last: last
+            first: first last: last!
 
     method precedence
-        Error raise: "{self string} is not valid in suffix position!"
+        Error raise: "{self string} is not valid in suffix position!"!
 
     method parseAsSuffixOf: prefix with: parser
-        Error raise: "Cannot parse {self} in suffix position!"
+        Error raise: "Cannot parse {self} in suffix position!"!
 
     method parseAsPrefixWith: parser
-        Error raise: "Cannot parse {self} in prefix position!"
+        Error raise: "Cannot parse {self} in prefix position!"!
 
     method toString
-        "#<Token {self string}>"
+        "#<Token {self string}>"!
 end
 
 interface SuffixToken
@@ -532,7 +525,7 @@ interface SuffixToken
     method precedence
         TokenPrecedence
             at: self string
-            ifNone: { UnknownOperatorPrecedence }
+            ifNone: { UnknownOperatorPrecedence }!
 end
 
 class TokenDecimal { string first last }
@@ -543,26 +536,26 @@ class TokenDecimal { string first last }
         1 to: string size
           do: { |pos|
                 n = n * 10 + (string at: pos) digit }.
-        SyntaxLiteral value: n
+        SyntaxLiteral value: n!
 end
 
 class TokenEof { position }
     is Token
 
     class method at: position in: parser
-        self position: position
+        self position: position!
 
     method precedence
-        0
+        0!
 
     method string
-        "EOF"
+        "EOF"!
 end
 
 interface ReservedToken
     is SuffixToken
     class method string: string first: first last: last
-        self first: first last: last
+        self first: first last: last!
 end
 
 class TokenReservedWordDefine { first last }
@@ -572,18 +565,18 @@ class TokenReservedWordDefine { first last }
         let def = SyntaxDefine
                       name: parser parseVariableName
                       body: (parser parseWithPrecedence: SeqPrecedence).
-        parser expect: "end".
-        def
+        parser expect: "!".
+        def!
 
     method string
-        "define"
+        "define"!
 end
 
 class TokenReservedWordEnd { first last }
     is ReservedToken
 
     method string
-        "end"
+        "end"!
 end
 
 class TokenReservedWordIs { first last }
@@ -592,10 +585,10 @@ class TokenReservedWordIs { first last }
     method parseAsSuffixOf: prefix with: parser
         SyntaxIs
             left: prefix
-            right: (parser parseWithPrecedence: (self precedence))
+            right: (parser parseWithPrecedence: (self precedence))!
 
     method string
-        "is"
+        "is"!
 end
 
 class TokenReservedWordLet { first last }
@@ -609,10 +602,10 @@ class TokenReservedWordLet { first last }
         SyntaxLet
             name: name
             value: value
-            body: (parser parseWithPrecedence: SeqPrecedence)
+            body: (parser parseWithPrecedence: SeqPrecedence)!
 
     method string
-        "let"
+        "let"!
 end
 
 class TokenReservedSigilDot { first last }
@@ -621,10 +614,10 @@ class TokenReservedSigilDot { first last }
     method parseAsSuffixOf: prefix with: parser
         SyntaxSeq
             first: prefix
-            then: (parser parseWithPrecedence: SeqPrecedence)
+            then: (parser parseWithPrecedence: SeqPrecedence)!
 
     method string
-        "."
+        "."!
 end
 
 class TokenReservedSigilOpenParen { first last }
@@ -634,16 +627,16 @@ class TokenReservedSigilOpenParen { first last }
         let body = parser parseWithPrecedence: SeqPrecedence.
         parser expect: ")".
         SyntaxParens
-            body: body
+            body: body!
 
     method string
-        "("
+        "("!
 end
 
 class TokenReservedSigilCloseParen { first last }
     is ReservedToken
     method string
-        ")"
+        ")"!
 end
 
 class TokenReservedSigilOpenBrace { first last }
@@ -657,16 +650,16 @@ class TokenReservedSigilOpenBrace { first last }
                            do: { arguments add: (parser parseVariableName) } }.
         let body = parser parseWithPrecedence: SeqPrecedence.
         parser expect: "}".
-        SyntaxBlock arguments: arguments body: body
+        SyntaxBlock arguments: arguments body: body!
 
     method string
-        "\{"
+        "\{"!
 end
 
 class TokenReservedSigilCloseBrace { first last }
     is ReservedToken
     method string
-        "}"
+        "}"!
 end
 
 class TokenReservedSigilEqual { first last }
@@ -675,10 +668,10 @@ class TokenReservedSigilEqual { first last }
     method parseAsSuffixOf: prefix with: parser
         SyntaxAssign
             variable: prefix::SyntaxVariable
-            value: (parser parseWithPrecedence: SingleExpressionPrecedence).
+            value: (parser parseWithPrecedence: SingleExpressionPrecedence)!
 
     method string
-        "="
+        "="!
 end
 
 define ReservedTokens
@@ -692,8 +685,7 @@ define ReservedTokens
     tokens put: TokenReservedWordDefine at: "define".
     tokens put: TokenReservedWordIs at: "is".
     tokens put: TokenReservedWordLet at: "let".
-    tokens
-end
+    tokens!
 
 interface LookupToken
     is SuffixToken
@@ -704,7 +696,7 @@ interface LookupToken
         let tokenClass = ReservedTokens
                              at: tokenString
                              ifNone: { Self }.
-        tokenClass string: tokenString first: first last: last
+        tokenClass string: tokenString first: first last: last!
 end
 
 class TokenSigil { string first last }
@@ -713,13 +705,13 @@ class TokenSigil { string first last }
     method parseAsPrefixWith: parser
         SyntaxPrefix
             receiver: (parser parseWithPrecedence: PrefixPrecedence)
-            selector: (Selector name: string)
+            selector: (Selector name: string)!
 
     method parseAsSuffixOf: prefix with: parser
         SyntaxBinary
             receiver: prefix
             selector: (Selector name: string)
-            argument: (parser parseWithPrecedence: (self precedence))
+            argument: (parser parseWithPrecedence: (self precedence))!
 end
 
 class TokenWord { string first last }
@@ -731,23 +723,23 @@ class TokenWord { string first last }
         let tokenClass = ReservedTokens
                              at: tokenString
                              ifNone: { TokenWord }.
-        tokenClass string: tokenString first: first last: last
+        tokenClass string: tokenString first: first last: last!
 
     method parseAsPrefixWith: parser
         SyntaxVariable
-            name: string
+            name: string!
 
     method parseAsSuffixOf: prefix with: parser
            SyntaxUnary
             receiver: prefix
-            selector: (Selector name: string).
+            selector: (Selector name: string)!
 end
 
 class TokenKeyword { string first last }
     is SuffixToken
 
     method precedence
-        KeywordPrecedence
+        KeywordPrecedence!
 
     method parseAsSuffixOf: prefix with: parser
         let arguments = List new.
@@ -762,23 +754,20 @@ class TokenKeyword { string first last }
         SyntaxKeyword
             receiver: prefix
             selector: (Selector name: selector content)
-            arguments: arguments
+            arguments: arguments!
 end
 
 define SpecialCharacters
     ["(" character,
      ")" character,
      "[" character,
-     "]" character]
-end
+     "]" character]!
 
 define UnderscoreCharacter
-    "_" character
-end
+    "_" character!
 
 define ColonCharacter
-    ":" character
-end
+    ":" character!
 
 -- FIXME: Broken for unicode input!
 class Parser { source::String
@@ -794,36 +783,36 @@ class Parser { source::String
              first: 1
              last: (source size)
              lookahead: List new)
-        parse
+        parse!
 
     method parse
-        self parseWithPrecedence: 0
+        self parseWithPrecedence: 0!
 
     method parseVariableName
         let token = self nextToken.
         (TokenWord includes: token)
             ifFalse: { panic "Invalid variable name: {token string}" }.
-        token string
+        token string!
 
     method expect: expected
         let got = self nextToken string.
         got == expected
-            ifFalse: { Error raise: "Expected '{expected}', got '{got}'" }.
+            ifFalse: { Error raise: "Expected '{expected}', got '{got}'" }!
 
     method when: test then: action
         self lookahead string == test
-            ifTrue: { self nextToken. action value }
+            ifTrue: { self nextToken. action value }!
 
     method until: test do: action
         { self lookahead string == test }
             whileFalse: action.
-        self nextToken.
+        self nextToken!
 
     method parseWithPrecedence: precedence
-        self parseSuffixOf: self parsePrefix with: precedence
+        self parseSuffixOf: self parsePrefix with: precedence!
 
     method parsePrefix
-        self nextToken parseAsPrefixWith: self
+        self nextToken parseAsPrefixWith: self!
 
     method parseSuffixOf: prefix with: precedence
         let expr = prefix.
@@ -833,23 +822,23 @@ class Parser { source::String
         whileTrue: { -- Debug println: " -> go".
                      expr = self parseSuffixOf: expr }.
         -- Debug println: " -> no".
-        expr
+        expr!
 
     method parseSuffixOf: prefix
-        self nextToken parseAsSuffixOf: prefix with: self
+        self nextToken parseAsSuffixOf: prefix with: self!
 
     method nextPrecedence
-        self lookahead precedence
+        self lookahead precedence!
 
     method lookahead
         lookahead
             ifEmpty: { lookahead push: self scanNext }.
-        lookahead first
+        lookahead first!
 
     method nextToken
         lookahead isEmpty
             ifTrue: { self scanNext }
-            ifFalse: { lookahead pop }.
+            ifFalse: { lookahead pop }!
 
     method scanNext
         self skipWhitespace.
@@ -863,32 +852,32 @@ class Parser { source::String
             ifTrue: { return self scanSigil }.
         self atWord
             ifTrue: { return self scanWord }.
-        Error raise: "Don't know how to scan pos: {position} in: {source}"
+        Error raise: "Don't know how to scan pos: {position} in: {source}"!
 
     method atEof
-        position > last
+        position > last!
 
     method atSpecial
         self isAt: { |char|
                      SpecialCharacters
-                         anySatisfy: { |special| special == char } }
+                         anySatisfy: { |special| special == char } }!
 
     method atDigit
-        self isAt: #isDigit
+        self isAt: #isDigit!
 
     method atWord
         self isAt: { |char|
-                     char isAlphanumeric or: char == UnderscoreCharacter }
+                     char isAlphanumeric or: char == UnderscoreCharacter }!
 
     method atTerminating
-        self atSpecial or: self atWhitespace
+        self atSpecial or: self atWhitespace!
 
     method atSigil
         self atEof not
-            ifTrue: { (self atWord or: self atTerminating) not }
+            ifTrue: { (self atWord or: self atTerminating) not }!
 
     method atWhitespace
-        self isAt: #isWhitespace
+        self isAt: #isWhitespace!
 
     method atChar: char1 thenNot: char2
         self atEof
@@ -896,22 +885,22 @@ class Parser { source::String
         (source at: position) == char1
             ifFalse: { return False }.
         (position + 1 > last)
-            ifFalse: { ((source at: position + 1) == char2) not }
+            ifFalse: { ((source at: position + 1) == char2) not }!
 
     method isAt: block
         self atEof
             ifTrue: { False }
-            ifFalse: { block value: (source at: position) }
+            ifFalse: { block value: (source at: position) }!
 
     method skipWhile: test
         -- Debug println: "/skipWhile: {test}".
         let start = position.
         { test value: self }
             whileTrue: { self advance }.
-        position - 1
+        position - 1!
 
     method skipWhitespace
-        self skipWhile: #atWhitespace
+        self skipWhile: #atWhitespace!
 
     method scanSpecial
         -- Debug println: "/scanSpecial".
@@ -920,21 +909,21 @@ class Parser { source::String
         TokenSigil
             from: start
             to: start
-            in: self.
+            in: self!
 
     method scanDecimal
         -- Debug println: "/scanDecimal".
         TokenDecimal
             from: position
             to: (self skipWhile: #atDigit)
-            in: self.
+            in: self!
 
     method scanSigil
         -- Debug println: "/scanSigil".
         TokenSigil
             from: position
             to: (self skipWhile: #atSigil)
-            in: self.
+            in: self!
 
     method scanWord
         -- Debug println: "/scanWord".
@@ -949,18 +938,18 @@ class Parser { source::String
             ifFalse: { TokenWord
                            from: first
                            to: position - 1
-                           in: self }
+                           in: self }!
 
     method advance
         position <= last
             ifFalse: { panic "Tried to advance beyond end: \"{source}\"" }.
-        position = position + 1.
+        position = position + 1!
 
 end
 
 class Tests {}
     class method run
-        self new run
+        self new run!
     method run
         self
             ; test42
@@ -976,7 +965,7 @@ class Tests {}
             ; testSimpleBlock
             ; testArgBlock
             ; testBlockClosure
-            ; testDefine
+            ; testDefine!
     method parseSyntax: string
         -- Check Syntax print/parse consistency.
         let syntax = Parser parse: string.
@@ -988,39 +977,39 @@ class Tests {}
 original: {string}
 printed: {printed}
 problem: {desc}" }.
-        syntax
+        syntax!
     method load: def eval: expr expect: expected
         let result = ((self parseSyntax: def) load eval: expr).
         (result == expected)
             ifFalse: { Error raise: "Expected {expected}, got: {result}
 from: {expr}
-with: {def}" }
+with: {def}" }!
     method eval: expr expect: expected
         let result = (self parseSyntax: expr) eval.
         (result == expected)
             ifFalse: { Error raise: "Expected {expected}, got: {result}
-from: '{expr}'" }
+from: '{expr}'" }!
     method test42
-        self eval: "42" expect: 42
+        self eval: "42" expect: 42!
     method testPlus
-        self eval: "100 + 1000 + 10 + 1" expect: 1111.
+        self eval: "100 + 1000 + 10 + 1" expect: 1111!
     method testPrecedence
-        self eval: "12 + 10 * 10 - 1" expect: 111.
+        self eval: "12 + 10 * 10 - 1" expect: 111!
     method testPrefixMethod
-        self eval: "- 42" expect: -42.
+        self eval: "- 42" expect: -42!
     method testUnaryMethod
-        self eval: "- 42 abs" expect: 42.
+        self eval: "- 42 abs" expect: 42!
     method testKeywordMethod
-        self eval: "1 to: 10 by: 2" expect: (1 to: 10 by: 2).
+        self eval: "1 to: 10 by: 2" expect: (1 to: 10 by: 2)!
     method testIs
         self eval: "1 is 1" expect: True.
-        self eval: "1 is 2" expect: False.
+        self eval: "1 is 2" expect: False!
     method testLet
         self eval: "let x = 1. x + x"
-             expect: 2
+             expect: 2!
     method testParens
         self eval: "(1 + 1) * 2"
-             expect: 4
+             expect: 4!
     method testAssign
         self eval: "let x = 20. x = x + 1. x * 2"
              expect: 42.
@@ -1028,28 +1017,27 @@ from: '{expr}'" }
                     let x = 20.
                     (let x = 2000. x = x + 100. y = x * 2).
                     x = x + 1. y + x * 2"
-            expect: 4242.
+            expect: 4242!
     method testSimpleBlock
         self eval: "\{ 32 + 10 } value"
-             expect: 42.
+             expect: 42!
     method testArgBlock
         self eval: "\{ |x| x + 1 } value: 41"
-             expect: 42
+             expect: 42!
     method testBlockClosure
         self eval: "let block = (let x = 21. \{ x = x * 2 }).
                     let x = 0.
                     block value. block value"
-            expect: 84
+            expect: 84!
     method testDefine
         self load: "define FourtyTwoForTestDefine
-                       42
-                    end"
+                       42!"
              eval: "FourtyTwoForTestDefine"
-             expect: 42
+             expect: 42!
 end
 
 class Main {}
     class method run: cmd in: system
         Tests run.
-        system output println: "ok!"
+        system output println: "ok!"!
 end

--- a/foo/lang/array.foo
+++ b/foo/lang/array.foo
@@ -6,37 +6,37 @@ class ArrayIterator { array index }
     is Iterator
 
     class method new: array
-        self array: array index: 1
+        self array: array index: 1!
 
     method nextIfNone: block
         let next = index > array size
             ifTrue: { return block value }
             ifFalse: { array at: index }.
         index = index + 1.
-        next
+        next!
 
     method hasNext
-        index <= array size
+        index <= array size!
 end
 
 class Specialized { containerClass elementType }
     class method class: containerClass of: elementType
-        self containerClass: containerClass elementType: elementType
+        self containerClass: containerClass elementType: elementType!
     method new
-        containerClass of: elementType new: 0
+        containerClass of: elementType new: 0!
     method new: size
-        containerClass of: elementType new: size
+        containerClass of: elementType new: size!
     method new: size value: value
-        containerClass of: elementType new: size value: value
+        containerClass of: elementType new: size value: value!
     method includes: thing
         (containerClass includes: thing)
-            ifTrue: { thing elementType is elementType }
+            ifTrue: { thing elementType is elementType }!
     method typecheck: thing
         self includes: thing
-             ifFalse: { TypeError raise: thing expected: self }.
-        thing
+             ifFalse: { TypeError raise: thing expected: self }
+        thing!
     method displayOn: stream
-        stream print: "{containerClass} of: {elementType}"
+        stream print: "{containerClass} of: {elementType}"!
 end
 
 extend Array
@@ -48,84 +48,84 @@ extend Array
         let new = self new: ordered size.
         1 to: new size
           do: { |i| new put: (ordered at: i) at: i }.
-        new
+        new!
 
     class method new: size
-        self of: Object new: size value: False
+        self of: Object new: size value: False!
 
     class method new: size value: value
-        self of: Object new: size value: value
+        self of: Object new: size value: value!
 
     class method of: type
-        Specialized class: Array of: type
+        Specialized class: Array of: type!
 
     class method of: type new: size
-        self of: type new: size value: type default
+        self of: type new: size value: type default!
 
     method from: first to: last
         let offset = first - 1.
         let new = Array of: self arrayElementType new: last - offset.
         1 to: new size
           do: { |i| new put: (self at: i + offset) at: i }.
-        new
+        new!
 
     method + x
-        x broadcast: {|a b| a + b} to: self.
+        x broadcast: {|a b| a + b} to: self!
     method - x
-        x broadcast: {|a b| a - b} to: self.
+        x broadcast: {|a b| a - b} to: self!
     method * x
-        x broadcast: {|a b| a * b} to: self.
+        x broadcast: {|a b| a * b} to: self!
     method / x
-        x broadcast: {|a b| a / b} to: self.
+        x broadcast: {|a b| a / b} to: self!
 
     method broadcast: block to: collection
-        collection with: self collect: block.
+        collection with: self collect: block!
 
     method iterator
-        ArrayIterator new: self
+        ArrayIterator new: self!
 
     method elementType
         -- KLUDGE: otherwise Iterator#elementType:
         -- need something like
         --  is Iterable except: [#elementType]
-        self arrayElementType
+        self arrayElementType!
 
     method _emitOn: stream using: block
         stream print: "[".
         self do: { |x| block value: x }
              interleaving: { stream print: ", " }.
-        stream print: "]".
+        stream print: "]"!
 
     method displayOn: stream
-        self _emitOn: stream using: { |x| x displayOn: stream }.
+        self _emitOn: stream using: { |x| x displayOn: stream }!
 
     method printOn: stream
-        self _emitOn: stream using: { |x| x printOn: stream }.
+        self _emitOn: stream using: { |x| x printOn: stream }!
 
     method dot: other
-        self with: other sum: { |a b| a * b }.
+        self with: other sum: { |a b| a * b }!
 
     method norm
-       (self inject: 0.0 into: { |abs elt| abs + (elt * elt) }) sqrt.
+       (self inject: 0.0 into: { |abs elt| abs + (elt * elt) }) sqrt!
 
     method normalized
-       let reciprocal = 1.0 / (self norm).
-        self * reciprocal.
+        let reciprocal = 1.0 / (self norm).
+        self * reciprocal!
 
     method scalarProjectionOn: other
-        (self dot: other) / other norm.
+        (self dot: other) / other norm!
 
     method vectorProjectionOn: other
-        ((self dot: other) / (other dot: other)) * other.
+        ((self dot: other) / (other dot: other)) * other!
 
     method addNumber: left
-       self collect: { |elt| left + elt }.
+       self collect: { |elt| left + elt }!
     method subNumber: left
-       self collect: { |elt| left - elt }.
+       self collect: { |elt| left - elt }!
     method divNumber: left
-       self collect: { |elt| left / elt }.
+       self collect: { |elt| left / elt }!
     method mulNumber: left
-       self collect: { |elt| left * elt }.
+       self collect: { |elt| left * elt }!
 end
 
 class TestArray {}
@@ -140,6 +140,7 @@ class TestArray {}
                testing: "Array#== (false 2)".
         assert false: { ["one", 2, 3] == [1, "two", 3] }
                testing: "Array#== (false 3)".
+        self!
 
     class method testSort: assert
         assert that: { [] sort }
@@ -166,6 +167,7 @@ class TestArray {}
         assert that: { [9, 2, 1, 8, 7, 3, 5, 4, 6, 0] sort }
                equals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                testing: "sort, ten".
+        self!
 
     class method testReverse: assert
         assert that: { let a = [].
@@ -192,6 +194,7 @@ class TestArray {}
                        a reverse }
                equals: [3,2,1]
                testing: "reverse array, retval (3)".
+        self!
 
     class method testReversed: assert
         assert that: { let a = [].
@@ -215,10 +218,12 @@ class TestArray {}
                        a }
                equals: [1,2,3]
                testing: "reversed array, side-effect (3)".
+        self!
 
     class method runTests: assert
         self testEquality: assert.
         self testSort: assert.
         self testReverse: assert.
         self testReversed: assert.
+        self!
 end

--- a/foo/lang/boolean.foo
+++ b/foo/lang/boolean.foo
@@ -4,59 +4,59 @@ extend Boolean
     is Object
 
     class method default
-        False
+        False!
 
     method assert: what
-        self ifFalse: { panic "{what} assertion failed!" }
+        self ifFalse: { panic "{what} assertion failed!" }!
 
     method == other -> Boolean
-        self is other
+        self is other!
 
     method isEquivalent: other
-        self is other
+        self is other!
 
     method and: other::Boolean
         self
            ifTrue: { other }
-           ifFalse: { False }
+           ifFalse: { False }!
 
     method and: other1 and: other2
         self
            ifTrue: { other1 and: other2 }
-           ifFalse: { False }
+           ifFalse: { False }!
 
     method and: other1 and: other2 and: other3
         self
            ifTrue: { other1 and: other2 and: other3 }
-           ifFalse: { False }
+           ifFalse: { False }!
 
     method or: other::Boolean
         self
            ifTrue: { True }
-           ifFalse: { other }
+           ifFalse: { other }!
 
     method not
         self
            ifTrue: { False }
-           ifFalse: { True }
+           ifFalse: { True }!
 
     method ifTrue: block
         self
            ifTrue: block
-           ifFalse: { False }
+           ifFalse: { False }!
 
     method ifFalse: block
         self
            -- FIXME: returning True in the first leg seems strange, but breaks a couple
            -- of tests. Should either explain the rational or return False.
            ifTrue: { True }
-           ifFalse: block
+           ifFalse: block!
 
     method toString
         self
            ifTrue: { "True" }
-           ifFalse: { "False" }
+           ifFalse: { "False" }!
 
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
 end

--- a/foo/lang/byteArray.foo
+++ b/foo/lang/byteArray.foo
@@ -6,10 +6,10 @@ extend ByteArray
     is Ordered
 
     method iterator
-        ArrayIterator new: self
+        ArrayIterator new: self!
 
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
 
     class method runTests: assert
         assert forAll: (1 to: 10)
@@ -23,5 +23,5 @@ extend ByteArray
                            and: (old == 0)
                            and: (new == n)
                            and: (n > 0) }
-               testing: "ByteArray creation and access"
+               testing: "ByteArray creation and access"!
 end

--- a/foo/lang/character.foo
+++ b/foo/lang/character.foo
@@ -3,16 +3,14 @@ define ASCII
      tab: 0x09,
      lineFeed: 0x0A,
      formFeed: 0x0C,
-     carriageReturn: 0x0D}
-end
+     carriageReturn: 0x0D}!
 
 define WhitespaceASCII
     [ASCII space,
      ASCII tab,
      ASCII lineFeed,
      ASCII formFeed,
-     ASCII carriageReturn]
-end
+     ASCII carriageReturn]!
 
 import .object.Object
 
@@ -20,18 +18,18 @@ import .object.Object
 class Character { code }
     is Object
     method isAlphanumeric
-        self isAlpha or: self isDigit
+        self isAlpha or: self isDigit!
     method isAlpha
         (0x41 <= code and: code <= 0x5A)
-            ifFalse: { 0x61 <= code and: code <= 0x7A }
+            ifFalse: { 0x61 <= code and: code <= 0x7A }!
     method isWhitespace
-        WhitespaceASCII anySatisfy: { |whitespaceCode| whitespaceCode is code }
+        WhitespaceASCII anySatisfy: { |whitespaceCode| whitespaceCode is code }!
     method isDigit
-        0x30 <= code and: code <= 0x39
+        0x30 <= code and: code <= 0x39!
     method digit
-        self isDigit ifTrue: { code - 0x30 }
+        self isDigit ifTrue: { code - 0x30 }!
     method isEquivalent: other
-        code is other code
+        code is other code!
     method toString
-        "#<Character code: {code}>"
+        "#<Character code: {code}>"!
 end

--- a/foo/lang/closure.foo
+++ b/foo/lang/closure.foo
@@ -4,53 +4,53 @@ extend Closure
     is Object
 
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
 
     method whileTrue
-        { self value } whileTrue: {}.
+        { self value } whileTrue: {}!
 
     method whileFalse
-        { self value } whileFalse: {}
+        { self value } whileFalse: {}!
 
     method whileFalse: bodyBlock
-        { self value not } whileTrue: bodyBlock
+        { self value not } whileTrue: bodyBlock!
 
     method loop
-        { True } whileTrue: self
+        { True } whileTrue: self!
 
     method with: value
         -- Deserves a better verb than close, should probably
         -- steal python's __enter__ and __exit__ style names.
         -- and protocol.
-        { self value: value } finally: { value close }
+        { self value: value } finally: { value close }!
 
     method ascending
-        { |a b| (self value: a) < (self value: b) }
+        { |a b| (self value: a) < (self value: b) }!
 
     method descending
-        { |a b| (self value: a) > (self value: b) }
+        { |a b| (self value: a) > (self value: b) }!
 
     method on: condition do: block
-        condition withHandler: block do: self
+        condition withHandler: block do: self!
 end
 
 -- For testing Closure#with:
 class _Closable { closed }
     method close
-        closed = True
+        closed = True!
 end
 
 class TestSelfRefInClosure { cookie }
     class method test
-        (self cookie: 132132132) test
+        (self cookie: 132132132) test!
     method test
-        { self cookie is cookie } value
+        { self cookie is cookie } value!
 end
 
 class TestClosure { assert }
 
     class method runTests: assert
-        (self assert: assert) runTests
+        (self assert: assert) runTests!
 
     method runTests
         self
@@ -63,27 +63,28 @@ class TestClosure { assert }
             ; testAscending
             ; testDescending
             ; testApply
-            ; testSelfRefInClosure
+            ; testSelfRefInClosure.
+        self!
 
     method testSelfRefInClosure
         assert true: { TestSelfRefInClosure test }
-               testing: "reference to self inside closure".
+               testing: "reference to self inside closure"!
 
     method testApplication
         assert true: { 1 == { 1 } value }
-               testing: "Closure#value".
+               testing: "Closure#value"!
 
     method testOnPanic
         assert true: { { panic "Foo". False }
                          onPanic: { |p| True } }
-        testing: "Closure#onPanic".
+               testing: "Closure#onPanic"!
 
     method testFinally
         assert true: { let flag = False.
                        { { panic "Foo". False }
                              finally: { flag = True } }
                        onPanic: { |p| flag } }
-                testing: "Closure#finally"
+               testing: "Closure#finally"!
 
     method testWhileTrue
         let a = 0.
@@ -93,7 +94,7 @@ class TestClosure { assert }
         let b = 0.
         assert that: { { b = b + 1. b < 10 } whileTrue. b }
                is: 10
-               testing: "Closure#whileTrue".
+               testing: "Closure#whileTrue"!
 
     method testWhileFalse
         let a = 0.
@@ -103,17 +104,17 @@ class TestClosure { assert }
         let b = 0.
         assert that: { { b = b + 1. b == 10 } whileFalse. b }
                is: 10
-               testing: "Closure#whileFalse".
+               testing: "Closure#whileFalse"!
 
     method auxTextLoop
         let a = 0.
-        { a = a + 1. a == 10 ifTrue: { return a } } loop
+        { a = a + 1. a == 10 ifTrue: { return a } } loop!
 
     method testLoop
         let a = 0.
         assert that: { auxTestLoop }
                is: 10
-               testing: "Closure#loop"
+               testing: "Closure#loop"!
 
     method testWith
         assert false: { (_Closable closed: False) closed }
@@ -128,23 +129,23 @@ class TestClosure { assert }
                                      onPanic: { |p| 104 }.
                        [obj closed, res] }
                equals: [True, 104]
-               testing: "Closure#with: (unwind)".
+               testing: "Closure#with: (unwind)"!
 
     method testAscending
         assert that: { ["a", "aaaa", "aa", "", "aaa"]
                            sort: { |array| array size } ascending }
                equals: ["", "a", "aa", "aaa", "aaaa"]
-               testing: "Closure#ascending".
+               testing: "Closure#ascending"!
 
     method testDescending
         assert that: { ["a", "aaaa", "aa", "", "aaa"]
                            sort: { |array| array size } descending }
                equals: ["aaaa", "aaa", "aa", "a", ""]
-               testing: "Closure#descending".
+               testing: "Closure#descending"!
 
     method testApply
         assert that: { { |x y| x + y } apply: [1, 2] }
                equals: 3
-               testing: "Closure#apply:"
+               testing: "Closure#apply:"!
 
 end

--- a/foo/lang/collection.foo
+++ b/foo/lang/collection.foo
@@ -24,142 +24,142 @@ interface Collection
     required method clear
 
     class method default
-        List new
+        List new!
 
     class method defaultCapacity
-        8
+        8!
 
     class method defaultElementType
-        Object
+        Object!
 
     class method from: iterable
         let new = self of: iterable elementType withCapacity: iterable sizeEstimate.
         iterable do: { |each| new add: each }.
-        new
+        new!
 
     class method newOf: type
         self of: type
-             withCapacity: self defaultCapacity
+             withCapacity: self defaultCapacity!
 
     class method new
-        self newOf: self defaultElementType
+        self newOf: self defaultElementType!
 
     class method new: size
-        self new _initSize: size
+        self new _initSize: size!
 
     class method of: type new: size
-        (self newOf: type) _initSize: size
+        (self newOf: type) _initSize: size!
 
     class method of: type new: size value: value
-        (self newOf: type) _initSize: size value: value
+        (self newOf: type) _initSize: size value: value!
 
     class method of: type from: iterable
         let new = self of: type withCapacity: iterable sizeEstimate.
         iterable do: { |each| new add: each }.
-        new
+        new!
 
     class method withCapacity: capacity
-        self of: self defaultElementType withCapacity: capacity
+        self of: self defaultElementType withCapacity: capacity!
 
     method _initSize: size
-        self _initSize: size value: self elementType default
+        self _initSize: size value: self elementType default!
 
     method _initSize: size value: value
         size times: { new add: value }.
-        self
+        self!
 
     method isEmpty
-        self size is 0
+        self size is 0!
 
     method addAll: iterable
         self reserveCapacity: (self size + iterable sizeEstimate).
         iterable do: { |each| self add: each }.
-        self
+        self!
 
     method as: type
-        type fromCollection: self
+        type fromCollection: self!
 
     method collect: block
-        self collect: block into: (Self withCapacity: self size)
+        self collect: block into: (Self withCapacity: self size)!
 
     method copy
         let new = Self withCapacity: self size.
         self do: { |each| new add: each }.
-        new
+        new!
 
     method reject: block
-        self select: { |each| (block value: each) not }
+        self select: { |each| (block value: each) not }!
 
     method removeAll: iterable
         self removeIf: { |each| iterable includes: each }.
-        self
+        self!
 
     method removeIfNot: block
         self removeIf: { |each| (block value: each) not }.
-        self
+        self!
 
     method reserveCapacity
-        self
+        self!
 
     method select: block
-        self select: block as: Self
+        self select: block as: Self!
 
     method sizeEstimate
-        self size
+        self size!
 
     method with: iterable collect: block
-        self with: iterable collect: block as: Self
+        self with: iterable collect: block as: Self!
 
     method second
-       self at: 2.
+       self at: 2!
 
     method last
-        self at: self size.
+        self at: self size!
 
     method isEmpty
-        self size is 0
+        self size is 0!
 
     method ifEmpty: block
         self size is 0
-            ifTrue: block.
+            ifTrue: block!
 
     method ifEmpty: block ifNotEmpty: notBlock
         self size is 0
             ifTrue: block
-            ifFalse: notBlock.
+            ifFalse: notBlock!
 
     method find: block
-        self find: block ifNone: { False }.
+        self find: block ifNone: { False }!
 
     method find: block ifNone: noneBlock
         self do: { |elt|
                    (block value: elt) is True
                        ifTrue: { return elt } }.
-        noneBlock value.
+        noneBlock value!
 
     method do: block
         1 to: self size
           do: { |i| block value: (self at: i) }.
-        self.
+        self!
 
     method inject: value into: block
         let result = value.
         self do: { |elt| result = (block value: result value: elt) }.
-        result.
+        result!
 
     method reject: block
         let selection = Array withCapacity: 4.
         self do: { |elt|
                    (block value: elt) is True
                        ifFalse: { selection push: elt } }.
-        selection.
+        selection!
 
     method select: block
         let selection = Array withCapacity: 4.
         self do: { |elt|
                    (block value: elt) is True
                        ifTrue: { selection push: elt } }.
-        selection.
+        selection!
 
     method with: other collect: block
         let size = self checkSize: other.
@@ -167,7 +167,7 @@ interface Collection
         1 to: size
           do: { |i|
                 new put: (block value: (self at: i)  value: (other at: i)) }.
-        new.
+        new!
 
     method with: array default: default collect: block
         let size1 = self size.
@@ -188,26 +188,26 @@ interface Collection
                                            block value: (self at: i) value: default } }.
         common + 1 to: size
                    do: { |i| result put: (tailHandler value: i) at: i }.
-        result
+        result!
 
     method with: sequence inject: value into: block
         let result = value.
         self with: sequence
              do: { |a b|
                    result = (block value: result value: a value: b) }.
-        result.
+        result!
 
     method sum
-        self inject: 0 into: { |res elt| res + elt }.
+        self inject: 0 into: { |res elt| res + elt }!
 
     method sum: block
-        self inject: 0 into: { |res elt| res + (block value: elt) }.
+        self inject: 0 into: { |res elt| res + (block value: elt) }!
 
     method with: array sum: block
         self
             with: array
             inject: 0
             into: { |res a b|
-                    res + (block value: a value: b) }.
+                    res + (block value: a value: b) }!
 
 end

--- a/foo/lang/dictionary.foo
+++ b/foo/lang/dictionary.foo
@@ -5,7 +5,7 @@ extend Dictionary
     is Object
 
     method at: key
-        self at: key ifNone: { False }
+        self at: key ifNone: { False }!
 
     class method runTests: assert
         assert that: { let d = { 1 + 1 + 40 -> "the" append: "Answer" }.
@@ -16,5 +16,5 @@ extend Dictionary
                        d put: "foo" at: "bar".
                        (d at: "bar") }
                is: "foo"
-               testing: "Dictionary#put:at: and #at:"
+               testing: "Dictionary#put:at: and #at:"!
 end

--- a/foo/lang/exception.foo
+++ b/foo/lang/exception.foo
@@ -4,77 +4,72 @@ class Panic { description context }
     is Object
     method displayOn: stream
         stream println: "PANIC: {self description}".
-        stream println: self context
+        stream println: self context!
 end
 
 define $error
-{ |ex| panic (ex description) }
-end
+    { |ex| panic (ex description) }!
 
 class Error { description }
     is Object
     class method withHandler: handler do: block
         let $error = { |error| self handle: error with: handler }.
-        block value
+        block value!
     class method raise: description
-        $error value: (self description: description)
+        $error value: (self description: description)!
     class method handle: error with: handler
         handler value: error.
-        panic "UNHANDLED ERROR: {error description}"
+        panic "UNHANDLED ERROR: {error description}"!
     class method handler
-        { |ex| $error value: ex }
+        { |ex| $error value: ex }!
     method displayOn: stream
-        stream print: "#<Error {self description}>"
+        stream print: "#<Error {self description}>"!
 end
 
 define $typeError
-    Error handler
-end
+    Error handler!
 
 class TypeError { value expected }
     is Object
     class method withHandler: handler do: block
         let $typeError = { |error| self handle: error with: handler }.
-        block value
+        block value!
     class method raise: value expected: type
-        $typeError value: (self value: value expected: type)
+        $typeError value: (self value: value expected: type)!
     method description
-        "Type error: {expected} expected, got: {value}".
+        "Type error: {expected} expected, got: {value}"!
     method displayOn: stream
-        stream print: "#<TypeError {expected}, got: {value}>"
+        stream print: "#<TypeError {expected}, got: {value}>"!
 end
-
 
 define $divideByZero
-    Error handler
-end
+    Error handler!
 
 class DivideByZero { value }
     is Object
     class method withHandler: handler do: block
         let $divideByZero = handler.
-        block value
+        block value!
     class method raise: value
-        $divideByZero value: (self value: value)
+        $divideByZero value: (self value: value)!
     method description
-        "Divide by zero: {value} cannot be divided by zero"
+        "Divide by zero: {value} cannot be divided by zero"!
     method displayOn: stream
-        stream print: "#<DivideByZero {value}>"
+        stream print: "#<DivideByZero {value}>"!
 end
 
 define $iteratorExhausted
-    Error handler
-end
+    Error handler!
 
 class IteratorExhausted { value }
     is Object
     class method withHandler: handler do: block
         let $iteratorExhausted = handler.
-        block value
+        block value!
     class method raise: value
-        $iteratorExhausted value: ( self value: value )
+        $iteratorExhausted value: ( self value: value )!
     method description
-        "Iterator exhausted: {value}"
+        "Iterator exhausted: {value}"!
     method displayOn: stream
-        stream print: "#<IteratorExhausted {value}>"
+        stream print: "#<IteratorExhausted {value}>"!
 end

--- a/foo/lang/file.foo
+++ b/foo/lang/file.foo
@@ -1,12 +1,12 @@
 extend File
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
     method open: block
-        block with: self open
+        block with: self open!
     method create: block
-        block with: self create
+        block with: self create!
     method createOrOpen: block
-        block with: self createOrOpen
+        block with: self createOrOpen!
     class method runTests: assert in: system
         let file = system currentDirectory file.
         assert false: { file isAppend }
@@ -52,7 +52,5 @@ extend File
         assert false: { truncatefile isRead }
                testing: "File#truncateExisting does not set read".
         assert false: { truncatefile isWrite }
-               testing: "File#forWrite does not set write"
-
-
+               testing: "File#forWrite does not set write"!
 end

--- a/foo/lang/filepath.foo
+++ b/foo/lang/filepath.foo
@@ -1,18 +1,18 @@
 extend FilePath
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
     method forAppend
-        self file forAppend
+        self file forAppend!
     method forRead
-        self file forRead
+        self file forRead!
     method forWrite
-        self file forWrite
+        self file forWrite!
     method readString
-        self forRead open: { |f| f readString }
+        self forRead open: { |f| f readString }!
     method readString: path
-        (self path: path) readString
+        (self path: path) readString!
     method ifExists: block
-        self exists ifTrue: block
+        self exists ifTrue: block!
 end
 
 class TestFilePath { assert dir none file }
@@ -22,7 +22,7 @@ class TestFilePath { assert dir none file }
         assert false: { none exists }
                testing: "FilePath#exists (none)".
         assert true: { file exists }
-               testing: "FilePath#exists (file)"
+               testing: "FilePath#exists (file)"!
 
     method testIsDirectory
         assert true: { dir isDirectory }
@@ -30,7 +30,7 @@ class TestFilePath { assert dir none file }
         assert false: { none isDirectory }
                testing: "FilePath#isDirectory (none)".
         assert false: { file isDirectory }
-               testing: "FilePath#isDirectory (file)"
+               testing: "FilePath#isDirectory (file)"!
 
     method testIsFile
         assert false: { dir isFile }
@@ -38,7 +38,7 @@ class TestFilePath { assert dir none file }
         assert false: { none isFile }
                testing: "FilePath#isFile (none)".
         assert true: { file isFile }
-               testing: "FilePath#isFile (file)".
+               testing: "FilePath#isFile (file)"!
 
     method testDeleteFile
         let tmpfile = dir path: "FilePath-testDeleteFile.tmp".
@@ -51,7 +51,7 @@ class TestFilePath { assert dir none file }
                testing: "FilePath#deleteFile (pre2)".
         tmpfile deleteFile.
         assert false: { tmpfile exists }
-               testing: "FilePath#deleteFile (post)"
+               testing: "FilePath#deleteFile (post)"!
 
     class method runTests: assert in: system
         -- Assumes the repository root as the current directory
@@ -62,6 +62,6 @@ class TestFilePath { assert dir none file }
         tests testDeleteFile.
         tests testExists.
         tests testIsDirectory.
-        tests testIsFile
+        tests testIsFile!
 
 end

--- a/foo/lang/filestream.foo
+++ b/foo/lang/filestream.foo
@@ -1,9 +1,9 @@
 extend FileStream
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
 
     method isOpen
-        self isClosed not
+        self isClosed not!
 
     method readBytes
         let n = self size - self offset.
@@ -11,13 +11,13 @@ extend FileStream
         let got = self tryRead: n bytesInto: bytes at: 1.
         got == n
             ifFalse: { panic "Could not #readBytes from {self} upto end of file" }.
-        bytes
+        bytes!
 
     method read: n bytesInto: buffer at: index
         let got = self tryRead: n bytesInto: buffer at: index.
         got == n
             ifTrue: { return n }
-            ifFalse: { panic "Could not read {n} bytes from {self}." }
+            ifFalse: { panic "Could not read {n} bytes from {self}." }!
 
     method tryRead: n bytesInto: buffer at: index
         let total = 0.
@@ -31,13 +31,13 @@ extend FileStream
                          total = total + did.
                          n = n - did.
                          index = index + did }.
-        total
+        total!
 
     method write: n bytesFrom: buffer at: index
         let did = self tryWrite: n bytesFrom: buffer at: index.
         did == n
             ifTrue: { return n }
-            ifFalse: { panic "Could not write {n} bytes to {self}." }
+            ifFalse: { panic "Could not write {n} bytes to {self}." }!
 
     method tryWrite: n bytesFrom: buffer at: index
         let total = 0.
@@ -51,14 +51,14 @@ extend FileStream
                          total = total + did.
                          n = n - did.
                          index = index + did }.
-        total
+        total!
 
     method size
         let pos = self offset.
-        { self offsetFromEnd: 0 } finally: { self offset: pos }
+        { self offsetFromEnd: 0 } finally: { self offset: pos }!
 
     method writeBytes: bytes
-        self write: bytes size bytesFrom: bytes at: 1
+        self write: bytes size bytesFrom: bytes at: 1!
 end
 
 class TestFileStream { assert dir foopath foodata }
@@ -72,7 +72,7 @@ class TestFileStream { assert dir foopath foodata }
                            open: { |f| f readBytes } }
                equals: [13, 13, 10, 10] bytes
                testing: "FileStream#readBytes".
-        newpath deleteFile
+        newpath deleteFile!
 
     method testReadString
         assert true: { foodata is (foopath forRead open readString) }
@@ -80,7 +80,7 @@ class TestFileStream { assert dir foopath foodata }
         assert true: { let s = foopath forRead open.
                        s close.
                        { s readString. False } onPanic: { |p| True } }
-               testing: "FileStream#readString (closed)".
+               testing: "FileStream#readString (closed)"!
 
     method testResize
         let newpath = dir path: "TestFileStream-testResize.tmp".
@@ -92,7 +92,7 @@ class TestFileStream { assert dir foopath foodata }
                                    [ f size, f resize: 4. f size, f readString ]
                                        == [ 38, 4, "This" ] } }
                testing: "FileStream#resize:".
-        newpath deleteFile
+        newpath deleteFile!
 
     method testTryReadBytesIntoAt
         let newpath = dir path: "TestFileStream-testTryReadBytesIntoAt.tmp".
@@ -116,7 +116,7 @@ class TestFileStream { assert dir foopath foodata }
         assert that: { [13, 10, 13, 10, 10, 106] bytes }
                equals: buf
                testing: "FileStream#tryRead:bytesInto:at: (short data)".
-        newpath deleteFile
+        newpath deleteFile!
 
     method testTryWriteBytesFromAt
         let newpath = dir path: "TestFileStream-testTryWriteBytesFromAt.tmp".
@@ -139,19 +139,19 @@ class TestFileStream { assert dir foopath foodata }
         assert that: { [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0] bytes }
                equals: data
                testing: "FileStream#tryWrite:bytesFrom:at: (wrote data)".
-        newpath deleteFile
+        newpath deleteFile!
 
     method testIsOpen
         assert true: { foopath forRead open: { |f| f isOpen } }
                testing: "FileStream#isOpen (true)".
         assert false: { (foopath forRead open: { |f| f }) isOpen }
-               testing: "FileStream#isOpen (false)"
+               testing: "FileStream#isOpen (false)"!
 
     method testIsClosed
         assert false: { foopath forRead open: { |f| f isClosed } }
                testing: "FileStream#isClosed (false)".
         assert true: { (foopath forRead open: { |f| f }) isClosed }
-               testing: "FileStream#isClosed (true)"
+               testing: "FileStream#isClosed (true)"!
 
     method testOffset
         assert that: { foopath forRead open: { |f| f offset } } is: 0
@@ -159,19 +159,19 @@ class TestFileStream { assert dir foopath foodata }
         assert that: { foopath forRead
                            open:  { |f| f readString. f offset } }
                is: 45
-               testing: "FileStream#offset (45)"
+               testing: "FileStream#offset (45)"!
 
     method testOffsetSet
         assert that: { foopath forRead
                            open: { |f| f offset: 5. f readString } }
                is: "file just says 'foo' for test purposes.\n"
-               testing: "FileStream#offset:"
+               testing: "FileStream#offset:"!
 
     method testOffsetFromEnd
         assert that: { foopath forRead
                            open: { |f| f offsetFromEnd: -10. f readString } }
                is: "purposes.\n"
-               testing: "FileStream#offsetFromEnd:"
+               testing: "FileStream#offsetFromEnd:"!
 
     method testSize
         assert that: { foopath forRead
@@ -184,7 +184,7 @@ class TestFileStream { assert dir foopath foodata }
         assert true: { let res = foopath forRead
                                     open: { |f| [f size, f offset] }.
                        res == [45, 0] }
-               testing: "FileStream#size"
+               testing: "FileStream#size"!
 
     method testWriteString
         let newpath = dir path: "TestFileStream-testWriteString.tmp".
@@ -197,7 +197,7 @@ class TestFileStream { assert dir foopath foodata }
         assert that: { newpath readString }
                is: newdata
                testing: "FileStream#writeString: (post)".
-        newpath deleteFile
+        newpath deleteFile!
 
     class method runTests: assert in: system
         let tests = self assert: assert
@@ -214,6 +214,6 @@ class TestFileStream { assert dir foopath foodata }
         tests testTryReadBytesIntoAt.
         tests testTryWriteBytesFromAt.
         tests testSize.
-        tests testWriteString
+        tests testWriteString!
 
 end

--- a/foo/lang/float.foo
+++ b/foo/lang/float.foo
@@ -4,53 +4,53 @@ extend Float
     is Number
 
     class method default
-        0.0
+        0.0!
 
     method asFloat
-        self.
+        self!
 
     method to: other
-       self to: other by: 1.0.
+       self to: other by: 1.0!
 
     method addNumber: left
-        left floatAdd: self
+        left floatAdd: self!
     method subNumber: left
-        left floatSub: self.
+        left floatSub: self!
     method mulNumber: left
-        left floatMul: self.
+        left floatMul: self!
     method divNumber: left
-        left floatDiv: self.
+        left floatDiv: self!
 
     method eqNumber: left
-        left floatEq: self.
+        left floatEq: self!
     method ltNumber: left
-        left floatLt: self.
+        left floatLt: self!
     method gtNumber: left
-        left floatGt: self.
+        left floatGt: self!
     method lteNumber: left
-        left floatLte: self.
+        left floatLte: self!
     method gteNumber: left
-        left floatGte: self.
+        left floatGte: self!
 
     method integerAdd: right
-        self floatAdd: right asFloat.
+        self floatAdd: right asFloat!
     method integerSub: right
-        self floatSub: right asFloat.
+        self floatSub: right asFloat!
     method integerMul: right
-        self floatMul: right asFloat.
+        self floatMul: right asFloat!
     method integerDiv: right
-        self floatDiv: right asFloat.
+        self floatDiv: right asFloat!
 
     method integerEq: right
-        self floatEq: right asFloat.
+        self floatEq: right asFloat!
     method integerLt: right
-        self floatLt: right asFloat.
+        self floatLt: right asFloat!
     method integerGt: right
-        self floatGt: right asFloat.
+        self floatGt: right asFloat!
     method integerLte: right
-        self floatLte: right asFloat.
+        self floatLte: right asFloat!
     method integerGte: right
-        self floatGte: right asFloat.
+        self floatGte: right asFloat!
 
     method atLeast: min atMost: max
         let min = min asFloat.
@@ -59,5 +59,5 @@ extend Float
         let max = max asFloat.
         (self floatGt: max)
             ifTrue: { return max }.
-        self.
+        self!
 end

--- a/foo/lang/integer.foo
+++ b/foo/lang/integer.foo
@@ -4,63 +4,63 @@ extend Integer
     is Number
 
     class method default
-        0
+        0!
 
     method asInteger
-        self
+        self!
 
     method to: other
-        self to: other by: 1
+        self to: other by: 1!
 
     method to: other do: block
         let i = self.
         { i <= other }
            whileTrue: { block value: i. i = i + 1 }.
-        self
+        self!
 
     method times: block
         let i = 0.
         { i < self }
            whileTrue: { block value. i = i + 1 }.
-        self
+        self!
 
     method addNumber: left
-        left integerAdd: self
+        left integerAdd: self!
     method subNumber: left
-        left integerSub: self
+        left integerSub: self!
     method mulNumber: left
-        left integerMul: self
+        left integerMul: self!
     method divNumber: left
-        left integerDiv: self
+        left integerDiv: self!
 
     method eqNumber: left
-        left integerEq: self
+        left integerEq: self!
     method ltNumber: left
-        left integerLt: self
+        left integerLt: self!
     method gtNumber: left
-        left integerGt: self
+        left integerGt: self!
     method lteNumber: left
-        left integerLte: self
+        left integerLte: self!
     method gteNumber: left
-        left integerGte: self
+        left integerGte: self!
 
     method floatAdd: right
-        self asFloat floatAdd: right
+        self asFloat floatAdd: right!
     method floatSub: right
-        self asFloat floatSub: right
+        self asFloat floatSub: right!
     method floatMul: right
-        self asFloat floatMul: right
+        self asFloat floatMul: right!
     method floatDiv: right
-        self asFloat floatDiv: right
+        self asFloat floatDiv: right!
 
     method floatEq: right
-        self asFloat floatEq: right
+        self asFloat floatEq: right!
     method floatGt: right
-        self asFloat floatGt: right
+        self asFloat floatGt: right!
     method floatLt: right
-        self asFloat floatLt: right
+        self asFloat floatLt: right!
     method floatGte: right
-        self asFloat floatGte: right
+        self asFloat floatGte: right!
     method floatLte: right
-        self asFloat floatLte: right
+        self asFloat floatLte: right!
 end

--- a/foo/lang/interval.foo
+++ b/foo/lang/interval.foo
@@ -9,20 +9,20 @@ class Interval { from to by }
             ifFalse: { return False }.
         by == other by
             ifFalse: { return False }.
-        True
+        True!
     method do: block
        let i = from.
        { i <= to }
            whileTrue: { block value: i. i = i + by }.
-       self
+       self!
     method size
        by == 1
           ifTrue: { 1 + to - from }
-          ifFalse: { (1 + to - from) asInteger / by }
+          ifFalse: { (1 + to - from) asInteger / by }!
     method displayOn: stream
        by == 1
          ifTrue: { stream print: "#<Interval {from} to: {to}>" }
-         ifFalse: { stream print: "#<Interval {from} to: {to} by: {by}>" }
+         ifFalse: { stream print: "#<Interval {from} to: {to} by: {by}>" }!
     method printOn: stream
-       self displayOn: stream
+       self displayOn: stream!
 end

--- a/foo/lang/iterable.foo
+++ b/foo/lang/iterable.foo
@@ -4,26 +4,26 @@ interface Iterator
     required method hasNext
 
     method next
-        self nextIfNone: { IteratorExhausted raise: self }
+        self nextIfNone: { IteratorExhausted raise: self }!
 
     method skip
         self next.
-        self
+        self!
 
     method skip: count
         1 to: count do: { self next }.
-        self
+        self!
 
     method do: block
-        { block value: (self nextIfNone: { return self }) } loop
+        { block value: (self nextIfNone: { return self }) } loop!
 
     method do: block with: iterator
-        self with: iterator ifExhausted: { return self } do: block
+        self with: iterator ifExhausted: { return self } do: block!
 
     method do: block with: iterator ifExhausted: exhaustedBlock
         { let each1 = self nextIfNone: { return self }.
           let each2 = iterator nextIfNone: exhaustedBlock.
-          block value: each1 value: each2 } loop
+          block value: each1 value: each2 } loop!
 end
 
 ---
@@ -53,50 +53,50 @@ interface Iterable
         self do: { |each|
                    (block value: each)
                        ifFalse: { return False } }.
-        True
+        True!
 
     method anySatisfy: block
         self do: { |each|
                    (block value: each)
                        ifTrue: { return True } }.
-        False
+        False!
 
     method collect: block into: collection
         self do: { |each|
                    collection add: (block value: each) }.
-        collection
+        collection!
 
     method with: iterable collect: block into: collection
         self
             with: iterable
             do: { |each1 each2|
                   collection add: (block value: each1 value: each2) }.
-        collection
+        collection!
 
     method count: block
         let n = 0.
         self do: { |each|
                    (block value: each)
                        ifTrue: { n = n + 1 } }.
-        n
+        n!
 
     method with: other count: block
         let n = 0.
         self do: { |each1 each2|
                    (block value: each1 value: each2)
                        ifTrue: { n = n + 1 } }.
-        n
+        n!
 
     method do: block
         self iterator do: block.
-        self
+        self!
 
     method with: iterable do: block
-        self do: block with: iterable iterator ifExhausted: { return self }
+        self do: block with: iterable iterator ifExhausted: { return self }!
 
     method with: iterable do: block ifExhausted: exhaustedBlock
         self iterator do: block with: iterable iterator ifExhausted: exhaustedBlock.
-        self
+        self!
 
     method do: block interleaving: interBlock
         let first = True.
@@ -104,10 +104,10 @@ interface Iterable
                    first
                        ifTrue: { first = False }
                        ifFalse: { interBlock value }.
-                   block value: elt }.
+                   block value: elt }!
 
     method elementType
-        Object
+        Object!
 
     method equals: other
         (self is other)
@@ -118,50 +118,50 @@ interface Iterable
                                      ifFalse: { return False } }
                            with: other
                            ifExhausted: { return False } }.
-        True
+        True!
 
     method find: block
-        self find: block ifNone: { False }
+        self find: block ifNone: { False }!
 
     method find: block ifNone: noneBlock
         self do: { |each|
                    (block value: each)
                        ifTrue: { return each } }.
-        noneBlock value
+        noneBlock value!
 
     method first
-        self do: { |elt| return elt }
+        self do: { |elt| return elt }!
 
     method ifEmpty: block
         self isEmpty
-            ifTrue: block
+            ifTrue: block!
 
     method ifEmpty: emptyBlock ifNotEmpty: notEmptyBlock
         self isEmpty
             ifTrue: emptyBlock
-            ifFalse: notEmptyBlock
+            ifFalse: notEmptyBlock!
 
     method ifNotEmpty: block
         self isEmpty
-            ifFalse: block
+            ifFalse: block!
 
     method includes: object
-        self anySatisfy: { |each| each == object }
+        self anySatisfy: { |each| each == object }!
 
     method includesAll: iterable
         iterable allSatisfy: { |each1|
-                               self anySatisfy: { |each2| each1 == each2 } }
+                               self anySatisfy: { |each2| each1 == each2 } }!
 
     method inject: value into: block
         self do: { |each| value = block value: value value: each }.
-        value
+        value!
 
     method inject: value into: block with: iterable
         self
             do: { |each1 each2|
                   value = block value: value value: each1 value: each2 }
             with: iterable.
-        value
+        value!
 
     method inject: value into: block with: iterable ifExhausted: exhaustedBlock
         self
@@ -169,61 +169,61 @@ interface Iterable
                   value = block value: value value: each1 value: each2 }
             with: iterable
             ifExhausted: exhaustedBlock.
-        value
+        value!
 
     method isEmpty
-        self iterator hasNext not
+        self iterator hasNext not!
 
     method isEquivalent: other
-        self equals: other
+        self equals: other!
 
     method max
-        self max: { |x| x }
+        self max: { |x| x }!
 
     method max: block
         self reduce: { |a b|
                        (block value: a) > (block value: b)
                            ifTrue: { a }
-                           ifFalse: { b } }
+                           ifFalse: { b } }!
 
     method min
-        self min: { |x| x }
+        self min: { |x| x }!
 
     method min: block
         self reduce: { |a b|
                        (block value: a) < (block value: b)
                            ifTrue: { a }
-                           ifFalse: { b } }
+                           ifFalse: { b } }!
 
     method reduce: block
         let iter = self iterator.
         let value = iter next.
         { value = block
               value: value
-              value: (iter nextIfNone: { return value }) } loop
+              value: (iter nextIfNone: { return value }) } loop!
 
     method second
-        self iterator skip next
+        self iterator skip next!
 
     method select: block as: species
-        self select: block into: species new.
+        self select: block into: species new!
 
     method select: block into: collection
         self do: { |each|
                    (block value: each)
                        ifTrue: { collection add: each } }.
-        collection
+        collection!
 
     method sizeEstimate
-        4
+        4!
 
     method sum
-        self sum: { |x| x }
+        self sum: { |x| x }!
 
     method sum: block
         self inject: 0
              into: { |sum each|
-                     sum + (block value: each) }
+                     sum + (block value: each) }!
 
 end
 
@@ -270,7 +270,7 @@ class TestIterable { make assert }
         self testSelectInto.
         self testSizeEstimate.
         self testSumArg.
-        self testSum.
+        self testSum!
 
     method testAllSatisfy
         assert true: { (make value: []) allSatisfy: { |each| False } }
@@ -286,7 +286,7 @@ class TestIterable { make assert }
         assert false: { (make value: [42, 42, 0]) allSatisfy: { |each| each is 42 } }
                testing: "allSatisfy: -> False (size 3)".
         assert false: { (make value: [42, 0, 42, 42]) allSatisfy: { |each| each is 42 } }
-               testing: "allSatisfy: -> False (size 4)".
+               testing: "allSatisfy: -> False (size 4)"!
 
     method testAnySatisfy
         assert false: { (make value: []) anySatisfy: { |each| True } }
@@ -303,7 +303,7 @@ class TestIterable { make assert }
                testing: "anySatisfy: -> True (size 5)".
 
         assert false: { (make value: [0, 0, 0]) anySatisfy: { |each| each is 42 }}
-               testing: "anySatisfy: -> False (size 3)".
+               testing: "anySatisfy: -> False (size 3)"!
 
     method testCollectAs
         assert that: { (make value: []) collect: { |each| 42 } as: List }
@@ -312,7 +312,7 @@ class TestIterable { make assert }
                assert that: { ((make value: [1, 2, 3, 4]) collect: { |each| each + 1 } as: List)
                                   sort }
                equals: [41, 42, 43, 44]
-               testing: "collect:as: (size 4)".
+               testing: "collect:as: (size 4)"!
 
     method testCollectInto
         assert that: { (make value: []) collect: { |each| 42 } into: [123] }
@@ -321,7 +321,7 @@ class TestIterable { make assert }
         assert that: { ((make value: [1,2,3]) collect: { |each| -each } into: [213])
                            sort }
                equals: [-1, -2, -3, 213]
-               testing: "collect:into: (size 3)".
+               testing: "collect:into: (size 3)"!
 
     method testCollectWithAs
         assert that: { (make value: [])
@@ -336,7 +336,7 @@ class TestIterable { make assert }
                            as: List)
                        sort }
                equals: [1, 10, 100]
-               testing: "collect:with:as: (size 3)".
+               testing: "collect:with:as: (size 3)"!
 
     method testCollectWithInto
         assert that: { (make value: [])
@@ -351,7 +351,7 @@ class TestIterable { make assert }
                            into: [123])
                        sort }
                equals: [1, 10, 100, 123]
-               testing: "collect:with:into: (size 3)".
+               testing: "collect:with:into: (size 3)"!
 
     method testCount
         assert that: { (make value: []) count: { |each| True }}
@@ -359,7 +359,7 @@ class TestIterable { make assert }
                testing: "count: (empty)".
         assert that: { (make value: [1,10,1,10,1,1,10]) count: { |each| each == 10 }}
                equals: 3
-               testing: "count: (size 7)".
+               testing: "count: (size 7)"!
 
     method testCountWith
         assert that: { (make value: [])
@@ -371,7 +371,7 @@ class TestIterable { make assert }
                            count: { |each1 each2| each1 == each2 }
                            with: [1,0,1,0,0,1,0] }
                equals: 3
-               testing: "count:with: (size 7)".
+               testing: "count:with: (size 7)"!
 
     method testDo
         assert that: { (make value: []) do: { |each| panic "never" }}
@@ -384,7 +384,7 @@ class TestIterable { make assert }
                            ifFalse: { panic "oops" }.
                        elts }
                equals: [1,2,3]
-               testing: "do: (size 3)".
+               testing: "do: (size 3)"!
 
     method testDoWith
         assert that: { (make value: [1,2])
@@ -400,7 +400,7 @@ class TestIterable { make assert }
                            ifFalse: { panic "oops" }.
                        elts }
                equals: [100, 10]
-               testing: "do:with: (size 2)".
+               testing: "do:with: (size 2)"!
 
     method testDoWithIfExhausted
         assert that: { (make value: [])
@@ -418,7 +418,7 @@ class TestIterable { make assert }
                            ifFalse: { panic "oops" }.
                        elts }
                equals: [1, 10, 300, 4000 ]
-               testing: "do:with:ifExhausted: (size 4)".
+               testing: "do:with:ifExhausted: (size 4)"!
 
     method testEquals
         assert that: { make value: [1,2,3] }
@@ -426,7 +426,7 @@ class TestIterable { make assert }
                testing: "equals: (true)".
         assert that: { make value: [1,2,3,4] }
                equals: make value: [1,2,3]
-               testing: "equals: (false)".
+               testing: "equals: (false)"!
 
     method testFind
         assert that: { (make value: [1,2,100,1]) find: { |each| each > 10 } }
@@ -434,7 +434,7 @@ class TestIterable { make assert }
                testing: "find: (yes)".
         assert that: { (make value: [1,2,10,1]) find: { |each| each > 10 } }
                equals: False
-               testing: "find: (no)"
+               testing: "find: (no)"!
 
     method testFindIfNone
         assert that: { (make value: [1,2,100,1])
@@ -446,7 +446,7 @@ class TestIterable { make assert }
                            find: { |each| each > 10 }
                            ifNone: { 42 }}
                equals: 42
-               testing: "find:ifNone: (no)".
+               testing: "find:ifNone: (no)"!
 
     method testFirst
         assert that: { (make value: [1,2]) first }
@@ -455,7 +455,7 @@ class TestIterable { make assert }
         assert that: { { (make value: []) first }
                            on: Error do: { 123 } }
                equals: 123
-               testing: "first (empty)".
+               testing: "first (empty)"!
 
     method testIfEmpty
         assert that: { (make value: []) ifEmpty: { 123 } }
@@ -463,7 +463,7 @@ class TestIterable { make assert }
                testing: "ifEmpty: (empty)".
         assert that: { (make value: [1] ifEmpty: { 123 }) }
                equals: False
-               testing: "ifEmpty: (not)".
+               testing: "ifEmpty: (not)"!
 
     method testIfEmptyNotEmpty
         assert that: { (make value: []) ifEmpty: { 123 } ifNotEmpty: { "foo" }}
@@ -471,7 +471,7 @@ class TestIterable { make assert }
                testing: "ifEmpty:IifNotEmpty: (empty)".
         assert that: { (make value: [1] ifEmpty: { "foo" } ifNotEmpty: { 123 }) }
                equals: 123
-               testing: "ifEmpty:ifNotEmpty: (not)".
+               testing: "ifEmpty:ifNotEmpty: (not)"!
 
     method testIfNotEmpty
         assert that: { (make value: []) ifNotEmpty: { "foo" } }
@@ -479,7 +479,7 @@ class TestIterable { make assert }
                testing: "ifNotEmpty: (empty)".
         assert that: { (make value: [1] ifEmpty: { 123 }) }
                equals: 123
-               testing: "ifNotEmpty: (not)".
+               testing: "ifNotEmpty: (not)"!
 
     method testIncludes
         assert that: { (make value: []) includes: 42 }
@@ -490,7 +490,7 @@ class TestIterable { make assert }
                testing: "includes: (non-empty, false)".
         assert that: { (make value: [1,42,3]) includes: 42 }
                equals: True
-               testing: "includes: (non-empty, true)".
+               testing: "includes: (non-empty, true)"!
 
     method testIncludesAll
         assert that: { (make value: []) includesAll: [] }
@@ -501,7 +501,7 @@ class TestIterable { make assert }
                testing: "includesAll: (true)".
         assert that: { (make value: [1,2]) includesAll: [1,2,3] }
                equals: False
-               testing: "includesAll: (false)".
+               testing: "includesAll: (false)"!
 
     method testInject
         assert that: { (make value: [])
@@ -513,13 +513,13 @@ class TestIterable { make assert }
                            inject: 100
                            into: { |acc each| acc + each } }
                equals: 106
-               testing: "inject:into: (size 3)".
+               testing: "inject:into: (size 3)"!
 
     method testIsEmpty
         assert true: { (make value: []) isEmpty }
                testing: "isEmpty (true)".
         assert true: { (make value: [1]) isEmpty }
-               testing: "isEmpty (false)".
+               testing: "isEmpty (false)"!
 
     method testIsEquivalent
         assert that: { make value: [1,2,3] }
@@ -527,27 +527,27 @@ class TestIterable { make assert }
                testing: "equals: (true)".
         assert that: { make value: [1,2,3,4] }
                equals: make value: [1,2,3]
-               testing: "equals: (false)".
+               testing: "equals: (false)"!
 
     method testMaxArg
         assert that: { (make value: ["a", "bb", "ccc", "d"]) max: { |each| each size } }
                equals: "ccc"
-               testing: "max:".
+               testing: "max:"!
 
     method testMax
         assert that: { (make value: [1, 100, 1, 1]) max }
                equals: 100
-               testing: "max"
+               testing: "max"!
 
     method testMinArg
         assert that: { (make value: ["aa", "bb", "ccc", "x", "dd", "fff"]) min: { |each| each size } }
                equals: "x"
-               testing: "min:".
+               testing: "min:"!
 
     method testMin
         assert that: { (make value: [1, -100, 1, 1]) min }
                equals: -100
-               testing: "min".
+               testing: "min"!
 
     method testReduce
         assert that: { (make value: [1]) reduce: { |sum each| panic "never" } }
@@ -555,22 +555,22 @@ class TestIterable { make assert }
                testing: "reduce: (one)"
         assert that: { (make value: [1, 2, 3]) reduce: { |sum each| sum + each } }
                equals: 6
-               testing: "reduce: (three)"
+               testing: "reduce: (three)"!
 
     method testSecond
         assert that: { (make value: [1,2]) second }
                equals: 2
-               testing: "second (not empty)".
+               testing: "second (not empty)"!
 
     method testSelectAs
         assert that: { (make value: [1,10,1,100]) select: { |each| each > 1 } as: List }
                equals: [10, 100]
-               testing: "select:as:".
+               testing: "select:as:"!
 
     method testSelectInto
         assert that: { (make value: [1,10,1,100]) select: { |each| each > 1 } into: [123] }
                equals: [123,10,100]
-               testing: "select:into:".
+               testing: "select:into:"!
 
     method testSizeEstimate
         assert that: { (make value: []) sizeEstimate }
@@ -578,7 +578,7 @@ class TestIterable { make assert }
                testing: "sizeEstimate (zero)".
         assert that: { (make value: [1,2,3]) sizeEstimate > 0 }
                equals: True
-               testing: "sizeEstimate (> 0)".
+               testing: "sizeEstimate (> 0)"!
 
     method testSumArg
         assert that: { (make value: []) sum: { |each| panic "never" }}
@@ -586,7 +586,7 @@ class TestIterable { make assert }
                testing: "sum: (empty)".
         assert that: { (make value: [1,2] sum: { |each| each * 100 }) }
                equals: 300
-               testing: "sum: (not empty)".
+               testing: "sum: (not empty)"!
 
     method testSum
         assert that: { (make value: []) sum }
@@ -594,6 +594,6 @@ class TestIterable { make assert }
                testing: "sum (empty)".
         assert that: { (make value: [1,2]) sum }
                equals: 3
-               testing: "sum (not empty)".
+               testing: "sum (not empty)"!
 
 end

--- a/foo/lang/list.foo
+++ b/foo/lang/list.foo
@@ -12,26 +12,26 @@ class List { size data }
     method toString
         self isEmpty
             ifTrue: { "List from: []" }
-            ifFalse: { "List from: {data from: 1 to: self size}" }.
+            ifFalse: { "List from: {data from: 1 to: self size}" }!
 
     class method from: collection
         let new = self withCapacity: collection size.
         collection do: { |elt| new add: elt }.
-        new
+        new!
 
     class method new: size value: init
         let new = self withCapacity: size.
         1 to: size do: { |_| new push: init }.
-        new
+        new!
 
     class method of: type withCapacity: capacity
-        self size: 0 data: (Array of: type new: capacity)
+        self size: 0 data: (Array of: type new: capacity)!
 
     class method of: type
-        Specialized class: List of: type
+        Specialized class: List of: type!
 
     method elementType
-        data elementType
+        data elementType!
 
     method add: element
         self atCapacity
@@ -42,39 +42,39 @@ class List { size data }
                       data = newdata }.
         data put: element at: size + 1.
         size = size + 1.
-        self
+        self!
 
     method pop
         size > 0
             ifTrue: { let elt = data at: size.
                       size = size - 1.
                       elt }
-            ifFalse: { Error raise: "Cannot pop from empty " }
+            ifFalse: { Error raise: "Cannot pop from empty " }!
 
     method push: element
-        self add: element
+        self add: element!
 
     method put: element at: index
         self checkIndex: index.
-        data put: element at: index
+        data put: element at: index!
 
     method at: index
         self checkIndex: index.
-        data at: index
+        data at: index!
 
     method checkIndex: index
         index > size
-            ifTrue: { Error raise: "List index out of bounds: {index}" }
+            ifTrue: { Error raise: "List index out of bounds: {index}" }!
 
     method capacity
-        data size
+        data size!
 
     method atCapacity
-        size == self capacity
+        size == self capacity!
 
     method clear
         size = 0.
-        self.
+        self!
 
     method _emitOn: stream using: block
         self elementType is Object
@@ -82,19 +82,19 @@ class List { size data }
             ifFalse: { stream print: "List of: {self elementType} from: [" }.
         self do: { |x| block value: x }
              interleaving: { stream print: ", " }.
-        stream print: "]".
+        stream print: "]"!
 
     method displayOn: stream
-        self _emitOn: stream using: { |x| x displayOn: stream }.
+        self _emitOn: stream using: { |x| x displayOn: stream }!
 
     method printOn: stream
-        self _emitOn: stream using: { |x| x printOn: stream }.
+        self _emitOn: stream using: { |x| x printOn: stream }!
 
     method concat: other
         let new = List withCapacity: self size + other size.
         self do: { |elt| new push: elt }.
         other do: { |elt| new push: elt }.
-        new.
+        new!
 
     method collect: block
         let size = self size.
@@ -102,12 +102,12 @@ class List { size data }
         1 to: size
           do: { |i|
                 result push: (block value: (self at: i)) }.
-        result.
+        result!
 
     method copy
         let copy = List withCapacity: self size.
         self do: { |elt| copy push: elt }.
-        copy.
+        copy!
 
     method count: block
         let n = 0.
@@ -115,7 +115,7 @@ class List { size data }
           do: { |i|
                 (block value: (self at: i))
                     ifTrue: { n = n + 1 } }.
-        n.
+        n!
 
     method with: list collect: block
         let size = self checkSize: list.
@@ -123,7 +123,7 @@ class List { size data }
         1 to: size
           do: { |i|
                 result push: (block value: (self at: i)  value: (list at: i)) }.
-        result.
+        result!
 
     method with: list default: default collect: block
         let size1 = self size.
@@ -142,58 +142,58 @@ class List { size data }
                                            block value: (self at: i) value: default } }.
         common + 1 to: size
                    do: { |i| result push: (tailHandler value: i) }.
-        result
+        result!
 
     method select: block
         let selection = List withCapacity: 4.
         self do: { |elt|
                    (block value: elt) is True
                        ifTrue: { selection push: elt } }.
-        selection.
+        selection!
 
     method reject: block
         let selection = List withCapacity: 4.
         self do: { |elt|
                    (block value: elt) is True
                        ifFalse: { selection push: elt } }.
-        selection.
+        selection!
 
     method + x
-        x broadcast: {|a b| a + b} to: self.
+        x broadcast: {|a b| a + b} to: self!
     method - x
-        x broadcast: {|a b| a - b} to: self.
+        x broadcast: {|a b| a - b} to: self!
     method * x
-        x broadcast: {|a b| a * b} to: self.
+        x broadcast: {|a b| a * b} to: self!
     method / x
-        x broadcast: {|a b| a / b} to: self.
+        x broadcast: {|a b| a / b} to: self!
 
     method broadcast: block to: collection
-        collection with: self collect: block.
+        collection with: self collect: block!
 
     method dot: other
-        self with: other sum: { |a b| a * b }.
+        self with: other sum: { |a b| a * b }!
 
     method norm
-       (self inject: 0.0 into: { |abs elt| abs + (elt * elt) }) sqrt.
+       (self inject: 0.0 into: { |abs elt| abs + (elt * elt) }) sqrt!
 
     method normalized
        let reciprocal = 1.0 / (self norm).
-       self * reciprocal.
+       self * reciprocal!
 
     method scalarProjectionOn: other
-        (self dot: other) / other norm.
+        (self dot: other) / other norm!
 
     method vectorProjectionOn: other
-        ((self dot: other) / (other dot: other)) * other.
+        ((self dot: other) / (other dot: other)) * other!
 
     method addNumber: left
-       self collect: { |elt| left + elt }.
+       self collect: { |elt| left + elt }!
     method subNumber: left
-       self collect: { |elt| left - elt }.
+       self collect: { |elt| left - elt }!
     method divNumber: left
-       self collect: { |elt| left / elt }.
+       self collect: { |elt| left / elt }!
     method mulNumber: left
-       self collect: { |elt| left * elt }.
+       self collect: { |elt| left * elt }!
 end
 
 class TestList {}
@@ -207,7 +207,7 @@ class TestList {}
         assert false: { [1, 2, 3, 4] == [1, 2, 3] }
                testing: "List#== (false 2)".
         assert false: { ["one", 2, 3] == [1, "two", 3] }
-               testing: "List#== (false 3)".
+               testing: "List#== (false 3)"!
 
     class method testSort: assert
         assert that: { [] sort }
@@ -233,7 +233,7 @@ class TestList {}
                testing: "sort, three in reverse order".
         assert that: { [9, 2, 1, 8, 7, 3, 5, 4, 6, 0] sort }
                equals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-               testing: "sort, ten".
+               testing: "sort, ten"!
 
     class method testReverse: assert
         assert that: { let a = [].
@@ -259,7 +259,7 @@ class TestList {}
         assert that: { let a = [1,2,3].
                        a reverse }
                equals: [3,2,1]
-               testing: "reverse list, retval (3)".
+               testing: "reverse list, retval (3)"!
 
     class method testReversed: assert
         assert that: { let a = [].
@@ -282,11 +282,11 @@ class TestList {}
                        a reversed.
                        a }
                equals: [1,2,3]
-               testing: "reversed list, side-effect (3)".
+               testing: "reversed list, side-effect (3)"!
 
     class method runTests: assert
         self testEquality: assert.
         self testSort: assert.
         self testReverse: assert.
-        self testReversed: assert.
+        self testReversed: assert!
 end

--- a/foo/lang/number.foo
+++ b/foo/lang/number.foo
@@ -5,60 +5,60 @@ interface Number
     is Object
 
     class method default
-        0
+        0!
 
     method == right -> Boolean
-        self is right
+        self is right!
 
     method isEquivalent: right
-        self is right
+        self is right!
 
     method broadcast: block to: collection
-        collection collect: { |x| block value: x value: self }
+        collection collect: { |x| block value: x value: self }!
 
     method square
-        self * self
+        self * self!
 
     method + right
-        right addNumber: self
+        right addNumber: self!
     method - right
-        right subNumber: self
+        right subNumber: self!
     method * right
-        right mulNumber: self
+        right mulNumber: self!
     method / right
-        right divNumber: self
+        right divNumber: self!
 
     method < right
-        right ltNumber: self
+        right ltNumber: self!
     method > right
-        right gtNumber: self
+        right gtNumber: self!
     method <= right
-        right lteNumber: self
+        right lteNumber: self!
     method >= right
-        right gteNumber: self
+        right gteNumber: self!
 
     -- FIXME: Should support floating point exponents for floats at least
     method ^ power::Integer
         let result = 1.
         power times: { result = result * self }.
-        result
+        result!
 
     method abs
         self < 0.0
             ifTrue: { -self }
-            ifFalse: { self }
+            ifFalse: { self }!
 
     method max: other
         self < other
             ifTrue: { other }
-            ifFalse: { self }
+            ifFalse: { self }!
 
     method min: other
         self > other
             ifTrue: { other }
-            ifFalse: { self }
+            ifFalse: { self }!
 
     method to: other by: step
-       Interval from: self to: other by: step
+       Interval from: self to: other by: step!
 
 end

--- a/foo/lang/object.foo
+++ b/foo/lang/object.foo
@@ -1,5 +1,3 @@
-import .output.Output
-
 -- Should this be "Standard" or "StandardObject" instead?
 
 -- Should be able to specify non-inherited methods for
@@ -8,37 +6,37 @@ interface Object
     class method default
         self is Object
             ifTrue: { False }
-            ifFalse: { Error raise: "No default value for {self}" }
+            ifFalse: { Error raise: "No default value for {self}" }!
 
     method isEquivalent: other
-        self is other
+        self is other!
 
     method == other -> Boolean
         (Self includes: other)
             ifTrue: { self isEquivalent: other }
-            ifFalse: { False }
+            ifFalse: { False }!
 
     class method printOn: stream
-        stream print: self toString
+        stream print: self toString!
 
     class method displayOn: stream
-        self printOn: stream
+        self printOn: stream!
 
     method printOn: stream
-        stream print: self toString
+        stream print: self toString!
 
     method displayOn: stream
-        self printOn: stream
+        self printOn: stream!
 
     method checkEqual: other
         (Self includes: other)
             ifTrue: { return self checkEqualInternal: other }.
-        self mismatch: other
+        self mismatch: other!
 
     method checkEqualInternal: other
         self == other
-            ifFalse: { self mismatch: other }
+            ifFalse: { self mismatch: other }!
 
     method mismatch: other
-        Error raise: "Mismatch: '{self}' != {other}"
+        Error raise: "Mismatch: '{self}' != {other}"!
 end

--- a/foo/lang/ordered.foo
+++ b/foo/lang/ordered.foo
@@ -6,7 +6,7 @@ interface Ordered
     method bytes
         let bytes = ByteArray new: self size.
         1 to: self size do: { |i| bytes put: (self at: i) at: i }.
-        bytes
+        bytes!
 
     method isEquivalent: other
         self size == other size
@@ -15,25 +15,25 @@ interface Ordered
                               (self at: i) == (other at: i)
                                   ifFalse: { return False } } }
             ifFalse: { return False }.
-        True
+        True!
 
     method isEmpty
-        self size is 0
+        self size is 0!
 
     method copy
         let copy = Self of: (self elementType) new: self size.
         1 to: self size
           do: { |i| copy put: (self at: i) at: i }.
-          copy.
+          copy!
 
     method species
-        Self of: self elementType
+        Self of: self elementType!
 
     method collect: block
-        self collect: block as: self species
+        self collect: block as: self species!
 
     method collect: block of: type
-        self collect: block as: (Self of: type)
+        self collect: block as: (Self of: type)!
 
     method collect: block as: type
         let n = self size.
@@ -41,7 +41,7 @@ interface Ordered
         1 to: n
           do: { |i|
                 new put: (block value: (self at: i)) at: i }.
-        new.
+        new!
 
     method split: byBlock do: block
         let cursor = 1.
@@ -49,19 +49,19 @@ interface Ordered
           do: { |index|
                 (byBlock value: (self at: index))
                     ifTrue: { block value: (self from: cursor to: index).
-                              cursor = index + 1 } }
+                              cursor = index + 1 } }!
 
     method do: block
         1 to: self size
           do: { |i|
                 block value: (self at: i) }.
-        self.
+        self!
 
     method with: other collect: block
-        self with: other collect: block of: Object
+        self with: other collect: block of: Object!
 
     method with: other collect: block of: type
-        self with: other collect: block as: (Self of: type)
+        self with: other collect: block as: (Self of: type)!
 
     method with: other collect: block as: species
         let new = species new: self size.
@@ -71,26 +71,26 @@ interface Ordered
                               value: (self at: i)
                               value: (other at: i))
                     at: i }.
-        new.
+        new!
 
     method with: other do: block
         1 to: self size
           do: { |i| block value: (self at: i) value: (other at: i) }.
-        self.
+        self!
 
     method with: other inject: value into: block
         let result = value.
         self
             with: other
             do: { |a b| result = block value: result value: a value: b }.
-        result.
+        result!
 
     method with: other sum: block
         self
             with: other
             inject: 0
             into: { |res a b|
-                    res + (block value: a value: b) }
+                    res + (block value: a value: b) }!
 
     method reverse
         let n = self size.
@@ -101,33 +101,33 @@ interface Ordered
                 j <= i
                     ifTrue: { return self }.
                 self swap: i with: j }.
-          panic "BUG: this should never happen."
+          panic "BUG: this should never happen."!
 
     method reversed
-        self copy reverse
+        self copy reverse!
 
     method sort
-        self sort: { |a b| a < b }.
+        self sort: { |a b| a < b }!
 
     method sort: block
         -- Unfortunate a straigthforward rust-side wrapper for Vec::sort_by()
         -- cannot propagate errors from the comparison function, so instead
         -- here's a quick and dirty quicksort. O(N^2) worst case, since I
         -- was too lazy to do the center pivot.
-        self _quicksort: 1 to: self size by: block.
+        self _quicksort: 1 to: self size by: block!
 
     method sorted
-        self copy sort.
+        self copy sort!
 
     method sorted: block
-        self copy sort: block.
+        self copy sort: block!
 
     method _quicksort: left to: right by: block
         left < right
             ifTrue: { let p = self _partition: left to: right by: block.
                       self _quicksort: left to: p - 1 by: block.
                       self _quicksort: p + 1 to: right by: block }.
-        self.
+        self!
 
     method _partition: left to: right by: block
         let pivot = self at: right.
@@ -139,12 +139,12 @@ interface Ordered
                            ifTrue: { self swap: i with: j.
                                      i = i + 1 } }.
         self swap: i with: right.
-        i.
+        i!
 
     method swap: i with: j
         let tmp = self at: i.
         self put: (self at: j) at: i.
         self put: tmp at: j.
-        self.
+        self!
 
 end

--- a/foo/lang/output.foo
+++ b/foo/lang/output.foo
@@ -1,13 +1,13 @@
 extend Output
     method println: string
         string printOn: self.
-        self newline
+        self newline!
     method newline
-        self print: "\n".
+        self print: "\n"!
     method print: object
-        object printOn: self.
+        object printOn: self!
     method display: object
-        object displayOn: self
+        object displayOn: self!
     method displayOn: stream
-        stream print: self toString
+        stream print: self toString!
 end

--- a/foo/lang/random.foo
+++ b/foo/lang/random.foo
@@ -1,8 +1,8 @@
 extend Random
    class method integer
-      self new integer
+      self new integer!
    class method float
-      self new float
+      self new float!
    class method boolean
-      self new boolean
+      self new boolean!
 end

--- a/foo/lang/record.foo
+++ b/foo/lang/record.foo
@@ -3,5 +3,5 @@ class TestRecord {}
         assert that: { let r = {x: -10, y: 52}.
                        r x + r y }
                is: 42
-               testing: "Record syntax and accessors".
+               testing: "Record syntax and accessors"!
 end

--- a/foo/lang/selector.foo
+++ b/foo/lang/selector.foo
@@ -1,27 +1,26 @@
 import .string.String
 
 define ColonCharacter
-    ":" character
-end
+    ":" character!
 
 class Selector { name }
     is Object
     class method new: name
-        self name: name
+        self name: name!
     method sendTo: receiver
-        name sendTo: receiver with: []
+        name sendTo: receiver with: []!
     method sendTo: receiver with: arguments
-        name sendTo: receiver with: (Array from: arguments)
+        name sendTo: receiver with: (Array from: arguments)!
     method value: value
-        self sendTo: value
+        self sendTo: value!
     method parts
         let parts = List new.
         self name split: { |c| c == ColonCharacter }
                   do:  { |part| parts add: part }.
-        parts
+        parts!
     -- FIXME: Should really intern selectors!
     method isEquivalent: other
-        name == other name
+        name == other name!
     method toString
-        "#{name}"
+        "#{name}"!
 end

--- a/foo/lang/string.foo
+++ b/foo/lang/string.foo
@@ -5,13 +5,13 @@ extend String
     is Ordered
 
     class method default
-        ""
+        ""!
     method append: other
-       other appendToString: self
+       other appendToString: self!
     method newline
-        "\n" appendToString: self
+        "\n" appendToString: self!
     method printOn: stream
-        stream writeString: self
+        stream writeString: self!
     method _escapeOn: stream
         [["\"", "\\\""],
          ["\n", "\\n"],
@@ -21,19 +21,19 @@ extend String
            do: { |esc|
                  (self isEquivalent: esc first)
                     ifTrue: { stream writeString: esc second. return stream } }.
-        stream writeString: self
+        stream writeString: self!
     method displayOn: stream
         stream writeString: "\"".
         self do: { |c| c _escapeOn: stream }.
-        stream writeString: "\""
+        stream writeString: "\""!
     method startsWith: other
         1 to: other size
           do: { |i|
                 (self at: i) == (other at: i)
                     ifFalse: { return False } }.
-        True
+        True!
     method character
         self size == 1
             ifTrue: { self at: 1 }
-            ifFalse: { Error raise: "Not a character designator string: {self}" }
+            ifFalse: { Error raise: "Not a character designator string: {self}" }!
 end

--- a/foo/lang/stringOutput.foo
+++ b/foo/lang/stringOutput.foo
@@ -2,15 +2,15 @@ extend StringOutput
     class method new: string
         let out = self new.
         out print: string.
-        out.
+        out!
     method toString
-        "#<StringOutput>"
+        "#<StringOutput>"!
     method flush
-        self
+        self!
     method println: string
         self print: string.
-        self newline
+        self newline!
     method newline
         self print: ("" newline).
-        self
+        self!
 end

--- a/foo/lang/time.foo
+++ b/foo/lang/time.foo
@@ -1,6 +1,6 @@
 extend Time
     method + x
-        x addTime: self
+        x addTime: self!
     method - x
-        x subTime: self
+        x subTime: self!
 end

--- a/foo/lib/assert.foo
+++ b/foo/lib/assert.foo
@@ -4,7 +4,7 @@ end
 class TestSuccess { case input }
     method reportOn: output
         -- No problem, nothing to report
-        output
+        output!
 end
 
 class TestFailure { case input expected result }
@@ -15,14 +15,14 @@ class TestFailure { case input expected result }
         let resultMessage = expected is Nothing
                                 ifTrue: { "" }
                                 ifFalse: { ", expected '{expected}', got '{result}'" }.
-        output println: "! FAILURE in {case name}{valueMessage}{resultMessage}"
+        output println: "! FAILURE in {case name}{valueMessage}{resultMessage}"!
 end
 
 class TestError { case input what }
     method reportOn: output
         input is Nothing
             ifTrue: { output println: "! ERROR in {case name}: {what}" }
-            ifFalse: { output println: "! ERROR in {case name} on {input}: {what}" }
+            ifFalse: { output println: "! ERROR in {case name} on {input}: {what}" }!
 end
 
 class TestCase { name condition successCount failureCount errorCount }
@@ -32,21 +32,21 @@ class TestCase { name condition successCount failureCount errorCount }
             condition: condition
             successCount: 0
             failureCount: 0
-            errorCount: 0
+            errorCount: 0!
 
     method failed
-        failureCount + errorCount > 0
+        failureCount + errorCount > 0!
 
     method summarizeOn: output
         self failed
             ifTrue: { self summarizeFailureOn: output }
-            ifFalse: { self summarizeSuccessOn: output }
+            ifFalse: { self summarizeSuccessOn: output }!
 
     method summarizeSuccessOn: output
-        output println: "  {name}: {successCount} tests ok"
+        output println: "  {name}: {successCount} tests ok"!
 
     method summarizeFailureOn: output
-        output println: "--{name}: {failureCount} failures, {errorCount} errors, {successCount} successes".
+        output println: "--{name}: {failureCount} failures, {errorCount} errors, {successCount} successes"!
 
     method expect: expected using: block
         let actual = { condition value }
@@ -57,7 +57,7 @@ class TestCase { name condition successCount failureCount errorCount }
             ifTrue: { self successOn: Nothing }
             ifFalse: { self failureOn: Nothing
                             expected: expected
-                            result: actual }
+                            result: actual }!
 
     method tryOn: input
         let ok = { condition value: input }
@@ -66,67 +66,67 @@ class TestCase { name condition successCount failureCount errorCount }
                                             what: (p description) }.
         ok
             ifTrue: { self successOn: input }
-            ifFalse: { self failureOn: input }
+            ifFalse: { self failureOn: input }!
 
     method successOn: input
         successCount = successCount + 1.
-        TestSuccess case: self input: input
+        TestSuccess case: self input: input!
     method failureOn: input
-        self failureOn: input expected: Nothing result: Nothing
+        self failureOn: input expected: Nothing result: Nothing!
     method failureOn: input expected: expected result: result
         failureCount = failureCount + 1.
-        TestFailure case: self input: input expected: expected result: result
+        TestFailure case: self input: input expected: expected result: result!
     method errorOn: input what: error
         errorCount = errorCount + 1.
-        TestError case: self input: input what: error
+        TestError case: self input: input what: error!
 end
 
 class Assert { output failed }
 
     class method reportingTo: output
-        self output: output failed: False
+        self output: output failed: False!
 
     method report: testResult
-        testResult reportOn: output
+        testResult reportOn: output!
 
     method summarize: testCase
-        testCase summarizeOn: output
+        testCase summarizeOn: output!
 
     method forAll: inputs that: condition testing: thing
         let test = TestCase name: thing condition: condition.
         inputs do: { |input| self report: (test tryOn: input) }.
         self summarize: test.
-        failed = failed or: test failed
+        failed = failed or: test failed!
 
     method exitCode
         failed
             ifTrue: { 1 }
-            ifFalse: { 0 }
+            ifFalse: { 0 }!
 
     method that: condition matches: value using: block testing: thing
         let test = TestCase name: thing condition: condition.
         self report: (test expect: value using: block).
         self summarize: test.
-        failed = failed or: test failed
+        failed = failed or: test failed!
 
     method that: condition is: value testing: thing
         self
             that: condition
             matches: value
             using: { |actual expected| actual is expected }
-            testing: thing
+            testing: thing!
 
     method that: condition equals: value testing: thing
         self
             that: condition
             matches: value
             using: { |actual expected| actual == expected }
-            testing: thing
+            testing: thing!
 
     method true: condition testing: thing
-        self that: condition is: True testing: thing
+        self that: condition is: True testing: thing!
 
     method false: condition testing: thing
-        self that: condition is: False testing: thing
+        self that: condition is: False testing: thing!
 
 end

--- a/foo/lib/si.foo
+++ b/foo/lib/si.foo
@@ -8,6 +8,7 @@ Implementation Notes:
   operations in could be done closer to 0-1 range.
 - Conventional compound units with their own names, like Joule not handled.
   Should deal with printing & entering values.
+- Should store the base unit powers as a vector instead of a table.
 - Would be nice of units were types: x::Meters^2
 - Would be nice to have specialized representations for commonplace units
   to avoid the fully general symbolic units -- ideally representing even the
@@ -42,112 +43,112 @@ class Prefix {}
             {base: 1e-15, prefix: "f"},
             {base: 1e-18, prefix: "a"},
             {base: 1e-21, prefix: "z"}
-        ]
+        ]!
     class method display: value on: stream
         let spec = self displaySpecs
                        find: { |spec| value >= spec base }
                        ifNone: { {base: 1e-24, prefix: "y"} }.
-        stream print: "{value / spec base} {spec prefix}"
+        stream print: "{value / spec base} {spec prefix}"!
 
     class method yocto
-        1e-24
+        1e-24!
     class method y
-        self yocto
+        self yocto!
 
     class method zepto
-        1e-21
+        1e-21!
     class method z
-        self zepto
+        self zepto!
 
     class method atto
-        1e-18
+        1e-18!
     class method a
-        self atto
+        self atto!
 
     class method femto
-        1e-15
+        1e-15!
     class method f
-        self femto
+        self femto!
 
     class method pico
-        1e-12
+        1e-12!
     class method p
-        self pico
+        self pico!
 
     class method nano
-        1e-9
+        1e-9!
     class method n
-        self nano
+        self nano!
 
     class method micro
-        1e-6
+        1e-6!
     class method u
-        self micro
+        self micro!
 
     class method milli
-        1e-3
+        1e-3!
     class method m
-        self milli
+        self milli!
 
     class method centi
-        1e-2
+        1e-2!
     class method c
-        self centi
+        self centi!
 
     class method deci
-        1e-1
+        1e-1!
     class method d
-        self deci
+        self deci!
 
     class method deka
-        1e0
+        1e0!
     class method da
-        self deka
+        self deka!
 
     class method hecto
-        1e2
+        1e2!
     class method h
-        self hecto
+        self hecto!
 
     class method kilo
-        1e3
+        1e3!
     class method k
-        self kilo
+        self kilo!
 
     class method mega
-        1e6
+        1e6!
     class method M
-        self mega
+        self mega!
 
     class method giga
-        1e9
+        1e9!
     class method G
-        self giga
+        self giga!
 
     class method tera
-        1e12
+        1e12!
     class method T
-        self tera
+        self tera!
 
     class method peta
-        1e15
+        1e15!
     class method P
-        self peta
+        self peta!
 
     class method exa
-        1e18
+        1e18!
     class method E
-        self exa
+        self exa!
 
-    class method Z
-        self zetta
     class method zetta
-        1e21
+        1e21!
+    class method Z
+        self zetta!
 
     class method yotta
-        1e24
+        1e24!
     class method Y
-        self yotta
+        self yotta!
 end
 
 interface SI_Unit
@@ -155,7 +156,7 @@ interface SI_Unit
 
     method isEquivalent: right
         -- Compound unit overrides this, but this is enough for base units
-        (self species) is (right species) and: self power == right power
+        (self species) is (right species) and: self power == right power!
 
     -- FIXME: since Object implements this, there is currently no way
     -- to require subclasses to implement it specifically.
@@ -163,16 +164,16 @@ interface SI_Unit
 
     method display: value on: stream
         Prefix display: (self scaleForDisplay: value) on: stream.
-        self displayOn: stream
+        self displayOn: stream!
 
     method displayUnitOn: stream
-        self displayOn: stream
+        self displayOn: stream!
 
     -- This is required for Kilograms to be able to print right:
     -- they scale they value by 1000.0 and then displayUsing: "g".
     -- Stupid fixed prefix.
     method scaleForDisplay: value
-        value
+        value!
 
     method displayUsing: type on: stream
         -- Implementing classes provide call this with appropriate
@@ -206,91 +207,91 @@ interface SI_Unit
                          power = high.
                          tmp print: (superscripts at: low + 1) }.
         stream print: tmp content.
-        False
+        False!
 
     method * right
-       right unitProduct: self
+       right unitProduct: self!
 
     method / right
-       right unitDivision: self
+       right unitDivision: self!
 
     method unitProduct: left
         self species is left species
             ifTrue: { self species power: (left power + self power) }
-            ifFalse: { CompoundUnit of: left multipliedBy: self }
+            ifFalse: { CompoundUnit of: left multipliedBy: self }!
 
     method unitDivision: left
         self species is left species
             ifTrue: { self species power: (left power - self power) }
-            ifFalse: { CompoundUnit of: left dividedBy: self }
+            ifFalse: { CompoundUnit of: left dividedBy: self }!
 
     method powersInto: powers by: mul
         let species = self species.
         let n = (powers has: species)
                     ifTrue: { powers at: species }
                     ifFalse: { 0 }.
-        powers put: n + (mul * self power) at: species
+        powers put: n + (mul * self power) at: species!
 
 end
 
 class Meters { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "m" on: stream
+        self displayUsing: "m" on: stream!
     method species
-       Meters
+       Meters!
 end
 
 class Seconds { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "s" on: stream
+        self displayUsing: "s" on: stream!
     method species
-        Seconds
+        Seconds!
 end
 
 class Moles { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "mol" on: stream
+        self displayUsing: "mol" on: stream!
     method species
-        Moles
+        Moles!
 end
 
 class Amperes { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "A" on: stream
+        self displayUsing: "A" on: stream!
     method species
-        Amperes
+        Amperes!
 end
 
 class Kelvins { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "K" on: stream
+        self displayUsing: "K" on: stream!
     method species
-        Kelvins
+        Kelvins!
 end
 
 class Candelas { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "cd" on: stream
+        self displayUsing: "cd" on: stream!
     method species
-        Candelas
+        Candelas!
 end
 
 class Kilograms { power::Integer }
     is SI_Unit
     method displayOn: stream
-        self displayUsing: "g" on: stream
+        self displayUsing: "g" on: stream!
     method displayUnitOn: stream
-        self displayUsing: "kg" on: stream
+        self displayUsing: "kg" on: stream!
     method scaleForDisplay: value
-        1000.0 * value
+        1000.0 * value!
     method species
-        Kilograms
+        Kilograms!
 end
 
 class CompoundUnit { units }
@@ -309,19 +310,19 @@ class CompoundUnit { units }
                                       ifFalse: { return False }.
                                   n = n - 1 }
                         ifFalse: { return False } }.
-        n is 0
+        n is 0!
 
     class method of: left multipliedBy: right
         let powers = Dictionary new.
         left powersInto: powers by: 1.
         right powersInto: powers by: 1.
-        self fromPowers: powers
+        self fromPowers: powers!
 
     class method of: left dividedBy: right
         let powers = Dictionary new.
         left powersInto: powers by: 1.
         right powersInto: powers by: -1.
-        self fromPowers: powers
+        self fromPowers: powers!
 
     class method fromPowers: powers
         let units = List new.
@@ -332,26 +333,26 @@ class CompoundUnit { units }
         units sort: { |a b| a power > b power }.
         units size is 1
             ifTrue: { units first }
-            ifFalse: { CompoundUnit units: units }
+            ifFalse: { CompoundUnit units: units }!
 
     method * right
-        CompoundUnit of: self multipliedBy: right
+        CompoundUnit of: self multipliedBy: right!
 
     method / right
-        CompoundUnit of: self dividedBy: right
+        CompoundUnit of: self dividedBy: right!
 
     method powersInto: powers by: mul
-        units do: { |unit| unit powersInto: powers by: mul }
+        units do: { |unit| unit powersInto: powers by: mul }!
 
     method power
-        units ifEmpty: { 0 } ifNotEmpty: { 1 }
+        units ifEmpty: { 0 } ifNotEmpty: { 1 }!
 
     method power: p
         let result = 1.0.
         p > 0
             ifTrue: { p times: { result = result * self } }
             ifFalse: { -p times: { result = result / self } }.
-        result
+        result!
 
     method conventionalUnits
         [
@@ -361,14 +362,14 @@ class CompoundUnit { units }
             {ident: "J", model: (CompoundUnit units: [Kilograms power: 1,
                                                       Meters power: 2,
                                                       Seconds power: -2])}
-        ]
+        ]!
 
     method tryConventionalUnits: stream
        self conventionalUnits
           do: { |info|
                 (self == info model)
                     ifTrue: { stream print: info ident. return True } }.
-       False
+       False!
 
     method displayOn: stream
         (self tryConventionalUnits: stream)
@@ -395,10 +396,10 @@ class CompoundUnit { units }
             interleaving: { stream print: " " }.
         encloseNegative
             ifTrue: { stream print: ")" }.
-        self
+        self!
 
     method species
-        self
+        self!
 end
 
 class SI { value::Float _unit::SI_Unit }
@@ -406,202 +407,193 @@ class SI { value::Float _unit::SI_Unit }
 
     method isEquivalent: right
         self checkUnit: right operation: "==".
-        self value == right value
+        self value == right value!
 
     class method meters: value
-        SI value: value unit: (Meters power: 1)
+        SI value: value unit: (Meters power: 1)!
 
     class method seconds: value
-        SI value: value unit: (Seconds power: 1)
+        SI value: value unit: (Seconds power: 1)!
 
     class method moles: value
-        SI value: value unit: (Moles power: 1)
+        SI value: value unit: (Moles power: 1)!
 
     class method amperes: value
-        SI value: value unit: (Amperes power: 1)
+        SI value: value unit: (Amperes power: 1)!
 
     class method kelvins: value
-        SI value: value unit: (Kelvins power: 1)
+        SI value: value unit: (Kelvins power: 1)!
 
     class method candelas: value
-        SI value: value unit: (Candelas power: 1)
+        SI value: value unit: (Candelas power: 1)!
 
     class method grams: value
-        SI value: value / Prefix k unit: (Kilograms power: 1)
+        SI value: value / Prefix k unit: (Kilograms power: 1)!
 
     class method value: value unit: unit
         -- Dimensionless number, unit has been divided out
         unit power is 0
             ifTrue: { value }
-            ifFalse: { SI value: value _unit: unit }
+            ifFalse: { SI value: value _unit: unit }!
 
     method unit
-        _unit
+        _unit!
 
     method checkUnit: right operation: op
         self unit == right unit
-            ifFalse: { panic "Invalid operation: {self} {op} {right}" }
+            ifFalse: { panic "Invalid operation: {self} {op} {right}" }!
 
     method < right
         self checkUnit: right operation: "<".
-        self value < right value
+        self value < right value!
 
     method <= right
         self checkUnit: right operation: "<=".
-        self value <= right value
+        self value <= right value!
 
     method >= right
         self checkUnit: right operation: ">=".
-        self value >= right value
+        self value >= right value!
 
     method > right
         self checkUnit: right operation: ">".
-        self value > right value
+        self value > right value!
 
     method + right
         self checkUnit: right operation: "+".
-        SI value: self value + right value unit: self unit
+        SI value: self value + right value unit: self unit!
 
     method - right
         self checkUnit: right operation: "-".
-        SI value: self value - right value unit: self unit
+        SI value: self value - right value unit: self unit!
 
     method ^ power::Integer
         let result = 1.0.
         power times: { result = result * self }.
-        result
+        result!
 
     method * right
-        right mulSI: self
+        right mulSI: self!
 
     method / right
-        right divSI: self
+        right divSI: self!
 
     method mulSI: left
-        SI value: left value * self value unit: (left unit * self unit)
+        SI value: left value * self value unit: (left unit * self unit)!
 
     method divSI: left
-        SI value: left value / self value unit: (left unit / self unit)
+        SI value: left value / self value unit: (left unit / self unit)!
 
     method mulNumber: left
-        SI value: left * self value unit: self unit
+        SI value: left * self value unit: self unit!
 
     method divNumber: left
         let unit = self unit.
-        SI value: left / self value unit: (unit species power: - (unit power))
+        SI value: left / self value unit: (unit species power: - (unit power))!
 
     method displayOn: stream
-        self unit display: self value on: stream
+        self unit display: self value on: stream!
     method toString
         let stream = StringOutput new.
         self displayOn: stream.
-        stream content
+        stream content!
 end
 
 extend Number
     method mm
-        SI meters: Prefix m * self
+        SI meters: Prefix m * self!
     method m
-        SI meters: self asFloat
+        SI meters: self asFloat!
     method km
-        SI meters: Prefix k * self
+        SI meters: Prefix k * self!
 
     method ns
-        SI seconds: Prefix n * self
+        SI seconds: Prefix n * self!
     method ms
-        SI seconds: Prefix m * self
+        SI seconds: Prefix m * self!
     method s
-        SI seconds: self asFloat
+        SI seconds: self asFloat!
 
     method mol
-        SI moles: self asFloat
+        SI moles: self asFloat!
     method mmol
-        SI moles: Prefix m * self
+        SI moles: Prefix m * self!
 
     method A
-        SI amperes: self asFloat
+        SI amperes: self asFloat!
     method mA
-        SI amperes: Prefix m * self
+        SI amperes: Prefix m * self!
 
     method K
-        SI kelvins: self asFloat
+        SI kelvins: self asFloat!
 
     method cd
-        SI candelas: self asFloat
+        SI candelas: self asFloat!
 
     -- Worry not, the underlying unit is actually kg, this
     -- just makes this part more obviously correct.
     method mg
-        SI grams: Prefix m * self
+        SI grams: Prefix m * self!
     method g
-        SI grams: self asFloat
+        SI grams: self asFloat!
     method kg
-        SI grams: Prefix k * self
+        SI grams: Prefix k * self!
 
     method mulSI: left
-        SI value: left value * self asFloat unit: left unit
+        SI value: left value * self asFloat unit: left unit!
     method divSI: left
-        SI value: left value / self asFloat unit: left unit
+        SI value: left value / self asFloat unit: left unit!
 end
 
 -- The point of these constants is to allow expressions like 1 m / s.
 define mm
-    1 mm.
-end
+    1 mm!
+
 define m
-    1 m.
-end
+    1 m!
+
 define km
-    1 km.
-end
+    1 km!
 
 define ns
-    1 ns.
-end
+    1 ns!
+
 define ms
-    1 ms.
-end
+    1 ms!
+
 define s
-    1 s.
-end
+    1 s!
 
 define mol
-    1 mol.
-end
+    1 mol!
+
 define mmol
-    1 mmol.
-end
+    1 mmol!
 
 define A
-    1 A.
-end
+    1 A!
 
 define mA
-    1 mA.
-end
+    1 mA!
 
 define K
-    1 K.
-end
+    1 K!
 
 define cd
-    1 cd.
-end
+    1 cd!
 
 define mg
-    1 mg.
-end
+    1 mg!
 
 define g
-    1 g.
-end
+    1 g!
+
 define kg
-    1 kg.
-end
+    1 kg!
 
 class SI_Tests { assert }
     class method runTests: assert
-        (self assert: assert) runTests
+        (self assert: assert) runTests!
 
     method runTests
         self testBaseUnitArithmetic.
@@ -609,16 +601,16 @@ class SI_Tests { assert }
         self testBaseUnitPrinting.
         self testCompoundUnitArithmetic.
         self testCompoundUnitComparisons.
-        self testCompoundUnitPrinting.
+        self testCompoundUnitPrinting!
 
     method baseUnits
-        [Meters, Seconds, Moles, Amperes, Kelvins, Candelas, Kilograms]
+        [Meters, Seconds, Moles, Amperes, Kelvins, Candelas, Kilograms]!
 
     method testBaseUnitArithmetic
         self testBaseUnitMultiplication.
         self testBaseUnitDivision.
         self testBaseUnitAddition.
-        self testBaseUnitSubstraction.
+        self testBaseUnitSubstraction!
 
     method testBaseUnitMultiplication
         assert forAll: self baseUnits
@@ -655,7 +647,7 @@ class SI_Tests { assert }
                        let unit = unitType power: 1.
                        let a = SI value: 10.0 unit: unit.
                        2 * a == (SI value: 20.0 unit: unit) }
-               testing: "integer * baseUnit".
+               testing: "integer * baseUnit"!
 
     method testBaseUnitDivision
         assert forAll: self baseUnits
@@ -692,7 +684,7 @@ class SI_Tests { assert }
                        let unit = unitType power: 1.
                        let b = SI value: 2.0 unit: unit.
                        10 / b == (SI value: 5.0 unit: (unitType power: -1)) }
-               testing: "integer / baseUnit".
+               testing: "integer / baseUnit"!
 
     method testBaseUnitAddition
         assert forAll: self baseUnits
@@ -701,7 +693,7 @@ class SI_Tests { assert }
                        let a = SI value: 10.0 unit: unit.
                        let b = SI value: 2.0 unit: unit.
                        a + b == (SI value: 12.0 unit: unit) }
-               testing: "baseUnit + baseUunit".
+               testing: "baseUnit + baseUunit"!
 
     method testBaseUnitSubstraction
         assert forAll: self baseUnits
@@ -710,7 +702,7 @@ class SI_Tests { assert }
                        let a = SI value: 10.0 unit: unit.
                        let b = SI value: 2.0 unit: unit.
                        a - b == (SI value: 8.0 unit: unit) }
-               testing: "baseUnit - baseUunit".
+               testing: "baseUnit - baseUunit"!
 
     method testBaseUnitComparisons
         -- test >
@@ -796,7 +788,7 @@ class SI_Tests { assert }
                        let unit = unitType power: 1.
                        let a = SI value: 10.0 unit: unit.
                        a >= a }
-               testing: "baseUnit >= baseUunit (eq)".
+               testing: "baseUnit >= baseUunit (eq)"!
 
     method testBaseUnitPrinting
         assert that: { "{10 m * 100}" }
@@ -813,7 +805,7 @@ class SI_Tests { assert }
                testing: "print 1 A".
         assert that: { "{10 cd * 100}" }
                is: "1.0 kcd"
-               testing: "print 1 kcd".
+               testing: "print 1 kcd"!
 
     method testCompoundUnitArithmetic
         assert that: { 1 km / 2 ms }
@@ -830,7 +822,7 @@ class SI_Tests { assert }
                testing: "compoundUnit * float".
         assert that: { 0.1 * (1 km / 2 ms) }
                equals: (SI value: 50000.0 unit: (CompoundUnit units: [(Meters power: 1), (Seconds power: -1)]))
-               testing: "float * compoundUnit".
+               testing: "float * compoundUnit"!
 
     method testCompoundUnitComparisons
         assert true: { 1 km / 1 s > 1 m / 1 s }
@@ -840,7 +832,7 @@ class SI_Tests { assert }
         assert true: { 1 mm / 1 s < 1 m / 1 s }
                testing: "compoundUnit < compoundUnit (true)".
         assert false: { 1 km / 1 s < 1 m / 1 s }
-               testing: "compoundUnit < compoundUnit (false)".
+               testing: "compoundUnit < compoundUnit (false)"!
 
     method testCompoundUnitPrinting
         assert that: { "{1 km / 1 ms}" }
@@ -854,8 +846,7 @@ class SI_Tests { assert }
                testing: "printing 12.96 kJ".
         assert that: { "{10 kg * 2 m / s^2}" }
                is: "20.0 N"
-               testing: "printing 20 N"
-
+               testing: "printing 20 N"!
 end
 
 class Demo {}
@@ -869,6 +860,5 @@ class Demo {}
         output println: "{10 m * 10 m / 10}".
         output println: "{(1 m * 1 kg * 1 m) / (1 s * 1 kg * 1 m * 1 s)}".
         output println: "{0.5 * 80 kg * (18 m / s)^2}".
-        output println: "{10 kg * 2 m / s^2}"
-
+        output println: "{10 kg * 2 m / s^2}"!
 end

--- a/foo/repl.foo
+++ b/foo/repl.foo
@@ -8,7 +8,7 @@ class REPL {
     }
 
     class method runIn: system
-        (self new: system) run
+        (self new: system) run!
 
     class method new: system
         let compiler = Compiler new.
@@ -17,23 +17,23 @@ class REPL {
              _output: system output
              _compiler: compiler
              _atEof: False
-             _value: False
+             _value: False!
 
     method run
         _output println: "Foolang 0.0.0".
-        { _atEof } whileFalse: { self readEvalPrint }
+        { _atEof } whileFalse: { self readEvalPrint }!
 
     method readEvalPrint
         {
             -- Cascade just for fun.
             self; prompt; read; eval; print
         }
-            onPanic: { |p| p displayOn: _output }
+            onPanic: { |p| p displayOn: _output }!
 
     method prompt
         _output print: "> ".
         _output flush.
-        self
+        self!
 
     method read
         let source = "".
@@ -44,25 +44,25 @@ class REPL {
                 source = source append: line newline.
                 self _tryParse: source
             }
-        } whileFalse
+        } whileFalse!
 
     method eval
-        _atEof ifFalse: { _value = _compiler evaluate }
+        _atEof ifFalse: { _value = _compiler evaluate }!
 
     method print
         _atEof ifFalse: {
             _output display: _value.
             _output newline.
             _output flush
-        }
+        }!
 
     method _tryParse: source
         _compiler parse: source onEof: { |_err| return False }.
-        True
+        True!
 
 end
 
 class Main {}
     class method run: command in: system
-        REPL runIn: system
+        REPL runIn: system!
 end

--- a/foo/tests/bar/y.foo
+++ b/foo/tests/bar/y.foo
@@ -1,4 +1,4 @@
 class Identity {}
    class method value: x
-      x
+      x!
 end

--- a/foo/tests/errorLocationTests.foo
+++ b/foo/tests/errorLocationTests.foo
@@ -1,63 +1,63 @@
 class UnboundVariable {}
     class method oops
-        oops
+        oops!
 end
 
 class ValueTypeError {}
     class method oops
-        14::String
+        14::String!
 end
 
 class SlotTypeError { slot::String }
     class method oops
-        (self slot: "OK") oops
+        (self slot: "OK") oops!
     method oops
-        slot = 123
+        slot = 123!
 end
 
 class VarTypeError {}
     class method oops
         let x::String = "OK".
-        x = 12312
+        x = 12312!
 end
 
 class VarInitTypeError {}
     class method oops
         let x::String = 123124.
-        x
+        x!
 end
 
 class MethodArgTypeError {}
     class method oops
-        self oops: 42
+        self oops: 42!
     class method oops: x::String
-        panic "Not supposed to happen! x = {x}"
+        panic "Not supposed to happen! x = {x}"!
 end
 
 class BlockArgTypeError {}
     class method oops
-        { |x::String| x } value: 42
+        { |x::String| x } value: 42!
 end
 
 class UndefinedValueTypeError {}
     class method oops
-        self oops: 42
+        self oops: 42!
     class method oops: x
-        x::UndefinedType
+        x::UndefinedType!
 end
 
 class UndefinedVarTypeError {}
     class method oops
         let x::UndefinedType = "OK".
-        x
+        x!
 end
 
 class PanicError {}
     class method oops
-        panic "This here"
+        panic "This here"!
 end
 
 class DoesNotUnderstandError {}
     class method oops
-        self noSuchMethod
+        self noSuchMethod!
 end

--- a/foo/tests/prefixedImport.foo
+++ b/foo/tests/prefixedImport.foo
@@ -1,11 +1,8 @@
 define X
-    "eks"
-end
+    "eks"!
 
 define _Y
-    "why"
-end
+    "why"!
 
 define Y
-    { _Y }
-end
+    { _Y }!

--- a/foo/tests/test.foo
+++ b/foo/tests/test.foo
@@ -15,7 +15,7 @@ class SmallIntegers {}
         block value: 1.
         -- Then random numbers
         let rng = Random new.
-        100 times: { block value: (rng integer / 2) }
+        100 times: { block value: (rng integer / 2) }!
 end
 
 class ShortStringSeqs {}
@@ -27,7 +27,7 @@ class ShortStringSeqs {}
       block value: ["", "", ""].
       block value: ["123", "", ""].
       block value: ["", "123", ""].
-      block value: ["", "", "123"]
+      block value: ["", "", "123"]!
 end
 
 class Floats {}
@@ -39,27 +39,26 @@ class Floats {}
       block value: 0.1.
       block value: -0.1.
       let rng = Random new.
-      100 times: { block value: rng float }
+      100 times: { block value: rng float }!
 end
 
 class Box { value }
     method *** other
-        self value * other
+        self value * other!
     method * other
-        self value * other
+        self value * other!
     method + other
-        self value + other
+        self value + other!
     method prefix-
-        - (self value)
+        - (self value)!
 end
 
 define $testVar
-    123
-end
+    123!
 
 class TestVar {}
     class method read
-        $testVar
+        $testVar!
 end
 
 class Main { assert system }
@@ -67,7 +66,7 @@ class Main { assert system }
         let instance = self assert: (Assert reportingTo: system output)
                             system: system.
         instance test.
-        system exit: instance assert exitCode
+        system exit: instance assert exitCode!
 
     method test
         [
@@ -90,7 +89,7 @@ class Main { assert system }
         self testPrecedence.
         self testPrefix.
         self testPanic.
-        self testDynamicVars.
+        self testDynamicVars!
 
     method testIs
         assert true: { 1 is 1 } testing: "integer 'is' integer (match)".
@@ -101,19 +100,19 @@ class Main { assert system }
         assert true: { { (panic "Oops") is 42. False } onPanic: { |_| True } }
                testing: "'is' propagates errors from left".
         assert true: { { 42 is (panic "Oops"). False } onPanic: { |_| True } }
-               testing: "'is' propagates errors from right"
+               testing: "'is' propagates errors from right"!
 
     method testPanic
         assert true: { ({ panic "BOOM" } onPanic: { |p| p description })
                            == "BOOM" }
-               testing: "panic with string argument"
+               testing: "panic with string argument"!
 
     method testPrefix
         assert forAll: (1 to: 10)
                that: { |n|
                        let b = Box value: n.
                        -n == -b }
-               testing: "custom prefix method"
+               testing: "custom prefix method"!
 
     method testPrecedence
        assert forAll: (2 to: 10)
@@ -125,17 +124,17 @@ class Main { assert system }
                       (a1 == a2)
                         and: (b1 == b2)
                         and: (a1 == b1) not }
-              testing: "operator precedence"
+              testing: "operator precedence"!
 
     method testFloats
        assert forAll: Floats
               that: { |x| x + x == x * 2.0 }
-              testing: "float addition"
+              testing: "float addition"!
 
     method auxIntegerDivZeroError: x by: y
         { x / y }
             on: Error
-            do: { |error| return "oops" }
+            do: { |error| return "oops" }!
 
     method testIntegers
         assert forAll: SmallIntegers
@@ -167,7 +166,7 @@ class Main { assert system }
                        [ self auxIntegerDivZeroError: x by: x,
                          self auxIntegerDivZeroError: x by: 0 ]
                        == [1, "oops"] }
-               testing: "division by zero (good catch)".
+               testing: "division by zero (good catch)"!
 
     method testStringOutput
        assert forAll: ShortStringSeqs
@@ -178,12 +177,12 @@ class Main { assert system }
                                  cmp = cmp append: s.
                                  out print: s }.
                       cmp == out content }
-             testing: "string output"
+             testing: "string output"!
 
     method testDynamicVars
         assert that: { [ TestVar read,
                          { let $testVar = 42. TestVar read } value,
                          TestVar read ] }
                equals: [ 123, 42, 123 ]
-               testing: "dynamic binding of dynamic variable".
+               testing: "dynamic binding of dynamic variable"!
 end

--- a/foo/tests/test_abort.foo
+++ b/foo/tests/test_abort.foo
@@ -1,4 +1,4 @@
 class Main {}
   class method run: cmd in: system
-     system abort
+     system abort!
 end

--- a/foo/tests/test_array_let1.foo
+++ b/foo/tests/test_array_let1.foo
@@ -1,4 +1,4 @@
 class Main {}
    class method run: command in: system
-      system output println: [let x = 42. x + x, x]
+      system output println: [let x = 42. x + x, x]!
 end

--- a/foo/tests/test_array_let2.foo
+++ b/foo/tests/test_array_let2.foo
@@ -1,5 +1,5 @@
 class Main {}
    class method run: command in: system
       let a = [let x = 42. x, 123].
-      system output println: x
+      system output println: x!
 end

--- a/foo/tests/test_benchmarks.foo
+++ b/foo/tests/test_benchmarks.foo
@@ -7,14 +7,14 @@ class Benchmarks { benchmarks output clock }
                            Benchmark ackermann: full,
                            Benchmark fibonacci: full ]
             output: output
-            clock: clock
+            clock: clock!
 
     method run
         benchmarks
             do: { |benchmark|
                   benchmark
                       ; runWith: clock
-                      ; reportTo: output }
+                      ; reportTo: output }!
 end
 
 class Benchmark { name block userTime systemTime realTime }
@@ -24,8 +24,7 @@ class Benchmark { name block userTime systemTime realTime }
              block: block
              userTime: False
              systemTime: False
-             realTime: False
-
+             realTime: False!
 
     method runWith: clock
         let t0 = clock time.
@@ -35,7 +34,7 @@ class Benchmark { name block userTime systemTime realTime }
         let delta = (t2 - t1) - (t1 - t0).
         userTime = delta user.
         systemTime = delta system.
-        realTime = delta real
+        realTime = delta real!
 
     method reportTo: output
         output
@@ -46,37 +45,37 @@ class Benchmark { name block userTime systemTime realTime }
             ; print: systemTime toString
             ; print: ", "
             ; print: realTime toString
-            ; newline
+            ; newline!
 
     class method sumFloats: full
         let n = full ifTrue: { 150_000 } ifFalse: { 150 }.
         let floats = List new.
         1 to: n do: { |x| floats add: x asFloat }.
         Benchmark new: "SumFloats"
-            is: { floats inject: 0.0 into: { |sum each | sum + each } }
+            is: { floats inject: 0.0 into: { |sum each | sum + each } }!
 
     class method factorial: full
         Benchmark new: "Factorial"
                   is: { let res = 0.
                         let n = full ifTrue: { 2000 } ifFalse: { 2 }.
                         n times: { res = Factorial of: 20 }.
-                        res }
+                        res }!
 
     class method emptyLoop: full
         Benchmark new: "EmptyLoop"
                   is: { let n = full ifTrue: { 600_000 } ifFalse: { 600 }.
-                        n times: {} }
+                        n times: {} }!
 
     class method ackermann: full
         Benchmark new: "Ackermann"
                   is: { let n = full ifTrue: { 50 } ifFalse: { 1 }.
-                        n times: { Ackermann m: 3 n: 2 } }
+                        n times: { Ackermann m: 3 n: 2 } }!
 
     class method fibonacci: full
         Benchmark new: "Fibonacci" is: {
             let n = full ifTrue: { 21 } ifFalse: { 5 }.
             Fibonacci of: n
-        }
+        }!
 
 end
 
@@ -85,7 +84,7 @@ class Fibonacci {}
     class method of: n
         n < 2
             ifTrue: { return 1 }.
-        (Fibonacci of: n - 1) + (Fibonacci of: n - 2)
+        (Fibonacci of: n - 1) + (Fibonacci of: n - 2)!
 end
 
 class Factorial {}
@@ -93,7 +92,7 @@ class Factorial {}
     class method of: n
         n < 2
             ifTrue: { return n }.
-        n * (Factorial of: n - 1)
+        n * (Factorial of: n - 1)!
 
 end
 
@@ -104,7 +103,7 @@ class Ackermann {}
             ifTrue: { return n + 1 }.
         n == 0
             ifTrue: { return Ackermann m: m - 1 n: 1 }.
-        Ackermann m: m - 1 n: (Ackermann m: m n: n - 1)
+        Ackermann m: m - 1 n: (Ackermann m: m n: n - 1)!
 
 end
 
@@ -114,5 +113,5 @@ class Main {}
         let benchmarks = Benchmarks output: system output
                                     clock: system clock
                                     full: False.
-        benchmarks run
+        benchmarks run!
 end

--- a/foo/tests/test_block_arg_type_error_location.foo
+++ b/foo/tests/test_block_arg_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.BlockArgTypeError
 
 class Main {}
     class method run: cmd in: sys
-        BlockArgTypeError oops
+        BlockArgTypeError oops!
 end

--- a/foo/tests/test_class_comment1.foo
+++ b/foo/tests/test_class_comment1.foo
@@ -1,5 +1,5 @@
 class Main {}
     -- leading comment 1
     class method run: cmd in: system
-        system output println: "ok"
+        system output println: "ok"!
 end

--- a/foo/tests/test_class_comment2.foo
+++ b/foo/tests/test_class_comment2.foo
@@ -1,7 +1,7 @@
 class Main {}
     class method run: cmd in: system
-        system output println: "ok"
+        system output println: "ok"!
     -- leading comment 1
     class method bar
-        42
+        42!
 end

--- a/foo/tests/test_class_comment3.foo
+++ b/foo/tests/test_class_comment3.foo
@@ -1,7 +1,7 @@
 class Main {}
     class method run: cmd in: system
-        system output println: "ok".
+        system output println: "ok"!
     -- leading comment 1
     class method bar
-        42
+        42!
 end

--- a/foo/tests/test_class_comments.foo
+++ b/foo/tests/test_class_comments.foo
@@ -21,13 +21,13 @@ is Object
 block
 ---
     method isEquivalent: other
-        other getName == self getName
+        other getName == self getName!
 -- comment
 ---
 block
 ---
     method getName
-        self name
+        self name!
 -- comment
 ---
 block
@@ -38,5 +38,5 @@ class Main {}
     class method run: cmd in: system
         (LotsOfComments name: "test") == (LotsOfComments name: "test")
             ifTrue: { system exit }
-            ifFalse: { system abort }
+            ifFalse: { system abort }!
 end

--- a/foo/tests/test_does_not_understand_location.foo
+++ b/foo/tests/test_does_not_understand_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.DoesNotUnderstandError
 
 class Main {}
     class method run: cmd in: sys
-        DoesNotUnderstandError oops
+        DoesNotUnderstandError oops!
 end

--- a/foo/tests/test_exit_42.foo
+++ b/foo/tests/test_exit_42.foo
@@ -1,4 +1,4 @@
 class Main {}
   class method run: command in: system
-     system exit: 42
+     system exit: 42!
 end

--- a/foo/tests/test_exit_zero.foo
+++ b/foo/tests/test_exit_zero.foo
@@ -1,4 +1,4 @@
 class Main {}
   class method run: command in: system
-     system exit
+     system exit!
 end

--- a/foo/tests/test_expr_at_toplevel_error_location.foo
+++ b/foo/tests/test_expr_at_toplevel_error_location.foo
@@ -2,5 +2,5 @@ import .expr_at_toplevel
 
 class Main {}
     class method run: cmd in: sys
-        sys exit
+        sys exit!
 end

--- a/foo/tests/test_import_bar_y.foo
+++ b/foo/tests/test_import_bar_y.foo
@@ -2,5 +2,5 @@ import bar.y
 
 class Main {}
    class method run: command in: system
-      system exit: (y.Identity value: 111)
+      system exit: (y.Identity value: 111)!
 end

--- a/foo/tests/test_import_x.foo
+++ b/foo/tests/test_import_x.foo
@@ -2,5 +2,5 @@ import x
 
 class Main {}
    class method run: command in: system
-      system exit: (x.Identity value: 123)
+      system exit: (x.Identity value: 123)!
 end

--- a/foo/tests/test_import_x_Identity.foo
+++ b/foo/tests/test_import_x_Identity.foo
@@ -2,5 +2,5 @@ import x.Identity
 
 class Main {}
    class method run: command in: system
-       system exit: (Identity value: 100)
+       system exit: (Identity value: 100)!
 end

--- a/foo/tests/test_import_x_local.foo
+++ b/foo/tests/test_import_x_local.foo
@@ -2,5 +2,5 @@ import .x
 
 class Main {}
    class method run: command in: system
-      system exit: (x.Identity value: 123)
+      system exit: (x.Identity value: 123)!
 end

--- a/foo/tests/test_import_x_star.foo
+++ b/foo/tests/test_import_x_star.foo
@@ -2,5 +2,5 @@ import x.*
 
 class Main {}
    class method run: command in: system
-      system exit: (Identity value: Utility foo)
+      system exit: (Identity value: Utility foo)!
 end

--- a/foo/tests/test_interface_bad_signature.foo
+++ b/foo/tests/test_interface_bad_signature.foo
@@ -5,5 +5,5 @@ end
 class C {}
     is I
     method quux
-        42
+        42!
 end

--- a/foo/tests/test_interface_inheritance.foo
+++ b/foo/tests/test_interface_inheritance.foo
@@ -1,18 +1,18 @@
 interface I0
     method foo
-        0
+        0!
 end
 
 interface I1
     method bar
-        1
+        1!
 end
 
 interface I
     is I0
     is I1
     method quux
-        2
+        2!
 end
 
 class C {}
@@ -21,14 +21,14 @@ end
 
 class Main {}
     class method foo: x::I0
-        x::I::C foo
+        x::I::C foo!
     class method bar: x::I1
-        x::I::C bar
+        x::I::C bar!
     class method quux: x::I
-        x quux
+        x quux!
     class method run: cmd in: sys
         let c = C new.
         sys output println: "foo: {self foo: c} => I0 ok".
         sys output println: "bar: {self bar: c} => I1 ok".
-        sys output println: "quux: {self quux: c} => I ok"
+        sys output println: "quux: {self quux: c} => I ok"!
 end

--- a/foo/tests/test_interface_ok.foo
+++ b/foo/tests/test_interface_ok.foo
@@ -1,17 +1,17 @@
 interface I
     method foo
-        "I#foo"
+        "I#foo"!
     method bar
-        "I#bar"
+        "I#bar"!
     required method quux -> Integer
 end
 
 class C {}
     is I
     method foo
-        "C#foo"
+        "C#foo"!
     method quux -> Integer
-        42
+        42!
 end
 
 class Main {}
@@ -19,5 +19,5 @@ class Main {}
         let c = C new.
         system output println: "foo = {c foo}".
         system output println: "bar = {c bar}".
-        system output println: "quux = {c quux}".
+        system output println: "quux = {c quux}"!
 end

--- a/foo/tests/test_interface_typecheck.foo
+++ b/foo/tests/test_interface_typecheck.foo
@@ -10,8 +10,8 @@ end
 
 class Main {}
     class method test: x::I
-        True
+        True!
     class method run: cmd in: system
         system output println: "YesI: {self test: YesI new}".
-        system output println: "NotI: {self test: NotI new}"
+        system output println: "NotI: {self test: NotI new}"!
 end

--- a/foo/tests/test_interface_unimplemented.foo
+++ b/foo/tests/test_interface_unimplemented.foo
@@ -1,8 +1,8 @@
 interface I
     method foo
-        "I#foo"
+        "I#foo"!
     method bar
-        "I#bar"
+        "I#bar"!
     required method quux -> Integer
 end
 

--- a/foo/tests/test_method_arg_type_error_location.foo
+++ b/foo/tests/test_method_arg_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.MethodArgTypeError
 
 class Main {}
     class method run: cmd in: sys
-        MethodArgTypeError oops
+        MethodArgTypeError oops!
 end

--- a/foo/tests/test_panic_location.foo
+++ b/foo/tests/test_panic_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.PanicError
 
 class Main {}
     class method run: cmd in: sys
-        PanicError oops
+        PanicError oops!
 end

--- a/foo/tests/test_prefixed_import.foo
+++ b/foo/tests/test_prefixed_import.foo
@@ -6,5 +6,5 @@ class Main {}
         out println: "X = {X}".
         out println: "Y = {Y value}".
         out println: "_Y = {_Y}".
-        sys exit
+        sys exit!
 end

--- a/foo/tests/test_prelude.foo
+++ b/foo/tests/test_prelude.foo
@@ -1,4 +1,4 @@
 class Main {}
    class method run: command in: system
-       system exit: (1 + 1)
+       system exit: (1 + 1)!
 end

--- a/foo/tests/test_print_flush.foo
+++ b/foo/tests/test_print_flush.foo
@@ -1,5 +1,5 @@
 class Main {}
   class method run: command in: system
      (system output print: "Foo") flush.
-     system exit
+     system exit!
 end

--- a/foo/tests/test_print_no_flush.foo
+++ b/foo/tests/test_print_no_flush.foo
@@ -1,5 +1,5 @@
 class Main {}
   class method run: command in: system
      system output print: "Foo".
-     system exit
+     system exit!
 end

--- a/foo/tests/test_redefinition_error_location.foo
+++ b/foo/tests/test_redefinition_error_location.foo
@@ -2,5 +2,5 @@ import .redefinition_error
 
 class Main {}
     class method run: cmd in: sys
-        sys exit
+        sys exit!
 end

--- a/foo/tests/test_slot_type_error_location.foo
+++ b/foo/tests/test_slot_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.SlotTypeError
 
 class Main {}
     class method run: cmd in: sys
-        SlotTypeError oops
+        SlotTypeError oops!
 end

--- a/foo/tests/test_unbound_variable_location.foo
+++ b/foo/tests/test_unbound_variable_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.UnboundVariable
 
 class Main {}
     class method run: cmd in: sys
-        UnboundVariable oops
+        UnboundVariable oops!
 end

--- a/foo/tests/test_undefined_interface_error_location.foo
+++ b/foo/tests/test_undefined_interface_error_location.foo
@@ -2,5 +2,5 @@ import .undefined_interface
 
 class Main {}
     class method run: cmd in: sys
-        sys exit
+        sys exit!
 end

--- a/foo/tests/test_undefined_value_type_error_location.foo
+++ b/foo/tests/test_undefined_value_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.UndefinedValueTypeError
 
 class Main {}
     class method run: cmd in: sys
-        UndefinedValueTypeError oops
+        UndefinedValueTypeError oops!
 end

--- a/foo/tests/test_undefined_var_type_error_location.foo
+++ b/foo/tests/test_undefined_var_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.UndefinedVarTypeError
 
 class Main {}
     class method run: cmd in: sys
-        UndefinedVarTypeError oops
+        UndefinedVarTypeError oops!
 end

--- a/foo/tests/test_value_type_error_location.foo
+++ b/foo/tests/test_value_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.ValueTypeError
 
 class Main {}
     class method run: cmd in: sys
-        ValueTypeError oops
+        ValueTypeError oops!
 end

--- a/foo/tests/test_var_init_type_error_location.foo
+++ b/foo/tests/test_var_init_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.VarInitTypeError
 
 class Main {}
     class method run: cmd in: sys
-        VarInitTypeError oops
+        VarInitTypeError oops!
 end

--- a/foo/tests/test_var_type_error_location.foo
+++ b/foo/tests/test_var_type_error_location.foo
@@ -2,5 +2,5 @@ import .errorLocationTests.VarTypeError
 
 class Main {}
     class method run: cmd in: sys
-        VarTypeError oops
+        VarTypeError oops!
 end

--- a/foo/tests/x.foo
+++ b/foo/tests/x.foo
@@ -1,9 +1,9 @@
 class Identity {}
    class method value: x
-      x
+      x!
 end
 
 class Utility {}
    class method foo
-      42
+      42!
 end

--- a/src/tests/test_block.rs
+++ b/src/tests/test_block.rs
@@ -38,9 +38,9 @@ fn test_closure5() {
         eval_ok(
             "class T {}
                  class method closeOver: value
-                     return { |x | value + x }.
+                     return { |x | value + x }!
                  class method test
-                     return (self closeOver: 40) value: 2.
+                     return (self closeOver: 40) value: 2!
              end
              T test"
         )
@@ -56,9 +56,9 @@ fn test_closure_return() {
             "class T {}
                class method test
                  self boo: { return 42 }.
-                 return 31
+                 return 31!
                class method boo: block
-                 block value
+                 block value!
              end
              T test",
         )

--- a/src/tests/test_clock.rs
+++ b/src/tests/test_clock.rs
@@ -8,7 +8,7 @@ fn test_clock1() {
         .run(
             "class Main {}
              class method run: command in: system
-                 system clock :: Clock toString
+                 system clock :: Clock toString!
          end",
             cmd,
         )
@@ -30,7 +30,7 @@ fn test_clock2() {
                  let t0 = clock time.
                  system sleep: 10.
                  let t1 = clock time.
-                 t0 real < t1 real
+                 t0 real < t1 real!
          end",
             cmd,
         )

--- a/src/tests/test_compiler.rs
+++ b/src/tests/test_compiler.rs
@@ -25,7 +25,7 @@ fn test_compiler2() {
                 "
                class Foox { bar }
                  method quux: n
-                    bar * n
+                    bar * n!
                end
                let foo = Foox bar: 21.
                foo quux: 2

--- a/src/tests/test_eval.rs
+++ b/src/tests/test_eval.rs
@@ -25,9 +25,9 @@ fn test_cascade2() {
           class Foo { a }
             method neg
                a = -a.
-               self
+               self!
             method up: by
-               a = a + by
+               a = a + by!
           end
           Foo a: 44; neg up: 2; neg; a"
         )
@@ -45,9 +45,9 @@ fn test_cascade3() {
           class Foo { a }
             method neg
                a = -a.
-               self
+               self!
             method up: by
-               a = a + by
+               a = a + by!
           end
           Foo a: 44
           ; neg up: 2
@@ -64,9 +64,9 @@ fn test_class_method1() {
     let (class, env) = eval_obj(
         "class Foo { a }
             class method new
-                self a: 42
+                self a: 42!
             class method foo
-                12
+                12!
          end",
     );
     assert_eq!(class.send("foo", &[], &env), Ok(env.foo.make_integer(12)));
@@ -81,11 +81,11 @@ fn test_class_method2() {
     let (class, env) = eval_obj(
         "class Foo { _a }
             class method new
-                self _a: 42
+                self _a: 42!
             class method foo
-                12
+                12!
             method a
-                _a
+                _a!
          end",
     );
     assert_eq!(class.send("foo", &[], &env), Ok(env.foo.make_integer(12)));
@@ -101,7 +101,7 @@ fn test_instance_variable1() {
         eval_ok(
             "class Foo { bar }
                method zot
-                  bar
+                  bar!
              end
              (Foo bar: 42) zot"
         )
@@ -117,9 +117,9 @@ fn test_instance_variable2() {
             "class Foo { bar }
                method zit
                   bar = bar + 1.
-                  self
+                  self!
                method zot
-                  bar
+                  bar!
              end
              (Foo bar: 41) zit zot"
         )
@@ -135,7 +135,7 @@ fn test_instance_variable3() {
             "class Foo { bar::Integer }
                method foo: x
                   bar = bar + x.
-                  self
+                  self!
              end
              ((Foo bar: 41) foo: 1) bar"
         )
@@ -150,7 +150,7 @@ fn test_instance_variable4() {
         "class Foo { bar::Integer }
            method foo: x
               bar = bar + x.
-              self
+              self!
          end
          ((Foo bar: 41) foo: 1.0) bar",
     );
@@ -167,7 +167,7 @@ fn test_instance_variable4() {
                     "002            method foo: x\n",
                     "003               bar = bar + x.\n",
                     "                        ^^^^^^^ Integer expected, got Float: 42.0\n",
-                    "004               self\n"
+                    "004               self!\n"
                 )
             )
         )
@@ -181,11 +181,11 @@ fn test_extend1() {
             "
          class Foo {}
             class method perform: s with: args
-               666
+               666!
          end
          extend Foo
             method bar
-               42
+               42!
          end
          Foo new bar",
         )
@@ -201,11 +201,11 @@ fn test_extend2() {
             "
          class Foo {}
             method perform: s with: args
-               666
+               666!
          end
          extend Foo
             class method bar
-               42
+               42!
          end
          Foo bar",
         )
@@ -219,11 +219,11 @@ fn test_extend_exception1() {
     let (exception, _env) = eval_exception(
         "class Foo {}
             method perform: s with: args
-               42
+               42!
          end
          extend Foo
             method bar
-               666
+               666!
          end",
     );
     assert_eq!(
@@ -242,11 +242,11 @@ fn test_extend_exception2() {
     let (exception, _env) = eval_exception(
         "class Foo {}
             class method perform: s with: args
-               42
+               42!
          end
          extend Foo
             class method bar
-               666
+               666!
          end",
     );
     assert_eq!(
@@ -401,9 +401,9 @@ fn test_typecheck8() {
         "class Foo {}
             defaultConstructor foo
             method zot: x::Integer
-                x
+                x!
             method boom
-                self zot: 1.0
+                self zot: 1.0!
          end
          Foo foo boom",
     );
@@ -415,10 +415,10 @@ fn test_typecheck8() {
                 expected: "Integer".to_string()
             }),
             Location::from(
-                146..154,
+                147..155,
                 concat!(
                     "005             method boom\n",
-                    "006                 self zot: 1.0\n",
+                    "006                 self zot: 1.0!\n",
                     "                         ^^^^^^^^ Integer expected, got Float: 1.0\n",
                     "007          end\n"
                 )
@@ -433,7 +433,7 @@ fn test_typecheck9() {
         "class Foo {}
             defaultConstructor foo
             method zot: x -> Integer
-                x + 1
+                x + 1!
          end
          Foo foo zot: 1.0",
     );
@@ -448,7 +448,7 @@ fn test_typecheck9() {
                 101..106,
                 concat!(
                     "003             method zot: x -> Integer\n",
-                    "004                 x + 1\n",
+                    "004                 x + 1!\n",
                     "                    ^^^^^ Integer expected, got Float: 2.0\n",
                     "005          end\n",
                 )
@@ -485,7 +485,7 @@ fn test_typecheck11() {
             "class Foo {}
             defaultConstructor foo
             method zot: x::Integer
-                x
+                x!
          end
          Foo foo zot: 42",
         )
@@ -632,7 +632,7 @@ fn test_new_instance1() {
 fn test_new_instance2() {
     let (object, env) = eval_obj(
         "class Oh {}
-            method no 42
+            method no 42!
             defaultConstructor noes
          end
          Oh noes",
@@ -644,7 +644,7 @@ fn test_new_instance2() {
 fn test_instance_method1() {
     let (object, env) = eval_obj(
         "class Foo {}
-            method bar 311.
+            method bar 311!
          end
          Foo new",
     );
@@ -656,9 +656,9 @@ fn test_instance_method2() {
     let (object, env) = eval_obj(
         "class Foo {}
             method foo
-               self bar
+               self bar!
             method bar
-               311
+               311!
          end
          Foo new",
     );
@@ -670,11 +670,11 @@ fn test_instance_method3() {
     let (object, env) = eval_obj(
         "class Foo { value }
             method + other
-               Foo value: value + other value
+               Foo value: value + other value!
          end
          class Bar { a b }
             method sum
-              a + b
+              a + b!
          end
          Bar a: (Foo value: 1) b: (Foo value: 10)",
     );
@@ -690,7 +690,7 @@ fn test_return_returns() {
         "class Foo {}
             method foo
                return 1.
-               2
+               2!
          end
          Foo new foo",
     );
@@ -703,9 +703,9 @@ fn test_return_from_method_block() {
         "class Foo {}
             method test
                 self boo: { return 42 }.
-                31
+                31!
             method boo: blk
-                blk value
+                blk value!
          end
          Foo new test
         ",
@@ -718,16 +718,16 @@ fn test_return_from_deep_block_to_middle() {
     let (object, env) = eval_obj(
         "class Foo {}
             method test
-               return 1 + let x = 41. self test0: x
+               return 1 + let x = 41. self test0: x!
             method test0: x
                self test1: { return x }.
-               return 100
+               return 100!
             method test1: blk
                self test2: blk.
-               return 1000
+               return 1000!
             method test2: blk
                blk value.
-               return 10000
+               return 10000!
          end
          Foo new test
         ",
@@ -741,7 +741,7 @@ fn test_not_understood() {
         eval_ok(
             r#"class Foo {}
                 method perform: m with: args
-                   "not understood: {m} args: {args}"
+                   "not understood: {m} args: {args}"!
                end
                Foo new foo: 1 bar: 2"#
         )
@@ -757,7 +757,7 @@ fn test_method_keyword_multiline() {
             r#"class Foo {}
                   class method bar: x
                                quux: y
-                    x + y
+                    x + y!
                end
                Foo bar: 40 quux: 2"#
         )
@@ -772,7 +772,7 @@ fn test_method_declares_class_as_argtype() {
         eval_ok(
             r#"class Foo { x }
                    method y: other::Foo
-                       other x
+                       other x!
                end
                (Foo x: 42) y: (Foo x: 123)"#
         )

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -123,7 +123,7 @@ fn test_sequence4() {
 #[test]
 fn test_define1() {
     assert_eq!(
-        parse_def("define m 1. end"),
+        parse_def("define m 1!"),
         Ok(Def::DefineDef(DefineDef {
             source_location: SourceLocation::span(&(7..8)),
             name: "m".to_string(),
@@ -135,7 +135,7 @@ fn test_define1() {
 #[test]
 fn test_define2() {
     assert_eq!(
-        parse_def("define m 1 m. end"),
+        parse_def("define m 1 m!"),
         Ok(Def::DefineDef(DefineDef {
             source_location: SourceLocation::span(&(7..8)),
             name: "m".to_string(),
@@ -227,7 +227,7 @@ fn test_parse_class1() {
 fn parse_method1() {
     let mut class = class(0..5, "Foo", vec![]);
     class.add_method(MethodKind::Instance, method(13..19, "bar", vec![], int(24..26, 42)));
-    assert_eq!(parse_def("class Foo {} method bar 42 . end"), Ok(class));
+    assert_eq!(parse_def("class Foo {} method bar 42! end"), Ok(class));
 }
 
 #[test]
@@ -237,19 +237,19 @@ fn parse_method2() {
         MethodKind::Instance,
         method(90..96, "foo", vec![], unary(130..133, "bar", var(125..129, "self"))),
     );
-    class.add_method(MethodKind::Instance, method(240..246, "bar", vec![], int(275..277, 42)));
+    class.add_method(MethodKind::Instance, method(241..247, "bar", vec![], int(276..278, 42)));
     assert_eq!(
         parse_def(
             "
                  class Foo {}
                      -- this is a foo
                      method foo
-                        self bar
+                        self bar!
                      ---
                      this is a bar
                      ---
                      method bar
-                        42
+                        42!
                  end"
         ),
         Ok(class)
@@ -269,9 +269,9 @@ fn parse_method3() {
             "
                  class Foo {}
                      method foo
-                        self bar.
+                        self bar!
                      method bar
-                        42.
+                        42!
                  end"
         ),
         Ok(class)
@@ -374,7 +374,7 @@ fn test_newlines1() {
         "class Point { x y }
             method add: point
                Point x: x + point x
-                     y: y + point y
+                     y: y + point y!
          end"
     )
     .is_ok());
@@ -392,7 +392,7 @@ fn test_newlines2() {
 
            method add: point
               Point x: x + point x
-                    y: y + point y
+                    y: y + point y!
          end"
     )
     .is_ok());
@@ -557,7 +557,7 @@ fn test_parse_import2() {
 fn test_parse_extend1() {
     let mut ext = ExtensionDef::new(SourceLocation::span(&(0..6)), "Foo");
     ext.add_method(MethodKind::Instance, method(11..17, "bar", vec![], int(22..24, 42)));
-    assert_eq!(parse_def("extend Foo method bar 42 end"), Ok(Def::ExtensionDef(ext)));
+    assert_eq!(parse_def("extend Foo method bar 42! end"), Ok(Def::ExtensionDef(ext)));
 }
 
 #[test]
@@ -574,10 +574,10 @@ fn test_parse_interface1() {
             "
 interface Foo
     method bar
-        42.
+        42!
     required method quux
     method zot
-        123.
+        123!
 end"
         ),
         Ok(Def::InterfaceDef(interface))

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -128,7 +128,7 @@ fn test_unbound_variable_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: Unbound variable: oops
 002     class method oops
-003         oops
+003         oops!
             ^^^^ Unbound variable: oops
 004 end",
     ));
@@ -142,7 +142,7 @@ fn test_value_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: String expected, got Integer: 14
 007     class method oops
-008         14::String
+008         14::String!
             ^^ String expected, got Integer: 14
 009 end",
     ));
@@ -156,7 +156,7 @@ fn test_slot_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: String expected, got Integer: 123
 014     method oops
-015         slot = 123
+015         slot = 123!
                    ^^^ String expected, got Integer: 123
 016 end",
     ));
@@ -170,7 +170,7 @@ fn test_var_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: String expected, got Integer: 12312
 020         let x::String = \"OK\".
-021         x = 12312
+021         x = 12312!
                 ^^^^^ String expected, got Integer: 12312
 022 end",
     ));
@@ -198,7 +198,7 @@ fn test_method_arg_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: String expected, got Integer: 42
 031     class method oops
-032         self oops: 42
+032         self oops: 42!
                  ^^^^^^^^ String expected, got Integer: 42
 033     class method oops: x::String",
     ));
@@ -212,7 +212,7 @@ fn test_block_arg_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: String expected, got Integer: 42
 038     class method oops
-039         { |x::String| x } value: 42
+039         { |x::String| x } value: 42!
                               ^^^^^^^^^ String expected, got Integer: 42
 040 end",
     ));
@@ -263,7 +263,7 @@ fn test_undefined_value_type_error_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: Undefined type: 'UndefinedType'
 045     class method oops: x
-046         x::UndefinedType
+046         x::UndefinedType!
                ^^^^^^^^^^^^^ Undefined type: 'UndefinedType'
 047 end",
     ));
@@ -307,7 +307,7 @@ fn test_panic_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: This here
 056     class method oops
-057         panic \"This here\"
+057         panic \"This here\"!
             ^^^^^ This here
 058 end",
     ));
@@ -322,7 +322,7 @@ fn test_does_not_understand_location() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: class DoesNotUnderstandError does not understand: noSuchMethod []
 061     class method oops
-062         self noSuchMethod
+062         self noSuchMethod!
                  ^^^^^^^^^^^^ class DoesNotUnderstandError does not understand: noSuchMethod []
 063 end",
     ));
@@ -496,7 +496,7 @@ fn test_array_let1() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: Unbound variable: x
 002    class method run: command in: system
-003       system output println: [let x = 42. x + x, x]
+003       system output println: [let x = 42. x + x, x]!
                                                      ^ Unbound variable: x
 004 end
 
@@ -512,7 +512,7 @@ fn test_array_let2() -> Test {
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
         "ERROR: Unbound variable: x
 003       let a = [let x = 42. x, 123].
-004       system output println: x
+004       system output println: x!
                                  ^ Unbound variable: x
 005 end
 ",
@@ -527,12 +527,12 @@ fn test_repl() -> Test {
         .write_stdin(
             r#"class Point { x y }
                   class method displayOn: stream
-                     stream print: "<class Point>"
+                     stream print: "<class Point>"!
                   method + other
                      Point x: x + other x
-                           y: y + other y
+                           y: y + other y!
                   method displayOn: stream
-                     stream print: "{x}@{y}"
+                     stream print: "{x}@{y}"!
                end
                { let p1 = Point x: 1 y: 2.
                  let p2 = Point x: 100 y: 200.


### PR DESCRIPTION
  -> `method`, `required`, and `end` are no longer reserved words.

  Same SHOULD apply to `define`, `interface`, and `class` as well in expression
  sontext, but that would require more changes to the bootstrap parser than I
  want to engage in right now.

  Closes #128
