### PR TITLE
transpiler refactoring

### DIFF
--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -220,12 +220,12 @@ class CTranspiler { output selectorMap blockFunctions }
                 output println: "}".
                 output newline
             }.
-        -- Direct Method Array
-        let directMethodArrayName = "FOO_{aClass name}DirectMethods".
-        output println: "struct FooMethodArray {directMethodArrayName} =".
+        -- Class Vtable
+        output println: "struct FooVtable {classVtableName} = ".
         output println: "\{".
+        output println: "    .name = &FOO_CSTRING({aClass name displayString}\" class\"),".
         output println: "    .size = {directMethods size},".
-        output println: "    .data = \{".
+        output println: "    .methods = \{".
         directMethods
             do: { |each|
                   output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
@@ -235,12 +235,13 @@ class CTranspiler { output selectorMap blockFunctions }
         output println: "    }".
         output println: "};".
         output newline.
-        -- Instance Method Array
-        let instanceMethodArrayName = "FOO_{aClass name}InstanceMethods".
-        output println: "struct FooMethodArray {instanceMethodArrayName} =".
+        -- Instance Vtable
+        output println: "struct FooVtable {instanceVtableName} = ".
         output println: "\{".
+        output println: "    .name = &FOO_CSTRING({aClass name displayString}),".
+        output println: "    .classptr = &{globalName},".
         output println: "    .size = {aClass instanceMethods size},".
-        output println: "    .data = \{".
+        output println: "    .methods = \{".
         aClass instanceMethods
             do: { |each|
                   output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
@@ -248,21 +249,6 @@ class CTranspiler { output selectorMap blockFunctions }
                   output println: "                            .frameSize = {each frameSize},".
                   output println: "                            .function = &{Name mangleInstanceMethod: each selector in: aClass} }," }.
         output println: "    }".
-        output println: "};".
-        output newline.
-        -- Class Vtable
-        output println: "struct FooVtable {classVtableName} = ".
-        output println: "\{".
-        output println: "    .name = &FOO_CSTRING({aClass name displayString}\" class\"),".
-        output println: "    .methods = &{directMethodArrayName}".
-        output println: "};".
-        output newline.
-        -- Instance Vtable
-        output println: "struct FooVtable {instanceVtableName} = ".
-        output println: "\{".
-        output println: "    .name = &FOO_CSTRING({aClass name displayString}),".
-        output println: "    .methods = &{instanceMethodArrayName},".
-        output println: "    .classptr = &{globalName}".
         output println: "};".
         output newline.
         -- Class struct

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -200,17 +200,6 @@ class TestTranspile3 { assert system }
                          end"
             expect: "#<Integer 2042>"!
 
-    method testNonLocalReturn
-        self transpile: "class Main \{}
-                             direct method run
-                                 self foo debug!
-                             direct method foo
-                                 100 + (self bar: \{ |x| return x })!
-                             direct method bar: block
-                                 block value: 420!
-                         end"
-            expect: "#<Integer 420>"!
-
     method testPrefixMethod
         self transpile: "class Main \{}
                              direct method run
@@ -254,6 +243,21 @@ class TestTranspile4 { assert system }
             expect: "#<Integer 2>#<Integer 100>"!
 end
 
+class TestTranspile5 { assert system }
+    is TranspilerTest
+
+    method testNonLocalReturn
+        self transpile: "class Main \{}
+                             direct method run
+                                 self foo debug!
+                             direct method foo
+                                 100 + (self bar: \{ |x| return x })!
+                             direct method bar: block
+                                 block value: 420!
+                         end"
+            expect: "#<Integer 420>"!
+end
+
 class Main {}
     direct method run: cmd in: system
         let tests = {
@@ -261,7 +265,8 @@ class Main {}
             "transpile1" -> TestTranspile1 system: system,
             "transpile2" -> TestTranspile2 system: system,
             "transpile3" -> TestTranspile3 system: system,
-            "transpile4" -> TestTranspile4 system: system
+            "transpile4" -> TestTranspile4 system: system,
+            "transpile5" -> TestTranspile4 system: system
         }.
         cmd do: { |name|
                   Assert

--- a/foo/impl/transpiler/block.foo
+++ b/foo/impl/transpiler/block.foo
@@ -10,7 +10,7 @@ return ctx->receiver.datum.block->function(block_ctx);"},
       #finally:
           -> {signature: [Block],
               body: "struct FooContext* block_ctx = foo_context_new_block(ctx);
-block_ctx->cleanup = block_ctx;
+block_ctx->cleanup_or_ret = block_ctx;
 struct Foo block_value = ctx->receiver.datum.block->function(block_ctx);
 foo_cleanup(block_ctx);
 return block_value;"}}!

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -21,64 +21,50 @@ fn test_self_hosted_prelude() -> Test {
     Ok(())
 }
 
-#[test]
-#[serial]
-fn test_self_hosted_transpiler0() -> Test {
+fn run_test_transpile(name: &str) -> Test {
     let mut cmd = Command::cargo_bin("foo")?;
     cmd.arg("foo/impl/test_transpile.foo");
     cmd.arg("--use=foo/lib");
     cmd.arg("--");
-    cmd.arg("name");
+    cmd.arg(name);
     cmd.assert().success();
     Ok(())
+}
+
+#[test]
+#[serial]
+fn test_self_hosted_transpiler0() -> Test {
+    run_test_transpile("name")
 }
 
 #[test]
 #[serial]
 fn test_self_hosted_transpiler1() -> Test {
-    let mut cmd = Command::cargo_bin("foo")?;
-    cmd.arg("foo/impl/test_transpile.foo");
-    cmd.arg("--use=foo/lib");
-    cmd.arg("--");
-    cmd.arg("transpile1");
-    cmd.assert().success();
-    Ok(())
+    run_test_transpile("transpile1")
 }
 
 #[test]
 #[serial]
 fn test_self_hosted_transpiler2() -> Test {
-    let mut cmd = Command::cargo_bin("foo")?;
-    cmd.arg("foo/impl/test_transpile.foo");
-    cmd.arg("--use=foo/lib");
-    cmd.arg("--");
-    cmd.arg("transpile2");
-    cmd.assert().success();
-    Ok(())
+    run_test_transpile("transpile2")
 }
 
 #[test]
 #[serial]
 fn test_self_hosted_transpiler3() -> Test {
-    let mut cmd = Command::cargo_bin("foo")?;
-    cmd.arg("foo/impl/test_transpile.foo");
-    cmd.arg("--use=foo/lib");
-    cmd.arg("--");
-    cmd.arg("transpile3");
-    cmd.assert().success();
-    Ok(())
+    run_test_transpile("transpile3")
 }
 
 #[test]
 #[serial]
 fn test_self_hosted_transpiler4() -> Test {
-    let mut cmd = Command::cargo_bin("foo")?;
-    cmd.arg("foo/impl/test_transpile.foo");
-    cmd.arg("--use=foo/lib");
-    cmd.arg("--");
-    cmd.arg("transpile4");
-    cmd.assert().success();
-    Ok(())
+    run_test_transpile("transpile4")
+}
+
+#[test]
+#[serial]
+fn test_self_hosted_transpiler5() -> Test {
+    run_test_transpile("transpile5")
 }
 
 #[test]


### PR DESCRIPTION
- remove indirection between context and frame
- remove indirection between vtable and methods
- use same context member for cleanup and ret
