### PR TITLE
refactor SyntaxVisitors and AstVisitors

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -218,9 +218,5 @@ class AstLexicalSet { name
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitLexicalSet: name
-            value: value
-            index: index
-            frame: frame!
+        visitor visitLexicalSet: self!
 end

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -134,7 +134,7 @@ class AstGlobal { name _value }
         _value = newValue!
 
     method visitBy: visitor
-        visitor visitGlobal: self value!
+        visitor visitGlobal: self!
 end
 
 class AstConstantRef { value }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -155,9 +155,7 @@ class AstSeq { first then }
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitSeqFirst: first
-            then: then!
+        visitor visitSeq: self!
 end
 
 class AstReturn { value }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -199,11 +199,7 @@ class AstBindLexical { name index value body }
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitBindLexical: name
-            value: value
-            index: index
-            body: body!
+        visitor visitBindLexical: self!
 end
 
 class AstLexicalRef { name

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -162,7 +162,7 @@ class AstReturn { value }
     is AstNode
 
     method visitBy: visitor
-        visitor visitReturn: value!
+        visitor visitReturn: self!
 end
 
 class AstSend {

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -148,9 +148,7 @@ class AstIs { left right }
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitIsLeft: left
-            right: right!
+        visitor visitIs: self!
 end
 
 class AstSeq { first then }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -208,10 +208,7 @@ class AstLexicalRef { name
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitLexicalRef: name
-            index: index
-            frame: frame!
+        visitor visitLexicalRef: self!
 end
 
 class AstLexicalSet { name

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -100,10 +100,7 @@ class AstComment { comment value source }
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitComment: comment
-            value: value
-            source: source!
+        visitor visitComment: self!
 end
 
 class AstUndefinedMarker {}

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -185,7 +185,7 @@ class AstSelfRef {}
     is AstNode
 
     method visitBy: visitor
-        visitor visitSelf!
+        visitor visitSelf: self!
 end
 
 class AstSlotRef { name index::Integer }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -141,7 +141,7 @@ class AstConstantRef { value }
     is AstNode
 
     method visitBy: visitor
-        visitor visitConstant: value!
+        visitor visitConstant: self!
 end
 
 class AstIs { left right }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -174,11 +174,7 @@ class AstSend {
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitSend: selector
-            to: receiver
-            with: arguments
-            source: source!
+        visitor visitSend: self!
 end
 
 class AstBlock { body argumentCount frameSize }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -192,9 +192,7 @@ class AstSlotRef { name index::Integer }
     is AstNode
 
     method visitBy: visitor
-        visitor
-            visitSlotRef: name
-            at: index!
+        visitor visitSlotRef: self!
 end
 
 class AstBindLexical { name index value body }

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -125,8 +125,8 @@ class AstInterpreter { context process }
         { AstInterpreter eval: astMethod body with: context }
             finally: { context invalidate } !
 
-    method visitConstant: value
-        value!
+    method visitConstant: constant
+        constant value!
 
     method visitGlobal: value
         value!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -159,8 +159,8 @@ class AstInterpreter { context process }
                                     on: object
                                     source: sendExpr source }} !
 
-    method visitComment: comment value: value source: source
-        value visitBy: self!
+    method visitComment: commentExpr
+        commentExpr value visitBy: self!
 
     method visitBlock: block
         AstBlockClosure

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -138,8 +138,8 @@ class AstInterpreter { context process }
         seqExpr first visitBy: self.
         seqExpr then visitBy: self!
 
-    method visitReturn: value
-        context returnBlock value: (value visitBy: self)!
+    method visitReturn: returnExpr
+        context returnBlock value: (returnExpr value visitBy: self)!
 
     method visitSend: selector to: receiver with: arguments source: source
         let object = receiver visitBy: self.

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -134,9 +134,9 @@ class AstInterpreter { context process }
     method visitIs: isExpr
         (isExpr left visitBy: self) is (isExpr right visitBy: self)!
 
-    method visitSeqFirst: first then: then
-        first visitBy: self.
-        then visitBy: self!
+    method visitSeq: seqExpr
+        seqExpr first visitBy: self.
+        seqExpr then visitBy: self!
 
     method visitReturn: value
         context returnBlock value: (value visitBy: self)!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -128,8 +128,8 @@ class AstInterpreter { context process }
     method visitConstant: constant
         constant value!
 
-    method visitGlobal: value
-        value!
+    method visitGlobal: global
+        global value!
 
     method visitIsLeft: left right: right
         (left visitBy: self) is (right visitBy: self)!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -181,12 +181,14 @@ class AstInterpreter { context process }
         bindExpr body visitBy: self!
 
     method visitLexicalRef: refExpr
-        context at: refExpr index inFrame: refExpr frame!
-
-
-    method visitLexicalSet: name value: value index: index frame: frame
         context
-            put: (value visitBy: self)
-            at: index
-            inFrame: frame!
+            at: refExpr index
+            inFrame: refExpr frame!
+
+
+    method visitLexicalSet: setExpr
+        context
+            put: (setExpr value visitBy: self)
+            at: setExpr index
+            inFrame: setExpr frame!
 end

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -167,7 +167,7 @@ class AstInterpreter { context process }
             context: context
             block: block!
 
-    method visitSelf
+    method visitSelf: selfExpr
         context receiver!
 
     method visitSlotRef: slotExpr

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -173,12 +173,12 @@ class AstInterpreter { context process }
     method visitSlotRef: slotExpr
         context slot: slotExpr index!
 
-    method visitBindLexical: name value: value index: index body: body
+    method visitBindLexical: bindExpr
         context
-            put: (value visitBy: self)
-            at: index
+            put: (bindExpr value visitBy: self)
+            at: bindExpr index
             inFrame: 1.
-        body visitBy: self!
+        bindExpr body visitBy: self!
 
     method visitLexicalRef: name index: index frame: frame
         context at: index inFrame: frame!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -125,26 +125,26 @@ class AstInterpreter { context process }
         { AstInterpreter eval: astMethod body with: context }
             finally: { context invalidate } !
 
-    method visitConstant: constant
-        constant value!
+    method visitConstant: aConstant
+        aConstant value!
 
-    method visitGlobal: global
-        global value!
+    method visitGlobal: aGlobal
+        aGlobal value!
 
-    method visitIs: isExpr
-        (isExpr left visitBy: self) is (isExpr right visitBy: self)!
+    method visitIs: anIs
+        (anIs left visitBy: self) is (anIs right visitBy: self)!
 
-    method visitSeq: seqExpr
-        seqExpr first visitBy: self.
-        seqExpr then visitBy: self!
+    method visitSeq: aSeq
+        aSeq first visitBy: self.
+        aSeq then visitBy: self!
 
-    method visitReturn: returnExpr
-        context returnBlock value: (returnExpr value visitBy: self)!
+    method visitReturn: aReturn
+        context returnBlock value: (aReturn value visitBy: self)!
 
-    method visitSend: sendExpr
-        let selector = sendExpr selector.
-        let object = sendExpr receiver visitBy: self.
-        let arguments = sendExpr arguments collect: { |arg| arg visitBy: self }.
+    method visitSend: aSend
+        let selector = aSend selector.
+        let object = aSend receiver visitBy: self.
+        let arguments = aSend arguments collect: { |arg| arg visitBy: self }.
         let $context = context.
         let $process = process.
         -- Debug println: "<- {selector}".
@@ -157,38 +157,37 @@ class AstInterpreter { context process }
                                     raise: selector
                                     with: arguments
                                     on: object
-                                    source: sendExpr source }} !
+                                    source: aSend source }} !
 
