### PR TITLE
towards self-hosting: better handling of suffix comments

### DIFF
--- a/foo/impl/foolang.foo
+++ b/foo/impl/foolang.foo
@@ -2,6 +2,7 @@ import .environment.Environment
 import .parser.Parser
 import .utils.Debug
 import .syntaxTranslator.SyntaxTranslator
+import .syntaxPrinter.SyntaxPrinter
 import .cTranspiler.CTranspiler
 
 class Tests { system ok }
@@ -22,6 +23,15 @@ class Tests { system ok }
 
     method run
         self
+            ; test: #testComment1
+            ; test: #testComment2
+            ; test: #testComment3
+            ; test: #testComment4
+            ; test: #testComment5
+            ; test: #testComment6
+            ; test: #testComment7
+            ; test: #testComment8
+            -- ; test: #testComment9
             ; test: #testTranspile
             ; test: #test42
             ; test: #testPlus
@@ -47,7 +57,6 @@ class Tests { system ok }
             ; test: #testBlockInMethod
             ; test: #testDirectMethod
             ; test: #testReturn
-            ; test: #testComment
             ; test: #testAstSource
             ; test: #testOutOfOrderDefine
             ; test: #testOutOfOrderClasses
@@ -57,7 +66,7 @@ class Tests { system ok }
     method checkParse: source
         -- Check Syntax print/parse consistency.
         let syntaxList = Parser parse: source.
