### PR TITLE
minor interface improvements

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1261,6 +1261,9 @@ impl Object {
                 Some(Method::Primitive(_)) => {
                     // FIXME: signature not checked!
                 }
+                Some(Method::Reader(_)) => {
+                    // FIXME: signature not checked!
+                }
                 Some(_) => {
                     return Unwind::error(&format!(
                     "{}#{} is an interface method, non-vanilla implementations not supporte yet",
@@ -1311,6 +1314,9 @@ impl Object {
                     }
                 }
                 Some(Method::Primitive(_)) => {
+                    // FIXME: signature not checked!
+                }
+                Some(Method::Reader(_)) => {
                     // FIXME: signature not checked!
                 }
                 Some(_) => {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -166,7 +166,7 @@ impl Method {
     fn extend_env(&self, name: &str, value: &Object) -> Method {
         match self {
             Method::Interpreter(ref c) => Method::Interpreter(c.extend_env(name, value)),
-            _ => panic!("BUG: Cannot extend environment of non-interpreter method."),
+            _ => self.clone(),
         }
     }
 }
@@ -1325,7 +1325,7 @@ impl Object {
                     class_name, selector
                 ))
                 }
-                None if required => {
+                None if required && !class.interface => {
                     return Unwind::error(&format!(
                         "{}#{} unimplemented, required by interface {}",
                         class_name, selector, name


### PR DESCRIPTION
- reader methods can be used to implement required methods
- required instance methods can be unimplemented in subinterfaces as long as they're implemented in class