-    method visitComment: commentExpr
-        commentExpr value visitBy: self!
+    method visitComment: aComment
+        aComment value visitBy: self!
 
-    method visitBlock: block
+    method visitBlock: aBlock
         AstBlockClosure
             context: context
-            block: block!
+            block: aBlock!
 
-    method visitSelf: selfExpr
+    method visitSelf: aSelf
         context receiver!
 
-    method visitSlotRef: slotExpr
-        context slot: slotExpr index!
+    method visitSlotRef: aSlotRef
+        context slot: aSlotRef index!
 
-    method visitBindLexical: bindExpr
+    method visitBindLexical: aBind
         context
-            put: (bindExpr value visitBy: self)
-            at: bindExpr index
+            put: (aBind value visitBy: self)
+            at: aBind index
             inFrame: 1.
-        bindExpr body visitBy: self!
+        aBind body visitBy: self!
 
-    method visitLexicalRef: refExpr
+    method visitLexicalRef: aRef
         context
-            at: refExpr index
-            inFrame: refExpr frame!
+            at: aRef index
+            inFrame: aRef frame!
 
-
-    method visitLexicalSet: setExpr
+    method visitLexicalSet: aSet
         context
-            put: (setExpr value visitBy: self)
-            at: setExpr index
-            inFrame: setExpr frame!
+            put: (aSet value visitBy: self)
+            at: aSet index
+            inFrame: aSet frame!
 end

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -170,8 +170,8 @@ class AstInterpreter { context process }
     method visitSelf
         context receiver!
 
-    method visitSlotRef: name at: index
-        context slot: index!
+    method visitSlotRef: slotExpr
+        context slot: slotExpr index!
 
     method visitBindLexical: name value: value index: index body: body
         context

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -141,9 +141,10 @@ class AstInterpreter { context process }
     method visitReturn: returnExpr
         context returnBlock value: (returnExpr value visitBy: self)!
 
-    method visitSend: selector to: receiver with: arguments source: source
-        let object = receiver visitBy: self.
-        let arguments = arguments collect: { |arg| arg visitBy: self }.
+    method visitSend: sendExpr
+        let selector = sendExpr selector.
+        let object = sendExpr receiver visitBy: self.
+        let arguments = sendExpr arguments collect: { |arg| arg visitBy: self }.
         let $context = context.
         let $process = process.
         -- Debug println: "<- {selector}".
@@ -156,7 +157,7 @@ class AstInterpreter { context process }
                                     raise: selector
                                     with: arguments
                                     on: object
-                                    source: source }} !
+                                    source: sendExpr source }} !
 
     method visitComment: comment value: value source: source
         value visitBy: self!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -180,8 +180,8 @@ class AstInterpreter { context process }
             inFrame: 1.
         bindExpr body visitBy: self!
 
-    method visitLexicalRef: name index: index frame: frame
-        context at: index inFrame: frame!
+    method visitLexicalRef: refExpr
+        context at: refExpr index inFrame: refExpr frame!
 
 
     method visitLexicalSet: name value: value index: index frame: frame

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -131,8 +131,8 @@ class AstInterpreter { context process }
     method visitGlobal: global
         global value!
 
-    method visitIsLeft: left right: right
-        (left visitBy: self) is (right visitBy: self)!
+    method visitIs: isExpr
+        (isExpr left visitBy: self) is (isExpr right visitBy: self)!
 
     method visitSeqFirst: first then: then
         first visitBy: self.

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -10,6 +10,6 @@ interface AstVisitor
     required method visitSelf
     required method visitSlotRef: slotExpr
     required method visitBindLexical: bindExpr
-    required method visitLexicalRef: name index: index frame: frame
+    required method visitLexicalRef: refExpr
     required method visitLexicalSet: name value: value index: index frame: frame
 end

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -1,8 +1,8 @@
 interface AstVisitor
-    required method visitConstant: constant
-    required method visitGlobal: global
+    required method visitConstant: constantExpr
+    required method visitGlobal: globalExpr
     required method visitIs: isExpr
-    required method visitSeqFirst: first then: then
+    required method visitSeq: seqExpr
     required method visitReturn: value
     required method visitSend: selector to: receiver with: arguments source: source
     required method visitComment: comment value: value source: source

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -7,7 +7,7 @@ interface AstVisitor
     required method visitSend: sendExpr
     required method visitComment: commentExpr
     required method visitBlock: blockExpr
-    required method visitSelf
+    required method visitSelf: selfExpr
     required method visitSlotRef: slotExpr
     required method visitBindLexical: bindExpr
     required method visitLexicalRef: refExpr

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -4,7 +4,7 @@ interface AstVisitor
     required method visitIs: isExpr
     required method visitSeq: seqExpr
     required method visitReturn: returnExpr
-    required method visitSend: selector to: receiver with: arguments source: source
+    required method visitSend: sendExpr
     required method visitComment: comment value: value source: source
     required method visitBlock: block
     required method visitSelf

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -3,7 +3,7 @@ interface AstVisitor
     required method visitGlobal: globalExpr
     required method visitIs: isExpr
     required method visitSeq: seqExpr
-    required method visitReturn: value
+    required method visitReturn: returnExpr
     required method visitSend: selector to: receiver with: arguments source: source
     required method visitComment: comment value: value source: source
     required method visitBlock: block

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -11,5 +11,5 @@ interface AstVisitor
     required method visitSlotRef: slotExpr
     required method visitBindLexical: bindExpr
     required method visitLexicalRef: refExpr
-    required method visitLexicalSet: name value: value index: index frame: frame
+    required method visitLexicalSet: setExpr
 end

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -1,15 +1,15 @@
 interface AstVisitor
-    required method visitConstant: constantExpr
-    required method visitGlobal: globalExpr
-    required method visitIs: isExpr
-    required method visitSeq: seqExpr
-    required method visitReturn: returnExpr
-    required method visitSend: sendExpr
-    required method visitComment: commentExpr
-    required method visitBlock: blockExpr
-    required method visitSelf: selfExpr
-    required method visitSlotRef: slotExpr
-    required method visitBindLexical: bindExpr
-    required method visitLexicalRef: refExpr
-    required method visitLexicalSet: setExpr
+    required method visitConstant: aConstant
+    required method visitGlobal: aGlobal
+    required method visitIs: anIs
+    required method visitSeq: aSeq
+    required method visitReturn: aReturn
+    required method visitSend: aSend
+    required method visitComment: aComment
+    required method visitBlock: aBlock
+    required method visitSelf: aSelf
+    required method visitSlotRef: aSlotRef
+    required method visitBindLexical: aBind
+    required method visitLexicalRef: aRef
+    required method visitLexicalSet: aSet
 end

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -1,5 +1,5 @@
 interface AstVisitor
