### PR TITLE
towards self-hosting: array expressions

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -140,6 +140,13 @@ class AstComment { comment value source }
         visitor visitComment: self!
 end
 
+class AstArray { elements }
+    is AstNode
+
+    method visitBy: visitor
+        visitor visitArray: self!
+end
+
 class AstUndefinedMarker {}
 end
 

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -139,6 +139,13 @@ class AstInterpreter { context process }
     method visitConstant: aConstant
         aConstant value!
 
+    method visitArray: anArray
+        let new = Array new: (anArray elements size).
+        anArray elements
+            doWithIndex: { |each index|
+                           new put: (each visitBy: self) at: index }.
+        new!
+
     method visitGlobal: aGlobal
         aGlobal value!
 

--- a/foo/impl/foolang.foo
+++ b/foo/impl/foolang.foo
@@ -23,6 +23,13 @@ class Tests { system ok }
 
     method run
         self
+            ; test: #testArray1
+            ; test: #testArray2
+            ; test: #testArray3
+            ; test: #testArray4
+            ; test: #testArray5
+            ; test: #testArray6
+            ; test: #testArray7
             ; test: #test42
             ; test: #testPlus
             ; test: #testPrecedence1
@@ -388,6 +395,34 @@ with: {defSource}"!
         self
             parse: "class X \{} -- boop\n method bar\n 42!\n end\n"
             expect: "class X \{}\n    -- boop\n    method bar\n        42!\nend\n"!
+
+    method testArray1
+        self eval: "[1, 1+1, 3]"
+             expect: [1,2,3]!
+
+    method testArray2
+        self eval: "[1, 1+1, 3, ]"
+             expect: [1,2,3]!
+
+    method testArray3
+        self eval: "[, 1, 1+1, 3]"
+             expect: [1,2,3]!
+
+    method testArray4
+        self eval: "[, 1, 1+1, 3,]"
+             expect: [1,2,3]!
+
+    method testArray5
+        self eval: "[1]"
+             expect: [1]!
+
+    method testArray6
+        self eval: "[]"
+             expect: []!
+
+    method testArray7
+        self eval: "[,]"
+             expect: []!
 
     method testBacktrace
         self load: "class BacktraceTest \{}

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -169,7 +169,8 @@ class BlockStartToken { precedence string first last }
             when: "|"
             then: { parser nextToken.
                     parser until: "|"
-                           do: { parameters add: (parser parseVariableName) } }.
+                           do: { parameters add: (parser parseVariableName) }.
+                    parser nextToken }.
         let body = parser parseAtPrecedence: SeqPrecedence.
         parser expect: "}".
         SyntaxBlock

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -86,7 +86,7 @@ end
 
 -- For CoreSyntaxTable --
 
-class UnmatchedCloseToken { precedence string first last }
+class InvalidToken { precedence string first last }
     is Token
 end
 
@@ -167,13 +167,32 @@ class BlockStartToken { precedence string first last }
         let parameters = List new.
         parser
             when: "|"
