### PR TITLE
Class names and printing

### DIFF
--- a/foo/lang/exception.foo
+++ b/foo/lang/exception.foo
@@ -130,7 +130,7 @@ class DoesNotUnderstand { receiver selector arguments source context }
             ifTrue: { False }
             ifFalse: { context bactrace }!
     method _description
-        let note = "{receiver displayString} does not understand: {selector} with: {arguments displayString}".
+        let note = "Instances of {receiver classOf} do not understand: {selector}".
         source is False
             ifTrue: { note }
             ifFalse: { "{note}\n{source note: note}" }!

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -218,7 +218,7 @@ impl Vtable {
     }
 
     pub fn for_class(name: &str) -> Vtable {
-        let vt = Vtable::raw(name);
+        let vt = Vtable::raw(&format!("{} classOf", name));
         vt.add_primitive_method_or_panic("classOf", classes::class::generic_class_class);
         vt.add_primitive_method_or_panic("includes:", classes::class::generic_class_includes_);
         vt.add_primitive_method_or_panic("typecheck:", classes::class::generic_class_typecheck_);
@@ -1428,13 +1428,7 @@ impl fmt::Display for Object {
             Datum::Boolean(true) => write!(f, "True"),
             Datum::Boolean(false) => write!(f, "False"),
             Datum::ByteArray(byte_array) => write!(f, "{:?}", byte_array),
-            Datum::Class(class) => {
-                if class.interface {
-                    write!(f, "#<interface {}>", self.vtable.name)
-                } else {
-                    write!(f, "#<class {}>", self.vtable.name)
-                }
-            }
+            Datum::Class(_class) => write!(f, "{}", self.vtable.name),
             Datum::Clock => write!(f, "#<Clock>"),
             Datum::Closure(x) => write!(f, "#<closure {:?}>", x.params),
             Datum::Compiler(_) => write!(f, "#<Compiler>"),
@@ -1490,9 +1484,7 @@ impl fmt::Debug for Object {
 
 fn generic_to_string(receiver: &Object, _args: &[Object], env: &Env) -> Eval {
     match &receiver.datum {
-        Datum::Class(class) => {
-            Ok(env.foo.into_string(format!("#<class {}>", &class.instance_vtable.name)))
-        }
+        Datum::Class(class) => Ok(env.foo.make_string(&class.instance_vtable.name)),
         Datum::Boolean(maybe) => {
             if *maybe {
                 Ok(env.foo.make_string("True"))

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -339,10 +339,10 @@ fn test_does_not_understand_location() -> Test {
     cmd.arg("foo/tests/test_does_not_understand_location.foo");
     // FIXME: Error points to class
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
-        "ERROR: class DoesNotUnderstandError does not understand: noSuchMethod []
+        "ERROR: DoesNotUnderstandError classOf does not understand: noSuchMethod []
 061     direct method oops
 062         self noSuchMethod!
-                 ^^^^^^^^^^^^ class DoesNotUnderstandError does not understand: noSuchMethod []
+                 ^^^^^^^^^^^^ DoesNotUnderstandError classOf does not understand: noSuchMethod []
 063 end",
     ));
     Ok(())


### PR DESCRIPTION
Make sure classes and metaclasses have appropriate names, use them when printing.

Also gets rid of the terrible hack for metaclasses.

Also makes DoesNotUnderstand reporting robust by limiting printing to the class of the receiver and the selector.