-    required method visitConstant: value
+    required method visitConstant: constant
     required method visitGlobal: value
     required method visitIsLeft: left right: right
     required method visitSeqFirst: first then: then

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -1,6 +1,6 @@
 interface AstVisitor
     required method visitConstant: constant
-    required method visitGlobal: value
+    required method visitGlobal: global
     required method visitIsLeft: left right: right
     required method visitSeqFirst: first then: then
     required method visitReturn: value

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -5,7 +5,7 @@ interface AstVisitor
     required method visitSeq: seqExpr
     required method visitReturn: returnExpr
     required method visitSend: sendExpr
-    required method visitComment: comment value: value source: source
+    required method visitComment: commentExpr
     required method visitBlock: block
     required method visitSelf
     required method visitSlotRef: name at: index

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -6,9 +6,9 @@ interface AstVisitor
     required method visitReturn: returnExpr
     required method visitSend: sendExpr
     required method visitComment: commentExpr
-    required method visitBlock: block
+    required method visitBlock: blockExpr
     required method visitSelf
-    required method visitSlotRef: name at: index
+    required method visitSlotRef: slotExpr
     required method visitBindLexical: name value: value index: index body: body
     required method visitLexicalRef: name index: index frame: frame
     required method visitLexicalSet: name value: value index: index frame: frame

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -1,7 +1,7 @@
 interface AstVisitor
     required method visitConstant: constant
     required method visitGlobal: global
-    required method visitIsLeft: left right: right
+    required method visitIs: isExpr
     required method visitSeqFirst: first then: then
     required method visitReturn: value
     required method visitSend: selector to: receiver with: arguments source: source

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -9,7 +9,7 @@ interface AstVisitor
     required method visitBlock: blockExpr
     required method visitSelf
     required method visitSlotRef: slotExpr
-    required method visitBindLexical: name value: value index: index body: body
+    required method visitBindLexical: bindExpr
     required method visitLexicalRef: name index: index frame: frame
     required method visitLexicalSet: name value: value index: index frame: frame
 end

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -115,8 +115,9 @@ class CTranspiler { output selectorMap blockFunctions }
         bindExpr body visitBy: self.
         output print: "; })"!
 
-    method visitLexicalRef: name index: index frame: frame
-        output print: "foo_lexical_ref(context, {index-1}ul, {frame-1}ul)"!
+    method visitLexicalRef: refExpr
+        -- name index: index frame: frame
+        output print: "foo_lexical_ref(context, {refExpr index -1}ul, {refExpr frame - 1}ul)"!
 
     method visitBlock: block
         output print: "foo_block_new(context, ".

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -89,42 +89,42 @@ class CTranspiler { output selectorMap blockFunctions }
         blockFunctions put: output content at: index.
         cname!
 
-    method visitConstant: constant
-        let value = constant value.
+    method visitConstant: aConstant
+        let value = aConstant value.
         (Integer includes: value)
             ifTrue: { return output print: "foo_Integer_new({value})" }.
         Error raise: "Don't know how to transpile constant `{value}` into C."!
 
-    method visitSend: sendExpr
+    method visitSend: aSend
         output print: "foo_send(context, &".
-        output print: (self selectorCName: sendExpr selector).
+        output print: (self selectorCName: aSend selector).
         output print: ", ".
-        sendExpr receiver visitBy: self.
+        aSend receiver visitBy: self.
         output print: ", ".
-        output print: sendExpr arguments size.
+        output print: aSend arguments size.
         output print: "ul".
-        sendExpr arguments do: { |arg|
-                        output print: ", ".
-                        arg visitBy: self }.
+        aSend arguments
+            do: { |arg|
+                  output print: ", ".
+                  arg visitBy: self }.
         output print: ")"!
 
-    method visitBindLexical: bindExpr
-        output print: "(\{ context->frame[{bindExpr index - 1}ul] = ".
-        bindExpr value visitBy: self.
+    method visitBindLexical: aBind
+        output print: "(\{ context->frame[{aBind index - 1}ul] = ".
+        aBind value visitBy: self.
         output print: ";".
-        bindExpr body visitBy: self.
+        aBind body visitBy: self.
         output print: "; })"!
 
-    method visitLexicalRef: refExpr
-        -- name index: index frame: frame
-        output print: "foo_lexical_ref(context, {refExpr index -1}ul, {refExpr frame - 1}ul)"!
+    method visitLexicalRef: aRef
+        output print: "foo_lexical_ref(context, {aRef index -1}ul, {aRef frame - 1}ul)"!
 
-    method visitBlock: block
+    method visitBlock: aBlock
         output print: "foo_block_new(context, ".
-        output print: (self blockCName: block).
+        output print: (self blockCName: aBlock).
         output print: ", ".
-        output print: block argumentCount.
+        output print: aBlock argumentCount.
         output print: ", ".
-        output print: block frameSize.
+        output print: aBlock frameSize.
         output print: ")"!
 end

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -95,15 +95,15 @@ class CTranspiler { output selectorMap blockFunctions }
             ifTrue: { return output print: "foo_Integer_new({value})" }.
         Error raise: "Don't know how to transpile constant `{value}` into C."!
 
-    method visitSend: selector to: receiver with: arguments source: source
+    method visitSend: sendExpr
         output print: "foo_send(context, &".
-        output print: (self selectorCName: selector).
+        output print: (self selectorCName: sendExpr selector).
         output print: ", ".
-        receiver visitBy: self.
+        sendExpr receiver visitBy: self.
         output print: ", ".
-        output print: arguments size.
+        output print: sendExpr arguments size.
         output print: "ul".
-        arguments do: { |arg|
+        sendExpr arguments do: { |arg|
                         output print: ", ".
                         arg visitBy: self }.
         output print: ")"!

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -108,11 +108,11 @@ class CTranspiler { output selectorMap blockFunctions }
                         arg visitBy: self }.
         output print: ")"!
 
-    method visitBindLexical: name value: value index: index body: body
-        output print: "(\{ context->frame[{index-1}ul] = ".
-        value visitBy: self.
+    method visitBindLexical: bindExpr
+        output print: "(\{ context->frame[{bindExpr index - 1}ul] = ".
+        bindExpr value visitBy: self.
         output print: ";".
-        body visitBy: self.
+        bindExpr body visitBy: self.
         output print: "; })"!
 
     method visitLexicalRef: name index: index frame: frame

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -89,7 +89,8 @@ class CTranspiler { output selectorMap blockFunctions }
         blockFunctions put: output content at: index.
         cname!
 