-            then: { parser until: "|"
+            then: { parser nextToken.
+                    parser until: "|"
                            do: { parameters add: (parser parseVariableName) } }.
         let body = parser parseAtPrecedence: SeqPrecedence.
         parser expect: "}".
         SyntaxBlock
             parameters: parameters
             body: body!
+end
+
+class ArrayStartToken { precedence string first last }
+    is Token
+
+    method parseAsPrefixWith: parser atPrecedence: _precedence
+        let elements = List new.
+        -- Optional leading comma
+        parser when: ","
+               then: { parser nextToken }.
+        parser until: "]"
+               do: { elements add: parser parse.
+                     -- Allow trailing comma
+                     parser unless: "]"
+                            then: { parser expect: "," } }.
+        parser expect: "]".
+        SyntaxArray
+            elements: elements!
 end
 
 class OpenParenToken { precedence string first last }
@@ -253,12 +272,13 @@ class ClassToken { precedence string first last }
         parser expect: "\{".
         parser until: "}"
                do: { slots add: parser parseVariableName }.
-
+        parser expect: "}".
         let theClass = SyntaxClass name: name slots: slots.
         let classParser = parser syntaxTable: ClassSyntaxTable.
         classParser
             until: "end"
             do: { theClass add: (classParser parseAtPrecedence: precedence) }.
+        parser expect: "end".
         parser handleSuffixCommentOf: theClass!
 
     method toString
@@ -289,6 +309,8 @@ class InterfaceToken { precedence string first last }
         interfaceParser
             until: "end"
             do: { theInterface add: (interfaceParser parseAtPrecedence: precedence) }.
+        interfaceParser
+            expect: "end".
         parser handleSuffixCommentOf: theInterface!
 
     method toString
@@ -407,9 +429,10 @@ define CoreSyntaxTable
     where: "anywhere"
     tokens:
     {
-         "}" -> SyntaxEntry tokenClass: UnmatchedCloseToken precedence: 0,
-         ")" -> SyntaxEntry tokenClass: UnmatchedCloseToken precedence: 0,
-         "]" -> SyntaxEntry tokenClass: UnmatchedCloseToken precedence: 0,
+         "}" -> SyntaxEntry tokenClass: InvalidToken precedence: 0,
+         ")" -> SyntaxEntry tokenClass: InvalidToken precedence: 0,
+         "]" -> SyntaxEntry tokenClass: InvalidToken precedence: 0,
+         "," -> SyntaxEntry tokenClass: InvalidToken precedence: 0,
          "--" -> SyntaxEntry tokenClass: CommentToken precedence: 1000
     }!
 
@@ -427,8 +450,10 @@ define ExpressionSyntaxTable
          "is" -> SyntaxEntry tokenClass: IsSuffixToken precedence: 10,
          "=" -> SyntaxEntry tokenClass: AssignmentToken precedence: 4,
          "let" -> SyntaxEntry tokenClass: LetToken precedence: 3,
-         "\{" -> SyntaxEntry tokenClass: BlockStartToken precedence: 3, -- ???
-         "(" -> SyntaxEntry tokenClass: OpenParenToken precedence: 3, -- ???
+         -- Why precedence 3 for these?
+         "\{" -> SyntaxEntry tokenClass: BlockStartToken precedence: 3,
+         "[" -> SyntaxEntry tokenClass: ArrayStartToken precedence: 3,
+         "(" -> SyntaxEntry tokenClass: OpenParenToken precedence: 3,
          "." -> SyntaxEntry tokenClass: SequenceToken precedence: 2,
          "!" -> SyntaxEntry tokenClass: BangToken precedence: 1
     }!
@@ -698,16 +723,15 @@ Source: {source}" }!
 
     method when: test then: action
         self lookahead string == test
-            ifTrue: { self nextToken. action value }!
+            ifTrue: { action value }!
+
+    method unless: test then: action
+        self lookahead string == test
+            ifFalse: { action value }!
 
     method until: test do: action
         { self lookahead string == test }
-            whileFalse: action.
-        self nextToken!
-
-    method while: test do: action
-        { self lookahead string == test }
-            whileTrue: { self nextToken. action value }!
+            whileFalse: action!
 
     method parseAtPrecedence: precedence
         self

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -32,6 +32,16 @@ class SyntaxLiteral { value }
         [value]!
 end
 
+class SyntaxArray { elements }
+    is Syntax
+
+    method visitBy: visitor
+        visitor visitArray: self!
+
+    method parts
+        elements!
+end
+
 class SyntaxSeq { first then }
     is Syntax
 

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -61,6 +61,13 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
     method visitLiteral: aLiteral
         self print: aLiteral value displayString!
 
+    method visitArray: anArray
+        self print: "[".
+        anArray elements
+            do: { |element| element visitBy: self }
+            interleaving: { self print: "," }.
+        self print: "]"!
+
     method visitSeq: aSeq
         self handleBlockStart.
         aSeq first visitBy: self.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -14,6 +14,10 @@ class SyntaxTranslator { env }
     method visitLiteral: aLiteral
         AstConstantRef value: aLiteral value!
 
+    method visitArray: anArray
+        AstArray elements: (anArray elements
+                                collect: { |each| each visitBy: self })!
+
     method visitSeq: aSeq
         -- FIXME: Would be nicer to flatten this out.
         AstSeq

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -1,6 +1,7 @@
 interface SyntaxVisitor
     is Object
     required method visitLiteral: aLiteral
+    required method visitArray: anArray
     required method visitSeq: aSeq
     required method visitReturn: aReturn
     required method visitPrefixComment: aComment

--- a/foo/lang/ordered.foo
+++ b/foo/lang/ordered.foo
@@ -67,6 +67,12 @@ interface Ordered
                 block value: (self at: i) }.
         self!
 
+    method doWithIndex: block
+        1 to: self size
+          do: { |i|
+                block value: (self at: i) value: i }.
+        self!
+
     method with: other collect: block
         self with: other collect: block of: Object!
 


### PR DESCRIPTION
  Extend array syntax to allow both leading and trailing commas
  while at it.