-         let output = StringOutput new.
+        let output = StringOutput new.
         syntaxList do: { |syntax|
                          -- Debug println: "".
                          -- SyntaxPrinter print: syntax to: Output debug.
@@ -67,9 +76,29 @@ class Tests { system ok }
             on: Error
             do: { |err|
                   panic "CST print/parse inconsistency!
-original: {source}
-printed: {printed}
+original:\n{source}
+printed:\n{printed}
 problem: {err description}" }!
+
+    method parse: source expect: pretty
+        -- Checks that parse pretty-prints as expected
+        let syntaxList1 = Parser parse: source.
+        let syntaxList2 = Parser parse: pretty.
+        { syntaxList1 checkEqual: syntaxList2 }
+            on: Error
+            do: { |err|
+                  Error raise: "parse inconsistent with desired pretty-print!
+source:\n{source}
+pretty:\n{pretty}
+problem: {err description}" }.
+        let output = StringOutput new.
+        syntaxList1 do: { |syntax| output print: syntax toString }.
+        let printed = output content.
+        printed == pretty
+            ifFalse: { Error raise: "print inconsistent with desired pretty-print!
+source:\n{source}
+printed:\n{printed}
+pretty:\n{pretty}" }!
 
     method eval: exprSource expect: expected
         self checkParse: exprSource.
@@ -233,23 +262,66 @@ with: {defSource}"!
                     end"
             eval: "ReturnTest test: True"
             expect: 42!
-    method testComment
-        self load: "class CommentTest1 \{}
-                       method foo
-                          let x = -- boop
-                                  21.
-                          x * 2!
-                    end"
-            eval: "CommentTest1 new foo"
-            expect: 42.
-        self load: "class CommentTest2 \{}
-                       method foo
-                          let x = 21 -- boop
-                          .
-                          x * 2!
-                    end"
-            eval: "CommentTest2 new foo"
-            expect: 42!
+
+    method testComment1
+        -- Prefix comment to let value
+        self
+            parse: "           let x = -- boop\n 21.     x     *  2"
+            expect: "let x = -- boop\n        21.\nx * 2"!
+
+    method testComment2
+        -- Suffix comment to let value
+        self
+            parse: "let x = 21 -- boop\n.\nx * 2"
+            expect: "let x = 21. -- boop\nx * 2".
+        self
+            parse: "let x = 21. -- boop\n\nx * 2"
+            expect: "let x = 21. -- boop\nx * 2"!
+
+    method testComment3
+        -- Prefix comment in sequence
+        self
+            parse: "    doo daa.\n    -- boop\n   self bar. \n x * 2"
+            expect: "doo daa.\n-- boop\nself bar.\nx * 2"!
+
+    method testComment4
+        -- Suffix comment in sequence
+        self
+            parse: "self bar. -- boop\n x * 2"
+            expect: "self bar. -- boop\nx * 2".
+        self
+            parse: "self bar -- boop\n. x * 2"
+            expect: "self bar. -- boop\nx * 2"!
+
+    method testComment5
+        -- Prefix comment to class
+        self
+            parse: "-- boop\n    class   X   \{}   end"
+            expect: "-- boop\nclass X \{}\nend\n"!
+
+    method testComment6
+        -- Suffix comment to class
+        self
+            parse: "class   X   \{}   end -- boop"
+            expect: "class X \{}\nend -- boop\n"!
+
+    method testComment7
+        -- Suffix comment to method signature == prefix comment to body
+        self
+            parse: "class   X   \{}method bar -- boop\n42!\nend"
+            expect: "class X \{}\n    method bar\n        -- boop\n        42!\nend\n"!
+
+    method testComment8
+        -- Suffix comment to method body
+        self
+            parse: "class X \{} method bar\n42! -- boop\nend"
+            expect: "class X \{}\n    method bar\n        42! -- boop\nend\n"!
+
+    method testComment9
+        -- Prefix comment to method (does not work currently!)
+        self
+            parse: "class X \{} -- boop\n method bar\n 42!\n end\n"
+            expect: "class X \{}\n    -- boop\n    method bar\n        42!\nend\n"!
 
     method testAstSource
         self load: "class SourceTest \{}

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -146,6 +146,16 @@ end
 class TokenReservedWordLet { first last }
     is ReservedToken
 
+    ---
+    Special casing for end of line comments after dot to
+    make the following a _suffix_ comment on `foo bar`:
+
+        let x = foo bar. -- comment
+        quux zot
+
+    The human expectation trumps consistency here.
+    ---
+
     method parseAsPrefixWith: parser atPrecedence: _precedence
         let name = parser parseVariableName.
         parser expect: "=".
@@ -153,7 +163,7 @@ class TokenReservedWordLet { first last }
         parser expect: ".".
         SyntaxLet
             name: name
-            value: value
+            value: (parser handleSuffixCommentOf: value)
             body: (parser parseAtPrecedence: SeqPrecedence)!
 
     method string
@@ -163,9 +173,19 @@ end
 class TokenReservedSigilDot { first last }
     is ReservedToken
 
+    ---
+    Special casing for end of line comments after dot to
+    make the following a _suffix_ comment on `foo bar`:
+
+        foo bar. -- comment
+        quux zot
+
+    The human expectation trumps consistency here.
+    ---
+
     method parseAsSuffixOf: prefix with: parser
         SyntaxSeq
-            first: prefix
+            first: (parser handleSuffixCommentOf: prefix)
             then: (parser parseAtPrecedence: SeqPrecedence)!
 
     method string
@@ -236,15 +256,16 @@ class TokenReservedSigilDoubledash { first last }
     is ReservedToken
 
     ---
-    FIXME: see below.
+    See also: special handlings in TokenReservedSigilDot and
+    TokenReservedSigilLet to parse
 
-    -- Prefix comments make sense
-    some expression.
+        foo bar. -- comment
+        quux zot
 
-    another expression. -- But what is intended as a suffix comment
-                        -- to `another expression` becomes a prefix
-                        -- comment to `next expression`!
-    next expression
+        let x = foo bar. -- comment
+        quux zot
+
+    as suffix comments on `foo bar`.
     ---
 
     method parseAsPrefixWith: parser atPrecedence: precedence
@@ -254,7 +275,14 @@ class TokenReservedSigilDoubledash { first last }
         --            -42 abs.
         --    123
         --
-        -- where the comment while parsing at SingleExpressionPrecedence!
+        -- where the comment is reached while parsing at SingleExpressionPrecedence,
+        -- versus:
+        --
+        --    foo bar.
+        --    -- comment
+        --    bar quux
+        --
+        -- where the comment is reached while parsing at SeqPrecedence!
         SyntaxPrefixComment
             comment: parser readline
             value: (parser parseAtPrecedence: precedence)
@@ -291,24 +319,36 @@ class TokenReservedWordClass { first last }
         let directMethods = List new.
         let methods = List new.
         parser until: "end"
-               do: { parser while: "direct"
-                            do: { parser expect: "method".
-                                  directMethods add: (self parseMethodWith: parser) }.
-                     parser while: "method"
-                            do: { methods add: (self parseMethodWith: parser) } }.
+               do: { self
+                         parseClassPartWith: parser
+                         directMethods: directMethods
+                         methods: methods }.
 
-        SyntaxClass
-            name: name
-            directMethods: directMethods
-            slots: slots
-            methods: methods!
+        let theClass = SyntaxClass
+                           name: name
+                           directMethods: directMethods
+                           slots: slots
+                           methods: methods.
+        parser handleSuffixCommentOf: theClass!
+
+    method parseClassPartWith: parser directMethods: directMethods methods: methods
+        -- FIXME: This should instead augment the syntax of the parser
+        -- with method and direct. That way we will get comments, etc right.
+        parser when: "direct"
+               then: { parser expect: "method".
+                       directMethods add: (self parseMethodWith: parser).
+                       return True }.
+        parser when: "method"
+               then: { methods add: (self parseMethodWith: parser).
+                       return True }.
+        Error raise: "Syntax error in class body: {parser nextToken string}"!
 
     method parseMethodWith: parser
         let syntax = SyntaxMethod
             signature: (self parseMethodSignatureWith: parser)
             body: (parser parseAtPrecedence: SeqPrecedence).
         parser expect: "!".
-        syntax!
+        parser handleSuffixCommentOf: syntax!
 
     method parseMethodSignatureWith: parser
         let selector = StringOutput new.
@@ -484,12 +524,21 @@ class Parser { source::String
         -- syntax do: { |s| Debug println: "=> {s}" }.
         syntax!
 
+    method handleSuffixCommentOf: prefix
+        -- #sees: means without intervening newline!
+        (self sees: "--")
+            ifTrue: { self nextToken
+                          parseAsSuffixOf: prefix
+                          with: self }
+            ifFalse: { prefix }!
+
     method readline
         let start = position.
         { self atEof or: self atNewline }
             whileFalse: { self advance }.
         let stop = position - 1.
-        self advance.
+        self atEof
+            ifFalse: { self advance }.
         source from: start to: stop!
 
     method sourceFrom: first to: last
@@ -509,6 +558,12 @@ class Parser { source::String
         got == expected
             ifFalse: { Error raise: "Self-hosted parser expected '{expected}', got '{got}'
 Context: {source}" }!
+
+    method sees: test
+        -- Cannot use lookahead since that would skip newlines!
+        self skipWhile: #atHorizontalWhitespace.
+        let last = (position + test size - 1) min: source size.
+        test == (source from: position to: last)!
 
     method when: test then: action
         self lookahead string == test
@@ -591,6 +646,9 @@ Context: {source}" }!
 
     method atNewline
         self isAt: #isNewline!
+
+    method atHorizontalWhitespace
+        self isAt: #isHorizontalWhitespace!
 
     method atSigil
         self atEof not

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -1,6 +1,6 @@
 import .syntaxVisitor.SyntaxVisitor
 
-class SyntaxPrinter { output indent printed blockStart }
+class SyntaxPrinter { output indent printed blockStart suffixComment }
     is SyntaxVisitor
 
     direct method print: syntax to: output
@@ -8,41 +8,54 @@ class SyntaxPrinter { output indent printed blockStart }
                              output: output
                              indent: 0
                              printed: 0
-                             blockStart: False)!
+                             blockStart: False
+                             suffixComment: False)!
 
     method indentBody
         SyntaxPrinter
             output: output
             indent: indent + 4
             printed: printed
-            blockStart: False!
+            blockStart: False
+            suffixComment: False!
 
     method indentHere
         SyntaxPrinter
             output: output
             indent: printed
             printed: printed
-            blockStart: False!
+            blockStart: False
+            suffixComment: False!
 
     method indentBlock
         SyntaxPrinter
             output: output
             indent: printed
             printed: printed
-            blockStart: True!
+            blockStart: True
+            suffixComment: False!
+
+    method newline
+        output println: "".
+        indent times: { output print: " " }.
+        printed = indent!
+
+    method handleSuffixComment
+        suffixComment is False
+            ifFalse: { self print: suffixComment.
+                       suffixComment = False }!
 
     method print: string::String
         output print: string.
         printed = printed + string size!
 
     method println: string::String
-        output println: string.
-        indent times: { output print: " " }.
-        printed = indent!
+        self print: string.
+        self newline!
 
     method handleBlockStart
         blockStart
-            ifTrue: { self println: "".
+            ifTrue: { self newline.
                       blockStart = False }!
 
     method visitLiteral: aLiteral
@@ -51,7 +64,9 @@ class SyntaxPrinter { output indent printed blockStart }
     method visitSeq: aSeq
         self handleBlockStart.
         aSeq first visitBy: self.
-        self println: ".".
+        self print: ".".
+        self handleSuffixComment.
+        self newline.
         aSeq then visitBy: self!
 
     method visitReturn: aReturn
@@ -60,15 +75,16 @@ class SyntaxPrinter { output indent printed blockStart }
 
     method visitPrefixComment: aComment
         self handleBlockStart.
-        self print: "--".
-        self println: aComment comment.
-        aComment value visitBy: self indentBody!
+        let valueVisitor = self indentHere.
+        self print: "--{aComment comment}".
+        valueVisitor newline.
+        aComment value visitBy: valueVisitor!
 
     method visitSuffixComment: aComment
         self handleBlockStart.
-        aComment value visitBy: self.
-        self print: " --".
-        self println: aComment comment!
+        suffixComment not assert.
+        suffixComment = " --{aComment comment}".
+        aComment value visitBy: self!
 
     method visitPrefixMessage: aMessage
         self print: aMessage selector name.
@@ -107,7 +123,9 @@ class SyntaxPrinter { output indent printed blockStart }
         self print: aLet name.
         self print: " = ".
         aLet value visitBy: self.
-        self println: ".".
+        self print: ".".
+        self handleSuffixComment.
+        self newline.
         aLet body visitBy: self!
 
     method visitSelf: aSelf
@@ -160,7 +178,9 @@ class SyntaxPrinter { output indent printed blockStart }
         let bodyVisitor = self indentBody.
         bodyVisitor println: "".
         aMethod body visitBy: bodyVisitor.
-        self print: "!"!
+        self print: "!".
+        -- no newline!
+        self handleSuffixComment!
 
     method visitClass: aClass
         self print: "class ".
@@ -176,13 +196,15 @@ class SyntaxPrinter { output indent printed blockStart }
         let methodVisitor = self indentBody.
         aClass directMethods
             do: { |m|
-                  methodVisitor println: "".
+                  methodVisitor newline.
                   methodVisitor print: "direct ".
                   m visitBy: methodVisitor }.
         aClass methods
             do: { |m|
-                  methodVisitor println: "".
+                  methodVisitor newline.
                   m visitBy: methodVisitor }.
-        self println: "".
-        self println: "end"!
+        self newline.
+        self print: "end".
+        self handleSuffixComment.
+        self newline!
 end

--- a/foo/lang/character.foo
+++ b/foo/lang/character.foo
@@ -5,6 +5,10 @@ define ASCII
      formFeed: 0x0C,
      carriageReturn: 0x0D}!
 
+define HorizontalWhitespaceASCII
+    [ASCII space,
+     ASCII tab]!
+
 define WhitespaceASCII
     [ASCII space,
      ASCII tab,
@@ -24,6 +28,8 @@ class Character { code }
             ifFalse: { 0x61 <= code and: code <= 0x7A }!
     method isWhitespace
         WhitespaceASCII anySatisfy: { |whitespaceCode| whitespaceCode is code }!
+    method isHorizontalWhitespace
+        HorizontalWhitespaceASCII anySatisfy: { |whitespaceCode| whitespaceCode is code }!
     method isDigit
         0x30 <= code and: code <= 0x39!
     method digit


### PR DESCRIPTION
      let x = 42. -- The answer!
      self theQuestion: x

  Parses the above with the comment as a suffix comment to 42 instead of
  a prefix comment to `self theQuestion: x`.

  This is slightly inconsistent in a way, but fits human expectactions better.