-    method visitConstant: value
+    method visitConstant: constant
+        let value = constant value.
         (Integer includes: value)
             ifTrue: { return output print: "foo_Integer_new({value})" }.
         Error raise: "Don't know how to transpile constant `{value}` into C."!

--- a/foo/impl/foolang.foo
+++ b/foo/impl/foolang.foo
@@ -23,7 +23,6 @@ class Tests { system ok }
     method run
         self
             ; test: #testTranspile
-            ---
             ; test: #test42
             ; test: #testPlus
             ; test: #testPrecedence
@@ -51,7 +50,6 @@ class Tests { system ok }
             ; test: #testAstSource
             ; test: #testOutOfOrderDefine
             ; test: #testOutOfOrderClasses
-            ---
                .
         self!
 

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -195,14 +195,16 @@ class TokenReservedSigilOpenBrace { first last }
     is ReservedToken
 
     method parseAsPrefixWith: parser atPrecedence: _precedence
-        let arguments = List new.
+        let parameters = List new.
         parser
             when: "|"
             then: { parser until: "|"
-                           do: { arguments add: (parser parseVariableName) } }.
+                           do: { parameters add: (parser parseVariableName) } }.
         let body = parser parseAtPrecedence: SeqPrecedence.
         parser expect: "}".
-        SyntaxBlock arguments: arguments body: body!
+        SyntaxBlock
+            parameters: parameters
+            body: body!
 
     method string
         "\{"!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -124,8 +124,7 @@ class SyntaxIs { left right }
     is Syntax
 
     method visitBy: visitor
-        visitor visitIsLeft: left
-                right: right!
+        visitor visitIs: self!
 
     method parts
         [left, right]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -26,7 +26,7 @@ class SyntaxLiteral { value }
     is Syntax
 
     method visitBy: visitor
