### PR TITLE
required ignored tests on windows as well, again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,6 @@ jobs:
 
       - name: Test large
         uses: actions-rs/cargo@v1
-        # Windows CI host keeps running out of memory in transpiler tests. I
-        # don't like this, but dealing with it is a terrible timesink and I
-        # build on windows daily otherwise.
-        continue-on-error: ${{ runner.os == 'Windows' }}
         with:
           command: test
           args: -- --ignored


### PR DESCRIPTION
  Seems that moving the transpiler tests to --ignored section makes
  them pass - further evidence of a leak in the Rust code, I guess.