-        visitor visitLiteral: value!
+        visitor visitLiteral: self!
 
     method parts
         [value]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -78,9 +78,7 @@ class SyntaxPrefix { receiver selector source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitPrefixMessage: selector
-                receiver: receiver
-                source: source!
+        visitor visitPrefixMessage: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -164,7 +164,7 @@ class SyntaxAssign { variable::String value }
     is Syntax
 
     method visitBy: visitor
-        visitor visitAssign: value to: variable!
+        visitor visitAssign: self!
 
     method parts
         [variable, value]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -89,9 +89,7 @@ class SyntaxUnary { receiver selector source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitUnaryMessage: selector
-                receiver: receiver
-                source: source!
+        visitor visitUnaryMessage: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -144,7 +144,7 @@ class SyntaxSelf {}
     is Syntax
 
     method visitBy: visitor
-        visitor visitSelf!
+        visitor visitSelf: self!
 
     method parts
         []!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -154,7 +154,7 @@ class SyntaxVariable { name::String }
     is Syntax
 
     method visitBy: visitor
-        visitor visitVariable: name!
+        visitor visitVariable: self!
 
     method parts
         [name]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -145,9 +145,7 @@ class SyntaxLet { name value body }
     is Syntax
 
     method visitBy: visitor
-        visitor visitLet: name
-                value: value
-                body: body!
+        visitor visitLet: self!
 
     method parts
         [value, name, body]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -46,7 +46,7 @@ class SyntaxReturn { value }
     is Syntax
 
     method visitBy: visitor
-        visitor visitReturn: value!
+        visitor visitReturn: self!
 
     method parts
         [value]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -56,9 +56,7 @@ class SyntaxPrefixComment { comment value source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitPrefixComment: self comment
-                value: self value
-                source: self source!
+        visitor visitPrefixComment: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -204,9 +204,7 @@ class SyntaxMethod { signature body }
     is Syntax
 
     method visitBy: visitor
-        visitor
-            visitMethodDefinition: signature
-            body: body!
+        visitor visitMethod: self!
 
     method selector
         signature selector!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -224,10 +224,7 @@ class SyntaxClass { name directMethods slots methods }
     is Syntax
 
     method visitBy: visitor
-        visitor visitClassDefinition: name
-                directMethods: directMethods
-                slots: slots
-                methods: methods!
+        visitor visitClass: self!
 
     method parts
         [name, directMethods, slots, methods]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -113,10 +113,7 @@ class SyntaxKeyword { receiver selector arguments source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitKeywordMessage: selector
-                receiver: receiver
-                arguments: arguments
-                source: source!
+        visitor visitKeywordMessage: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -67,9 +67,7 @@ class SyntaxSuffixComment { comment value source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitSuffixComment: self comment
-                value: self value
-                source: self source!
+        visitor visitSuffixComment: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -194,7 +194,7 @@ class SyntaxDefine { name body }
     is Syntax
 
     method visitBy: visitor
-        visitor visitDefine: name body: body!
+        visitor visitDefine: self!
 
     method parts
         [name, body]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -180,14 +180,14 @@ class SyntaxParens { body }
         [body]!
 end
 
-class SyntaxBlock { arguments body }
+class SyntaxBlock { parameters body }
     is Syntax
 
     method visitBy: visitor
-        visitor visitBlockWith: arguments body: body!
+        visitor visitBlock: self!
 
     method parts
-        [arguments, body]!
+        [parameters, body]!
 end
 
 class SyntaxDefine { name body }

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -174,7 +174,7 @@ class SyntaxParens { body }
     is Syntax
 
     method visitBy: visitor
-        visitor visitParens: body!
+        visitor visitParens: self!
 
     method parts
         [body]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -100,10 +100,7 @@ class SyntaxBinary { receiver selector argument source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitBinaryMessage: selector
-                receiver: receiver
-                argument: argument
-                source: source!
+        visitor visitBinaryMessage: self!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -36,7 +36,7 @@ class SyntaxSeq { first then }
     is Syntax
 
     method visitBy: visitor
-        visitor visitSeqFirst: first then: then!
+        visitor visitSeq: self!
 
     method parts
         [first, then]!

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -48,11 +48,11 @@ class SyntaxPrinter { output indent printed blockStart }
     method visitLiteral: aLiteral
         self print: aLiteral value toString!
 
-    method visitSeqFirst: first then: then
+    method visitSeq: aSeq
         self handleBlockStart.
-        first visitBy: self.
+        aSeq first visitBy: self.
         self println: ".".
-        then visitBy: self!
+        aSeq then visitBy: self!
 
     method visitReturn: value
         self print: "return ".

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -101,14 +101,14 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: " is ".
         right visitBy: self!
 
-    method visitLet: name value: value body: body
+    method visitLet: aLet
         self handleBlockStart.
         self print: "let ".
-        self print: name.
+        self print: aLet name.
         self print: " = ".
-        value visitBy: self.
+        aLet value visitBy: self.
         self println: ".".
-        body visitBy: self!
+        aLet body visitBy: self!
 
     method visitSelf
         self print: "self"!

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -110,7 +110,7 @@ class SyntaxPrinter { output indent printed blockStart }
         self println: ".".
         aLet body visitBy: self!
 
-    method visitSelf
+    method visitSelf: aSelf
         self print: "self"!
 
     method visitVariable: name

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -162,23 +162,27 @@ class SyntaxPrinter { output indent printed blockStart }
         aMethod body visitBy: bodyVisitor.
         self print: "!"!
 
-    method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods
+    method visitClass: aClass
         self print: "class ".
-        self print: name.
+        self print: aClass name.
         self print: " \{".
-        slots ifNotEmpty: { self print: " ".
-                            slots do: { |slot|
-                                        self print: slot.
-                                        self print: " " } }.
+        aClass slots
+            ifNotEmpty: { self print: " ".
+                          aClass slots
+                              do: { |slot|
+                                    self print: slot.
+                                    self print: " " }}.
         self print: "}".
         let methodVisitor = self indentBody.
-        directMethods do: { |m|
-                            methodVisitor println: "".
-                            methodVisitor print: "direct ".
-                            m visitBy: methodVisitor }.
-        methods do: { |m|
-                      methodVisitor println: "".
-                      m visitBy: methodVisitor }.
+        aClass directMethods
+            do: { |m|
+                  methodVisitor println: "".
+                  methodVisitor print: "direct ".
+                  m visitBy: methodVisitor }.
+        aClass methods
+            do: { |m|
+                  methodVisitor println: "".
+                  m visitBy: methodVisitor }.
         self println: "".
         self println: "end"!
 end

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -45,8 +45,8 @@ class SyntaxPrinter { output indent printed blockStart }
             ifTrue: { self println: "".
                       blockStart = False }!
 
-    method visitLiteral: value
-        self print: value toString!
+    method visitLiteral: aLiteral
+        self print: aLiteral value toString!
 
     method visitSeqFirst: first then: then
         self handleBlockStart.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -54,9 +54,9 @@ class SyntaxPrinter { output indent printed blockStart }
         self println: ".".
         aSeq then visitBy: self!
 
-    method visitReturn: value
+    method visitReturn: aReturn
         self print: "return ".
-        value visitBy: self!
+        aReturn value visitBy: self!
 
     method visitPrefixComment: comment value: value source: source
         self handleBlockStart.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -86,10 +86,10 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: " ".
         aMessage argument visitBy: self!
 
-    method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
-        receiver visitBy: self.
-        selector parts
-            with: arguments
+    method visitKeywordMessage: aMessage
+        aMessage receiver visitBy: self.
+        aMessage selector parts
+            with: aMessage arguments
             do: { |part arg|
                   self print: " ".
                   self print: part.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -145,20 +145,21 @@ class SyntaxPrinter { output indent printed blockStart }
         aDefine body visitBy: bodyVisitor.
         self println: "!"!
 
-    method visitMethodDefinition: signature body: body
+    method visitMethod: aMethod
         self print: "method".
+        let signature = aMethod signature.
         signature parameters isEmpty
             ifTrue: { self print: " ".
                       self print: signature selector name }
             ifFalse: { signature selector parts
                            withIndexDo: { |part index|
-                                 self print: " ".
-                                 self print: part.
-                                 self print: " ".
+                                          self print: " ".
+                                          self print: part.
+                                          self print: " ".
                                           self print: (signature parameters at: index) } }.
         let bodyVisitor = self indentBody.
         bodyVisitor println: "".
-        body visitBy: bodyVisitor.
+        aMethod body visitBy: bodyVisitor.
         self print: "!"!
 
     method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -58,11 +58,11 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: "return ".
         aReturn value visitBy: self!
 
-    method visitPrefixComment: comment value: value source: source
+    method visitPrefixComment: aComment
         self handleBlockStart.
         self print: "--".
-        self println: comment.
-        value visitBy: self indentBody!
+        self println: aComment comment.
+        aComment value visitBy: self indentBody!
 
     method visitSuffixComment: comment value: value source: source
         self handleBlockStart.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -64,11 +64,11 @@ class SyntaxPrinter { output indent printed blockStart }
         self println: aComment comment.
         aComment value visitBy: self indentBody!
 
-    method visitSuffixComment: comment value: value source: source
+    method visitSuffixComment: aComment
         self handleBlockStart.
-        value visitBy: self.
+        aComment value visitBy: self.
         self print: " --".
-        self println: comment!
+        self println: aComment comment!
 
     method visitPrefixMessage: selector receiver: receiver source: source
         self print: selector name.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -116,10 +116,10 @@ class SyntaxPrinter { output indent printed blockStart }
     method visitVariable: aVariable
         self print: aVariable name!
 
-    method visitAssign: value to: variable
-        self print: variable name.
+    method visitAssign: anAssign
+        self print: anAssign variable name.
         self print: " = ".
-        value visitBy: self!
+        anAssign value visitBy: self!
 
     method visitParens: body
         self print: "(".

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -70,9 +70,9 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: " --".
         self println: aComment comment!
 
-    method visitPrefixMessage: selector receiver: receiver source: source
-        self print: selector name.
-        receiver visitBy: self!
+    method visitPrefixMessage: aMessage
+        self print: aMessage selector name.
+        aMessage receiver visitBy: self!
 
     method visitUnaryMessage: selector receiver: receiver source: source
         receiver visitBy: self.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -74,10 +74,10 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: aMessage selector name.
         aMessage receiver visitBy: self!
 
-    method visitUnaryMessage: selector receiver: receiver source: source
-        receiver visitBy: self.
+    method visitUnaryMessage: aMessage
+        aMessage receiver visitBy: self.
         self print: " ".
-        self print: selector name!
+        self print: aMessage selector name!
 
     method visitBinaryMessage: selector receiver: receiver argument: argument source: source
         receiver visitBy: self.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -96,10 +96,10 @@ class SyntaxPrinter { output indent printed blockStart }
                   self print: " ".
                   arg visitBy: self }!
 
-    method visitIsLeft: left right: right
-        left visitBy: self.
+    method visitIs: anIs
+        anIs left visitBy: self.
         self print: " is ".
-        right visitBy: self!
+        anIs right visitBy: self!
 
     method visitLet: aLet
         self handleBlockStart.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -121,9 +121,9 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: " = ".
         anAssign value visitBy: self!
 
-    method visitParens: body
+    method visitParens: aParens
         self print: "(".
-        body visitBy: self indentHere.
+        aParens body visitBy: self indentHere.
         self print: ")"!
 
     method visitBlockWith: parameters body: body

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -126,15 +126,16 @@ class SyntaxPrinter { output indent printed blockStart }
         aParens body visitBy: self indentHere.
         self print: ")"!
 
-    method visitBlockWith: parameters body: body
+    method visitBlock: aBlock
         self print: "\{ ".
         let bodyPrinter = self indentBlock.
-        parameters
+        aBlock parameters
             ifNotEmpty: { self print: "|".
-                          parameters do: { |param| self print: param }
-                                     interleaving: { self print: " " }.
+                          aBlock parameters
+                              do: { |param| self print: param }
+                              interleaving: { self print: " " }.
                           self print: "| " }.
-        body visitBy: bodyPrinter.
+        aBlock body visitBy: bodyPrinter.
         self print: " }"!
 
     method visitDefine: name body: body

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -138,11 +138,11 @@ class SyntaxPrinter { output indent printed blockStart }
         aBlock body visitBy: bodyPrinter.
         self print: " }"!
 
-    method visitDefine: name body: body
+    method visitDefine: aDefine
         self print: "define ".
         let bodyVisitor = self indentBody.
-        bodyVisitor println: name.
-        body visitBy: bodyVisitor.
+        bodyVisitor println: aDefine name.
+        aDefine body visitBy: bodyVisitor.
         self println: "!"!
 
     method visitMethodDefinition: signature body: body

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -113,8 +113,8 @@ class SyntaxPrinter { output indent printed blockStart }
     method visitSelf: aSelf
         self print: "self"!
 
-    method visitVariable: name
-        self print: name!
+    method visitVariable: aVariable
+        self print: aVariable name!
 
     method visitAssign: value to: variable
         self print: variable name.

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -79,12 +79,12 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: " ".
         self print: aMessage selector name!
 
-    method visitBinaryMessage: selector receiver: receiver argument: argument source: source
-        receiver visitBy: self.
+    method visitBinaryMessage: aMessage
+        aMessage receiver visitBy: self.
         self print: " ".
-        self print: selector name.
+        self print: aMessage selector name.
         self print: " ".
-        argument visitBy: self!
+        aMessage argument visitBy: self!
 
     method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
         receiver visitBy: self.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -79,8 +79,8 @@ class SyntaxTranslator { env }
     method visitSelf: aSelf
         AstSelfRef new!
 
-    method visitVariable: name
-        env reference: name!
+    method visitVariable: aVariable
+        env reference: aVariable name!
 
     method visitAssign: value to: variable
         let binding = env reference: variable name.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -11,9 +11,8 @@ class SyntaxTranslator { env }
     method addVariable: name
         SyntaxTranslator env: (env addVariable: name)!
 
-    method visitLiteral: value
-        AstConstantRef
-            value: value!
+    method visitLiteral: aLiteral
+        AstConstantRef value: aLiteral value!
 
     method visitSeqFirst: first then: then
         -- FIXME: Would be nicer to flatten this out.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -116,13 +116,13 @@ class SyntaxTranslator { env }
             body: (aMethod body visitBy: (SyntaxTranslator env: bodyEnv))
             frameSize: bodyEnv allocation size!
 
-    method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods
-        let astDirectMethods = directMethods collect: { |m| m visitBy: self }.
-        let instanceMethodVisitor = SyntaxTranslator env: (env addSlots: slots).
-        let astMethods = methods collect: { |m| m visitBy: instanceMethodVisitor }.
+    method visitClass: aClass
+        let instanceMethodVisitor = SyntaxTranslator env: (env addSlots: aClass slots).
         AstClass
-            name: name
-            directMethods: astDirectMethods
-            slots: slots
-            methods: astMethods!
+            name: aClass name
+            directMethods: (aClass directMethods
+                                collect: { |m| m visitBy: self })
+            slots: aClass slots
+            methods: (aClass methods
+                          collect: { |m| m visitBy: instanceMethodVisitor })!
 end

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -35,13 +35,13 @@ class SyntaxTranslator { env }
             value: (aComment value visitBy: self)
             source: aComment source!
 
-    method visitLet: name value: value body: body
-        let bodyVisitor = self addVariable: name.
+    method visitLet: aLet
+        let bodyVisitor = self addVariable: aLet name.
         AstBindLexical
-            name: name
+            name: aLet name
             index: bodyVisitor env allocation index
-            value: (value visitBy: self)
-            body: (body visitBy: bodyVisitor)!
+            value: (aLet value visitBy: self)
+            body: (aLet body visitBy: bodyVisitor)!
 
     method visitPrefixMessage: selector receiver: receiver source: source
         AstSend receiver: (receiver visitBy: self)

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -76,7 +76,7 @@ class SyntaxTranslator { env }
             left: (anIs left visitBy: self)
             right: (anIs right visitBy: self)!
 
-    method visitSelf
+    method visitSelf: aSelf
         AstSelfRef new!
 
     method visitVariable: name

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -90,8 +90,8 @@ class SyntaxTranslator { env }
             index: binding index :: Integer
             value: (anAssign value visitBy: self)!
 
-    method visitParens: body
-        body visitBy: self!
+    method visitParens: aParens
+        aParens body visitBy: self!
 
     method visitBlockWith: parameters body: body
         let bodyEnv = env newFrame addVariables: parameters.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -43,11 +43,12 @@ class SyntaxTranslator { env }
             value: (aLet value visitBy: self)
             body: (aLet body visitBy: bodyVisitor)!
 
-    method visitPrefixMessage: selector receiver: receiver source: source
-        AstSend receiver: (receiver visitBy: self)
-                selector: (Selector name: "prefix{selector name}")
-                arguments: []
-                source: source!
+    method visitPrefixMessage: aMessage
+        AstSend
+            receiver: (aMessage receiver visitBy: self)
+            selector: (Selector name: "prefix{aMessage selector name}")
+            arguments: []
+            source: aMessage source!
 
     method visitUnaryMessage: selector receiver: receiver source: source
         AstSend receiver: (receiver visitBy: self)

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -23,10 +23,11 @@ class SyntaxTranslator { env }
     method visitReturn: aReturn
         AstReturn value: (aReturn value visitBy: self)!
 
-    method visitPrefixComment: comment value: value source: source
-        AstComment comment: comment
-                   value: (value visitBy: self)
-                   source: source!
+    method visitPrefixComment: aComment
+        AstComment
+            comment: aComment comment
+            value: (aComment value visitBy: self)
+            source: aComment source!
 
     method visitSuffixComment: comment value: value source: source
         AstComment comment: comment

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -64,12 +64,12 @@ class SyntaxTranslator { env }
             arguments: [aMessage argument visitBy: self]
             source: aMessage source!
 
-    method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
-        AstSend receiver: (receiver visitBy: self)
-                selector: selector
-                arguments: (arguments
-                                collect: { |arg|  arg visitBy: self })
-                source: source!
+    method visitKeywordMessage: aMessage
+        AstSend
+            receiver: (aMessage receiver visitBy: self)
+            selector: aMessage selector
+            arguments: (aMessage arguments collect: { |arg| arg visitBy: self })
+            source: aMessage source!
 
     method visitIsLeft: left right: right
         AstIs left: (left visitBy: self)

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -100,12 +100,12 @@ class SyntaxTranslator { env }
             argumentCount: aBlock parameters size
             frameSize: aBlock parameters size + bodyEnv allocation size!
 
-    method visitDefine: name body: body
-        -- FIXME: Is this right?? Should body not gets an environment of its own?
+    method visitDefine: aDefine
+        let bodyVisitor = SyntaxTranslator env: env newFrame.
         AstDefine
-            name: name
-            body: (body visitBy: self)
-            frameSize: env allocation size!
+            name: aDefine name
+            body: (aDefine body visitBy: bodyVisitor)
+            frameSize: bodyVisitor env allocation size!
 
     method visitMethodDefinition: signature body: body
         let bodyEnv = env newFrame addVariables: signature parameters.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -29,10 +29,11 @@ class SyntaxTranslator { env }
             value: (aComment value visitBy: self)
             source: aComment source!
 
-    method visitSuffixComment: comment value: value source: source
-        AstComment comment: comment
-                   value: (value visitBy: self)
-                   source: source!
+    method visitSuffixComment: aComment
+        AstComment
+            comment: aComment comment
+            value: (aComment value visitBy: self)
+            source: aComment source!
 
     method visitLet: name value: value body: body
         let bodyVisitor = self addVariable: name.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -50,11 +50,11 @@ class SyntaxTranslator { env }
             arguments: []
             source: aMessage source!
 
-    method visitUnaryMessage: selector receiver: receiver source: source
-        AstSend receiver: (receiver visitBy: self)
-                selector: selector
+    method visitUnaryMessage: aMessage
+        AstSend receiver: (aMessage receiver visitBy: self)
+                selector: aMessage selector
                 arguments: []
-                source: source!
+                source: aMessage source!
 
     method visitBinaryMessage: selector receiver: receiver argument: argument source: source
         AstSend receiver: (receiver visitBy: self)

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -51,16 +51,18 @@ class SyntaxTranslator { env }
             source: aMessage source!
 
     method visitUnaryMessage: aMessage
-        AstSend receiver: (aMessage receiver visitBy: self)
-                selector: aMessage selector
-                arguments: []
-                source: aMessage source!
+        AstSend
+            receiver: (aMessage receiver visitBy: self)
+            selector: aMessage selector
+            arguments: []
+            source: aMessage source!
 
-    method visitBinaryMessage: selector receiver: receiver argument: argument source: source
-        AstSend receiver: (receiver visitBy: self)
-                selector: selector
-                arguments: [argument visitBy: self]
-                source: source!
+    method visitBinaryMessage: aMessage
+        AstSend
+            receiver: (aMessage receiver visitBy: self)
+            selector: aMessage selector
+            arguments: [aMessage argument visitBy: self]
+            source: aMessage source!
 
     method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
         AstSend receiver: (receiver visitBy: self)

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -20,9 +20,8 @@ class SyntaxTranslator { env }
             first: (aSeq first visitBy: self)
             then: (aSeq then visitBy: self)!
 
-    method visitReturn: syntax
-        AstReturn
-            value: (syntax visitBy: self)!
+    method visitReturn: aReturn
+        AstReturn value: (aReturn value visitBy: self)!
 
     method visitPrefixComment: comment value: value source: source
         AstComment comment: comment

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -107,12 +107,13 @@ class SyntaxTranslator { env }
             body: (aDefine body visitBy: bodyVisitor)
             frameSize: bodyVisitor env allocation size!
 
-    method visitMethodDefinition: signature body: body
+    method visitMethod: aMethod
+        let signature = aMethod signature.
         let bodyEnv = env newFrame addVariables: signature parameters.
         AstMethod
-            selector: signature selector name
+            selector: signature selector name -- FIXME: should pass in whole selector
             argumentCount: signature parameters size
-            body: (body visitBy: (SyntaxTranslator env: bodyEnv))
+            body: (aMethod body visitBy: (SyntaxTranslator env: bodyEnv))
             frameSize: bodyEnv allocation size!
 
     method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -93,12 +93,12 @@ class SyntaxTranslator { env }
     method visitParens: aParens
         aParens body visitBy: self!
 
-    method visitBlockWith: parameters body: body
-        let bodyEnv = env newFrame addVariables: parameters.
+    method visitBlock: aBlock
+        let bodyEnv = env newFrame addVariables: aBlock parameters.
         AstBlock
-            body: (body visitBy: (SyntaxTranslator env: bodyEnv))
-            argumentCount: parameters size
-            frameSize: parameters size + bodyEnv allocation size!
+            body: (aBlock body visitBy: (SyntaxTranslator env: bodyEnv))
+            argumentCount: aBlock parameters size
+            frameSize: aBlock parameters size + bodyEnv allocation size!
 
     method visitDefine: name body: body
         -- FIXME: Is this right?? Should body not gets an environment of its own?

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -71,9 +71,10 @@ class SyntaxTranslator { env }
             arguments: (aMessage arguments collect: { |arg| arg visitBy: self })
             source: aMessage source!
 
-    method visitIsLeft: left right: right
-        AstIs left: (left visitBy: self)
-              right: (right visitBy: self)!
+    method visitIs: anIs
+        AstIs
+            left: (anIs left visitBy: self)
+            right: (anIs right visitBy: self)!
 
     method visitSelf
         AstSelfRef new!

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -14,11 +14,11 @@ class SyntaxTranslator { env }
     method visitLiteral: aLiteral
         AstConstantRef value: aLiteral value!
 
-    method visitSeqFirst: first then: then
+    method visitSeq: aSeq
         -- FIXME: Would be nicer to flatten this out.
         AstSeq
-            first: (first visitBy: self)
-            then: (then visitBy: self)!
+            first: (aSeq first visitBy: self)
+            then: (aSeq then visitBy: self)!
 
     method visitReturn: syntax
         AstReturn

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -82,13 +82,13 @@ class SyntaxTranslator { env }
     method visitVariable: aVariable
         env reference: aVariable name!
 
-    method visitAssign: value to: variable
-        let binding = env reference: variable name.
+    method visitAssign: anAssign
+        let binding = env reference: anAssign variable name.
         AstLexicalSet
-            name: variable name
+            name: anAssign variable name
             frame: binding frame :: Integer
             index: binding index :: Integer
-            value: (value visitBy: self)!
+            value: (anAssign value visitBy: self)!
 
     method visitParens: body
         body visitBy: self!

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -18,6 +18,6 @@ interface SyntaxVisitor
     required method visitBlock: aBlock
     required method visitDefine: aDefine
     required method visitMethod: aMethod
-    required method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods
+    required method visitClass: aClass
 end
 

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -9,7 +9,7 @@ interface SyntaxVisitor
     required method visitPrefixMessage: aMessage
     required method visitUnaryMessage: aMessage
     required method visitBinaryMessage: aMessage
-    required method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
+    required method visitKeywordMessage: aMessage
     required method visitIsLeft: left right: right
     required method visitSelf
     required method visitVariable: name

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -13,7 +13,7 @@ interface SyntaxVisitor
     required method visitIs: anIs
     required method visitSelf: aSelf
     required method visitVariable: aVariable
-    required method visitAssign: value to: variable
+    required method visitAssign: anAssign
     required method visitParens: body
     required method visitBlockWith: parameters body: body
     required method visitDefine: name body: body

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -14,7 +14,7 @@ interface SyntaxVisitor
     required method visitSelf: aSelf
     required method visitVariable: aVariable
     required method visitAssign: anAssign
-    required method visitParens: body
+    required method visitParens: aParens
     required method visitBlockWith: parameters body: body
     required method visitDefine: name body: body
     required method visitMethodDefinition: signature body: body

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -15,7 +15,7 @@ interface SyntaxVisitor
     required method visitVariable: aVariable
     required method visitAssign: anAssign
     required method visitParens: aParens
-    required method visitBlockWith: parameters body: body
+    required method visitBlock: aBlock
     required method visitDefine: name body: body
     required method visitMethodDefinition: signature body: body
     required method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -6,7 +6,7 @@ interface SyntaxVisitor
     required method visitPrefixComment: aComment
     required method visitSuffixComment: aComment
     required method visitLet: aLet
-    required method visitPrefixMessage: selector receiver: receiver source: source
+    required method visitPrefixMessage: aMessage
     required method visitUnaryMessage: selector receiver: receiver source: source
     required method visitBinaryMessage: selector receiver: receiver argument: argument source: source
     required method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -1,6 +1,6 @@
 interface SyntaxVisitor
     is Object
-    required method visitLiteral: value
+    required method visitLiteral: aLiteral
     required method visitSeqFirst: first then: then
     required method visitReturn: syntax
     required method visitPrefixComment: comment value: value source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -5,7 +5,7 @@ interface SyntaxVisitor
     required method visitReturn: aReturn
     required method visitPrefixComment: aComment
     required method visitSuffixComment: aComment
-    required method visitLet: name value: value body: body
+    required method visitLet: aLet
     required method visitPrefixMessage: selector receiver: receiver source: source
     required method visitUnaryMessage: selector receiver: receiver source: source
     required method visitBinaryMessage: selector receiver: receiver argument: argument source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -4,7 +4,7 @@ interface SyntaxVisitor
     required method visitSeq: aSeq
     required method visitReturn: aReturn
     required method visitPrefixComment: aComment
-    required method visitSuffixComment: comment value: value source: source
+    required method visitSuffixComment: aComment
     required method visitLet: name value: value body: body
     required method visitPrefixMessage: selector receiver: receiver source: source
     required method visitUnaryMessage: selector receiver: receiver source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -8,7 +8,7 @@ interface SyntaxVisitor
     required method visitLet: aLet
     required method visitPrefixMessage: aMessage
     required method visitUnaryMessage: aMessage
-    required method visitBinaryMessage: selector receiver: receiver argument: argument source: source
+    required method visitBinaryMessage: aMessage
     required method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
     required method visitIsLeft: left right: right
     required method visitSelf

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -16,7 +16,7 @@ interface SyntaxVisitor
     required method visitAssign: anAssign
     required method visitParens: aParens
     required method visitBlock: aBlock
-    required method visitDefine: name body: body
+    required method visitDefine: aDefine
     required method visitMethodDefinition: signature body: body
     required method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods
 end

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -17,7 +17,7 @@ interface SyntaxVisitor
     required method visitParens: aParens
     required method visitBlock: aBlock
     required method visitDefine: aDefine
-    required method visitMethodDefinition: signature body: body
+    required method visitMethod: aMethod
     required method visitClassDefinition: name directMethods: directMethods slots: slots methods: methods
 end
 

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -2,7 +2,7 @@ interface SyntaxVisitor
     is Object
     required method visitLiteral: aLiteral
     required method visitSeq: aSeq
-    required method visitReturn: syntax
+    required method visitReturn: aReturn
     required method visitPrefixComment: comment value: value source: source
     required method visitSuffixComment: comment value: value source: source
     required method visitLet: name value: value body: body

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -1,7 +1,7 @@
 interface SyntaxVisitor
     is Object
     required method visitLiteral: aLiteral
-    required method visitSeqFirst: first then: then
+    required method visitSeq: aSeq
     required method visitReturn: syntax
     required method visitPrefixComment: comment value: value source: source
     required method visitSuffixComment: comment value: value source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -3,7 +3,7 @@ interface SyntaxVisitor
     required method visitLiteral: aLiteral
     required method visitSeq: aSeq
     required method visitReturn: aReturn
-    required method visitPrefixComment: comment value: value source: source
+    required method visitPrefixComment: aComment
     required method visitSuffixComment: comment value: value source: source
     required method visitLet: name value: value body: body
     required method visitPrefixMessage: selector receiver: receiver source: source

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -7,7 +7,7 @@ interface SyntaxVisitor
     required method visitSuffixComment: aComment
     required method visitLet: aLet
     required method visitPrefixMessage: aMessage
-    required method visitUnaryMessage: selector receiver: receiver source: source
+    required method visitUnaryMessage: aMessage
     required method visitBinaryMessage: selector receiver: receiver argument: argument source: source
     required method visitKeywordMessage: selector receiver: receiver arguments: arguments source: source
     required method visitIsLeft: left right: right

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -12,7 +12,7 @@ interface SyntaxVisitor
     required method visitKeywordMessage: aMessage
     required method visitIs: anIs
     required method visitSelf: aSelf
-    required method visitVariable: name
+    required method visitVariable: aVariable
     required method visitAssign: value to: variable
     required method visitParens: body
     required method visitBlockWith: parameters body: body

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -10,7 +10,7 @@ interface SyntaxVisitor
     required method visitUnaryMessage: aMessage
     required method visitBinaryMessage: aMessage
     required method visitKeywordMessage: aMessage
-    required method visitIsLeft: left right: right
+    required method visitIs: anIs
     required method visitSelf
     required method visitVariable: name
     required method visitAssign: value to: variable

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -11,7 +11,7 @@ interface SyntaxVisitor
     required method visitBinaryMessage: aMessage
     required method visitKeywordMessage: aMessage
     required method visitIs: anIs
-    required method visitSelf
+    required method visitSelf: aSelf
     required method visitVariable: name
     required method visitAssign: value to: variable
     required method visitParens: body

--- a/foo/impl/undefinedPolicy.foo
+++ b/foo/impl/undefinedPolicy.foo
@@ -57,5 +57,5 @@ class UndefinedPolicy {}
     direct method reference: name in: environment
         $UndefinedPolicy reference: name in: environment!
     direct method resolve: name
-        $UndefinedPolicy resolve: name in: environment!
+        $UndefinedPolicy resolve: name!
 end


### PR DESCRIPTION
- Receive the visited node directly instead of the parts. No idea why I did it the stupid way around at first.
- Use the Smalltalkish naming convention `aFoo` for the arguments. Not sure I like it everywhere, but works here.
