### PR TITLE
quick and dirty mark-and-sweep gc

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -172,6 +172,9 @@ class AstClass { name slots interfaces _directMethods _instanceMethods }
             _collectFromInterfaces: #directMethods
             _with: _directMethods!
 
+    method markFunction
+        "foo_mark_array"!
+
     method instanceMethods
         self
             _collectFromInterfaces: #instanceMethods
@@ -284,6 +287,11 @@ class AstMethod { selector argumentVariables returnType body frameSize isDirect 
     method frameSize: frameSizeVal
         frameSize is False assert: "frame size not set".
         frameSize = frameSizeVal!
+
+    method addTemp
+        let offset = frameSize.
+        frameSize = frameSize + 1.
+        offset!
 
     method name
         selector name!
@@ -561,6 +569,11 @@ class AstBlock { body argumentVariables returnType frameSize }
 
     method visitBy: visitor
         visitor visitBlock: self!
+
+    method addTemp
+        let offset = frameSize.
+        frameSize = frameSize + 1.
+        offset!
 
     method argumentCount
         argumentVariables size!

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -22,18 +22,20 @@ class BuiltinMethod { selector definition }
     method arity
         definition signature size!
     method frameSize
-        self arity!
+        self arity + self definition vars!
     method signature
         definition signature!
     method body
         definition body!
 end
 
-class BuiltinClass { host directMethods instanceMethods }
+class BuiltinClass { host markFunction directMethods instanceMethods }
     direct method new: host
+                  mark: mark
                   directMethods: directMethods
                   instanceMethods: instanceMethods
         self host: host
+             markFunction: mark
              directMethods: (BuiltinMethod forEach: directMethods)
              instanceMethods: (BuiltinMethod forEach: instanceMethods)!
     method name
@@ -55,26 +57,32 @@ end
 define BuiltinClasses [
      BuiltinClass
          new: Array
+         mark: "foo_mark_array"
          directMethods: array.DirectMethods
          instanceMethods: array.InstanceMethods,
      BuiltinClass
          new: Block
+         mark: "foo_mark_block"
          directMethods: []
          instanceMethods: block.InstanceMethods,
      BuiltinClass
          new: Boolean
+         mark: "foo_mark_noop"
          directMethods: boolean.DirectMethods
          instanceMethods: boolean.InstanceMethods,
      BuiltinClass
          new: Float
+         mark: "foo_mark_noop"
          directMethods: []
          instanceMethods: float.FloatMethods,
      BuiltinClass
          new: Integer
+         mark: "foo_mark_noop"
          directMethods: []
          instanceMethods: integer.IntegerMethods,
      BuiltinClass
          new: String
+         mark: "foo_mark_noop"
          directMethods: []
          instanceMethods: string.InstanceMethods
 ]!
@@ -91,6 +99,9 @@ class SelectorMap { names }
     method do: block
         names do: block!
 end
+
+define $home
+    False!
 
 class CTranspiler { output selectorMap blockFunctions constants variables tmpCounter }
 
@@ -112,6 +123,9 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
           constants: visitor generateConstants,
           classes: classes,
           selectors: visitor generateSelectors }!
+
+    method addTemp
+        $home addTemp!
 
     method genTemp: name
         tmpCounter = tmpCounter + 1.
@@ -143,12 +157,12 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output println: "    (int argc, char** argv)".
         output println: "\{".
         output println: "    fooinit();".
-        output println: "    struct FooProcess* process = foo_process_new({variables size});".
+        output println: "    struct FooArray* vars = foo_Array_alloc({variables size});".
         variables
             do: { |name offset|
                   let var = {name: name}.
-                  output println: "process->vars[{offset}] = {Name mangleDynamic: var};" }.
-        output println: "    struct FooContext* ctx = foo_context_new_main(process);".
+                  output println: "vars->data[{offset}] = {Name mangleDynamic: var};" }.
+        output println: "    struct FooContext* ctx = foo_context_new_main(vars);".
         let main = Name mangleGlobal: {name: "Main"}.
         output println: "    foo_send(ctx, &{Name mangleSelector: #run}, {main}, 0);".
         output println: "    return 0;".
@@ -237,6 +251,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         cname!
 
     method blockCName: block
+        let $home = block.
         let output = StringOutput new.
         -- Placeholder so that recursive entry by visitor doesn't grab the
         -- same id.
@@ -307,6 +322,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output println: "    .name = &FOO_CSTRING({anInterface name displayString}\" interface\"),".
         output println: "    .inherited = \{ .size = 0, .data = NULL },".
         output println: "    .size = {anInterface directMethods size},".
+        output println: "    .mark = foo_mark_noop,".
         output println: "    .methods = \{".
         anInterface directMethods
             do: { |each|
@@ -323,6 +339,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output println: "    .name = &FOO_CSTRING({anInterface name displayString}),".
         output println: "    .classptr = NULL,". -- FIXME
         output println: "    .inherited = \{ .size = 0, .data = NULL },".
+        output println: "    .mark = foo_mark_noop,".
         output println: "    .size = 0,".
         output println: "    .methods = \{}".
         output println: "};".
@@ -380,23 +397,21 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
                 output newline.
                 -- Constructor
                 let ctor = aClass constructor.
-                directMethods push: { selector: ctor, arity: aClass slots size, frameSize: 0 }.
+                directMethods push: { selector: ctor, arity: aClass slots size, frameSize: aClass slots size }.
                 let ctorName = Name mangleDirectMethod: ctor in: aClass.
                 output newline.
                 output print: "struct Foo ".
                 output println: ctorName.
-                output println: "    (struct FooContext* ctx, size_t nargs, va_list args)".
+                output println: "    (struct FooContext* ctx)".
                 output println: "\{".
                 output println: "    (void)ctx;".
-                output println: "    (void)nargs;".
-                output println: "    (void)args;".
-                output println: "    struct Foo* new = FOO_ALLOC_ARRAY({aClass slots size}, struct Foo);".
+                output println: "    struct FooArray* new = foo_Array_alloc({aClass slots size} * sizeof(struct Foo));".
                 aClass slots
                     doWithIndex: { |each index|
                                    let type = each type value.
                                    type is Any
-                                       ifTrue: { output println: "new[{index-1}] = va_arg(args, struct Foo);" }
-                                       ifFalse: { output println: "new[{index -1}] = foo_vtable_typecheck(&{Name mangleInstanceVtable: type}, va_arg(args, struct Foo));" } }.
+                                       ifTrue: { output println: "new->data[{index-1}] = ctx->frame[{index-1}];" }
+                                       ifFalse: { output println: "new->data[{index -1}] = foo_vtable_typecheck(&{Name mangleInstanceVtable: type}, ctx->frame[{index-1}]);" } }.
                 output println: "    return (struct Foo)\{ .vtable = &{instanceVtableName}, .datum = \{ .ptr = new } };".
                 output println: "}".
                 output newline
@@ -422,6 +437,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output println: "    .name = &FOO_CSTRING({aClass name displayString}\" class\"),".
         output println: "    .classptr = NULL,". -- FIXME
         output println: "    .inherited = \{ .size = {aClass interfaces size}, .data = {classInterfacesName} },".
+        output println: "    .mark = foo_mark_noop,".
         output println: "    .size = {directMethods size},".
         output println: "    .methods = \{".
         directMethods
@@ -439,6 +455,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output println: "    .name = &FOO_CSTRING({aClass name displayString}),".
         output println: "    .classptr = &{globalName},".
         output println: "    .inherited = \{ .size = {aClass interfaces size}, .data = {instanceInterfacesName} },".
+        output println: "    .mark = {aClass markFunction},".
         output println: "    .size = {aClass instanceMethods size},".
         output println: "    .methods = \{".
         aClass instanceMethods
@@ -466,18 +483,16 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output newline!
 
     method _generateMethod: aMethod _in: aClass _as: mangledName
+        let $home = aMethod.
         output print: "struct Foo ".
         output println: mangledName.
-        output println: "    (struct FooContext* ctx, size_t nargs, va_list args)".
+        output println: "    (struct FooContext* ctx)".
         output println: "\{".
         output println: "    (void)ctx;".
-        output println: "    (void)nargs;".
-        output println: "    (void)args;".
         aMethod signature
             doWithIndex: { |type index|
                            type is Any
-                               ifTrue: { output println: "    ctx->frame[{index-1}ul] = va_arg(args, struct Foo);" }
-                               ifFalse: { output println: "    ctx->frame[{index-1}ul] = foo_vtable_typecheck(&{Name mangleInstanceVtable: type}, va_arg(args, struct Foo));" } }.
+                               ifFalse: { output println: "    foo_vtable_typecheck(&{Name mangleInstanceVtable: type}, ctx->frame[{index-1}ul]);" } }.
         aMethod isBuiltin
             ifTrue: {  output print: "    ".
                        output println: (aMethod body replace: "\n" with: "\n    ").
@@ -496,7 +511,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         let index = variables
                         at: aVar name
                         ifNone: { Error raise: "No index for: {aVar}" }.
-        output print: "ctx->process->vars[{index}]"!
+        output print: "ctx->vars->data[{index}]"!
 
     method _generateTypecheck: type _for: value
         type is Any
@@ -512,13 +527,15 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
              _for: aCheck value!
 
     method visitIs: anIs
-        output print: "(\{ struct Foo left = ".
+        let left = self addTemp.
+        output print: "(\{ ctx->frame[{left}] = ".
         anIs left visitBy: self.
         output print: "; ".
-        output print: "struct Foo right = ".
+        let right = self addTemp.
+        output print: "ctx->frame[{right}] = ".
         anIs right visitBy: self.
         output print: "; ".
-        output print: "foo_Boolean_new(left.vtable == right.vtable && left.datum.int64 == right.datum.int64); ".
+        output print: "foo_Boolean_new(ctx->frame[{left}].vtable == ctx->frame[{right}].vtable && ctx->frame[{left}].datum.int64 == ctx->frame[{right}].datum.int64); ".
         output print: "})"!
 
     method visitSeq: seq
@@ -529,7 +546,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output print: "; })"!
 
     method visitSlotSet: set
-        output print: "(PTR(Foo, ctx->receiver.datum)[".
+        output print: "(PTR(FooArray, ctx->receiver.datum)->data[".
         output print: (set slot index - 1).
         output print: "] = ".
         self _generateTypecheck: set slot type value
@@ -537,7 +554,7 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output print: ")"!
 
     method visitSlotRef: ref
-        output print: "PTR(Foo, ctx->receiver.datum)[".
+        output print: "PTR(FooArray, ctx->receiver.datum)->data[".
         output print: (ref slot index - 1).
         output print: "]"!
 
@@ -571,6 +588,14 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output newline!
 
     method visitSend: aSend
+        output print: "(\{ ".
+        let argVars = aSend arguments
+                          collect: { |each|
+                                     let index = self addTemp.
+                                     output print: "ctx->frame[{index}] = ".
+                                     each visitBy: self.
+                                     output print: "; ".
+                                     index }.
         output print: "foo_send(ctx, &".
         output print: (self selectorCName: aSend selector).
         output print: ", ".
@@ -578,11 +603,10 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output print: ", ".
         output print: aSend arguments size.
         output print: "ul".
-        aSend arguments
-            do: { |arg|
-                  output print: ", ".
-                  arg visitBy: self }.
-        output print: ")"!
+        argVars
+            do: { |index|
+                  output print: ", ctx->frame[{index}]" }.
+        output print: "); })"!
 
     method visitSelfInstance: aSelf
         output print: "ctx->receiver"!
@@ -594,19 +618,19 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         let name = aBind variable name.
         let index = variables at: name.
         let unbind = self genTemp: "unbind".
-        output print: "(\{ struct FooUnbind {unbind} = \{ .cleanup = \{ .function = foo_unbind, .next = ctx->cleanup }, .index = {index}, .value = ctx->process->vars[{index}] };".
+        output print: "(\{ struct FooUnbind {unbind} = \{ .cleanup = \{ .function = foo_unbind, .next = ctx->cleanup }, .index = {index}, .value = ctx->vars->data[{index}] };".
         output print: " ctx->cleanup = &{unbind}.cleanup;".
-        output print: " ctx->process->vars[{index}] = ".
+        output print: " ctx->vars->data[{index}] = ".
         aBind value visitBy: self.
         output print: ";".
-        let res = self genTemp: "res".
-        output print: " struct Foo {res} = ".
+        let res = self addTemp.
+        output print: " ctx->frame[{res}] = ".
         aBind body visitBy: self.
         output print: ";".
         output print: " assert(&{unbind}.cleanup == ctx->cleanup);".
         output print: " ctx->cleanup = ctx->cleanup->next;".
         output print: " foo_unbind(ctx, &{unbind}.cleanup);".
-        output print: " {res}; })"!
+        output print: " ctx->frame[{res}]; })"!
 
     method visitBindLexical: aBind
         output print: "(\{ ctx->frame[{aBind variable index - 1}ul] = ".
@@ -635,18 +659,18 @@ class CTranspiler { output selectorMap blockFunctions constants variables tmpCou
         output print: ")"!
 
     method visitArray: anArray
-        let a = self genTemp: "array".
         let entries = anArray entries.
-        output print: "(\{ struct Foo {a} = foo_Array_new({entries size}); ".
+        let array = self addTemp.
+        output print: "(\{ ctx->frame[{array}] = foo_Array_new({entries size}); ".
         entries isEmpty
             ifFalse: { let p = self genTemp: "arrayPtr".
-                       output print: "struct FooArray* {p} = PTR(FooArray, {a}.datum);".
+                       output print: "struct FooArray* {p} = PTR(FooArray, ctx->frame[{array}].datum);".
                        entries
                            doWithIndex: { |each index|
                                           output print: "{p}->data[{index-1}] = ".
                                           each visitBy: self.
                                           output print: "; " } }.
-        output print: "{a}; })"!
+        output print: "ctx->frame[{array}]; })"!
 
     method visitPanic: aPanic
         output println: "foo_panic(".

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -360,6 +360,28 @@ class TestTranspileArray { assert system }
                                 (a at: 4) debug!
                          end"
             expect: "#<Integer 999>#<Integer 42>"!
+
+    method testArraySums
+        self transpile: "class Main \{}
+                             direct method run
+                                (self sums: 10) debug!
+                             direct method sum: n
+                                 let array = Array new: n.
+                                 1 to: n
+                                   do: \{ |each|
+                                         array at: each put: each * 2 }.
+                                 let sum = 0.
+                                 1 to: n
+                                   do: \{ |each|
+                                         sum = sum + (array at: each) }.
+                                 sum!
+                             direct method sums: n
+                                n > 0
+                                   ifTrue: \{ (self sum: n) + (self sums: n - 1) }
+                                   ifFalse: \{ 0 }!
+                         end"
+            expect: "#<Integer 440>"!
+
 end
 
 class TestTranspileClass { assert system }

--- a/foo/impl/transpiler/array.foo
+++ b/foo/impl/transpiler/array.foo
@@ -1,6 +1,6 @@
 define DirectMethods
     { #new:
-          -> {signature: [Integer],
+          -> {signature: [Integer], vars: 0,
               body: "size_t size = ctx->frame[0].datum.int64;
 // FIXME: error instead!
 assert(size >= 0);
@@ -9,7 +9,7 @@ return foo_Array_new(size);"}
 
 define InstanceMethods
     { #debug
-          -> {signature: [],
+          -> {signature: [], vars: 0,
               body: "struct FooArray* array = PTR(FooArray, ctx->receiver.datum);
 printf(\"[\");
 for (size_t i = 0; i < array->size; i++) \{
@@ -20,20 +20,20 @@ for (size_t i = 0; i < array->size; i++) \{
 printf(\"]\");
 return ctx->receiver;"},
       #at:
-          -> {signature: [Integer],
+          -> {signature: [Integer], vars: 0,
               body: "struct FooArray* array = PTR(FooArray, ctx->receiver.datum);
 int64_t i = ctx->frame[0].datum.int64 - 1;
 assert(i >= 0);
 assert(i < array->size);
 return array->data[i];"},
       #at:put:
-          -> {signature: [Integer, Any],
+          -> {signature: [Integer, Any], vars: 0,
               body: "struct FooArray* array = PTR(FooArray, ctx->receiver.datum);
 int64_t i = ctx->frame[0].datum.int64 - 1;
 assert(i >= 0);
 assert(i < array->size);
 return array->data[i] = ctx->frame[1];"},
       #size
-              -> {signature: [],
+              -> {signature: [], vars: 0,
                   body: "return foo_Integer_new(PTR(FooArray, ctx->receiver.datum)->size);"}
 }!

--- a/foo/impl/transpiler/block.foo
+++ b/foo/impl/transpiler/block.foo
@@ -3,15 +3,15 @@ define DirectMethods
 
 define InstanceMethods
     { #value
-          -> {signature: [],
+          -> {signature: [], vars: 0,
               body: "struct FooContext* block_ctx = foo_context_new_block(ctx);
 return PTR(FooBlock, ctx->receiver.datum)->function(block_ctx);"},
       #value:
-          -> {signature: [Any],
+          -> {signature: [Any], vars: 0,
               body: "struct FooContext* block_ctx = foo_context_new_block(ctx);
 return PTR(FooBlock, ctx->receiver.datum)->function(block_ctx);"},
       #finally:
-          -> {signature: [Block],
+          -> {signature: [Block], vars: 1,
               body: "struct FooFinally finally = \{
     .cleanup = \{
         .function = foo_finally,
@@ -21,7 +21,7 @@ return PTR(FooBlock, ctx->receiver.datum)->function(block_ctx);"},
 };
 ctx->cleanup = &finally.cleanup;
 struct FooContext* block_ctx = foo_context_new_block(ctx);
-struct Foo block_value = PTR(FooBlock, ctx->receiver.datum)->function(block_ctx);
+ctx->frame[1] = PTR(FooBlock, ctx->receiver.datum)->function(block_ctx);
 ctx->cleanup = ctx->cleanup->next;
 foo_finally(ctx, &finally.cleanup);
-return block_value;"}}!
+return ctx->frame[1];"}}!

--- a/foo/impl/transpiler/boolean.foo
+++ b/foo/impl/transpiler/boolean.foo
@@ -2,19 +2,19 @@ import .name.Name
 
 define DirectMethods
     { #debug
-          -> { signature: [],
+          -> { signature: [], vars: 0,
                body: "printf(\"#<Class Boolean>\");
 return ctx->receiver;" } }!
 
 define InstanceMethods
     { #ifTrue:ifFalse:
-          -> { signature: [Block, Block],
+          -> { signature: [Block, Block], vars: 0,
                body: "if (ctx->receiver.datum.boolean) \{
     return foo_send(ctx, &{Name mangleSelector: #value}, ctx->frame[0], 0);
 } else \{
     return foo_send(ctx, &{Name mangleSelector: #value}, ctx->frame[1], 0);
 }" },
       #debug
-          -> { signature: [],
+          -> { signature: [], vars: 0,
                body: "printf(\"#<Boolean %s>\", ctx->receiver.datum.boolean ? \"True\" : \"False\");
 return ctx->receiver;" } }!

--- a/foo/impl/transpiler/float.foo
+++ b/foo/impl/transpiler/float.foo
@@ -7,40 +7,40 @@ import .name.Name
 -- things - doing them for floats here would be a waste of time.
 define FloatMethods
     { (Selector name: "prefix-")
-          -> { signature: [],
+          -> { signature: [], vars: 0,
                body: "return foo_Float_new(- ctx->receiver.datum.float64);" },
       -- FIXME: I absolutely despise the C floating point printing:
       -- print the required number of digits without trailing zeros.
       -- Either integrate dtoa.c, link to a small Rust library,
       -- or implement the algorithm myself.
-      #debug -> {signature: [],
+      #debug -> {signature: [], vars: 0,
                  body: "printf(\"#<Float %f>\", ctx->receiver.datum.float64);
 return ctx->receiver;"},
       #floatAdd:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Float_new(ctx->receiver.datum.float64 + ctx->frame[0].datum.float64);" },
       #floatDiv:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Float_new(ctx->receiver.datum.float64 / ctx->frame[0].datum.float64);" },
       #floatEq:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.float64 == ctx->frame[0].datum.float64);" },
       #floatGt:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.float64 > ctx->frame[0].datum.float64);" },
       #floatGte:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.float64 >= ctx->frame[0].datum.float64);" },
       #floatLt:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.float64 < ctx->frame[0].datum.float64);" },
       #floatLte:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.float64 <= ctx->frame[0].datum.float64);" },
       #floatMul:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Float_new(ctx->receiver.datum.float64 * ctx->frame[0].datum.float64);" },
       #floatSub:
-          -> { signature: [Float],
+          -> { signature: [Float], vars: 0,
                body: "return foo_Float_new(ctx->receiver.datum.float64 - ctx->frame[0].datum.float64);" },
     }!

--- a/foo/impl/transpiler/integer.foo
+++ b/foo/impl/transpiler/integer.foo
@@ -5,101 +5,108 @@ import .name.Name
 define IntegerMethods
     { -- FIXME: The binary methods here should be generated from lang.number.foo
       (Selector name: "prefix-")
-          -> { signature: [],
+          -> { signature: [], vars: 0,
                body: "return foo_Integer_new(- ctx->receiver.datum.int64);" },
       #+
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #addNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #/
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #divNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #==
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #eqNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #>
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #gtNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #>=
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #gteNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #<
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #ltNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #<=
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #lteNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #*
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #mulNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       #-
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #subNumber:}, ctx->frame[0], 1, ctx->receiver);" },
       -- FIXME: These *Number methods should come from lang.integer.foo
+      #to:do:
+          -> { signature: [Integer, Block], vars: 0,
+               body: "int64_t to = ctx->frame[0].datum.int64;
+for (int64_t i = ctx->receiver.datum.int64; i <= to; i++) \{
+    foo_send(ctx, &{Name mangleSelector: #value:}, ctx->frame[1], 1, foo_Integer_new(i));
+}
+return ctx->receiver;" },
       #addNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerAdd:}, ctx->frame[0], 1, ctx->receiver);" },
       #divNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerDiv:}, ctx->frame[0], 1, ctx->receiver);" },
       #eqNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerEq:}, ctx->frame[0], 1, ctx->receiver);" },
       #gtNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerGt:}, ctx->frame[0], 1, ctx->receiver);" },
       #gteNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerGte:}, ctx->frame[0], 1, ctx->receiver);" },
       #ltNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerLt:}, ctx->frame[0], 1, ctx->receiver);" },
       #lteNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerLte:}, ctx->frame[0], 1, ctx->receiver);" },
       #mulNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerMul:}, ctx->frame[0], 1, ctx->receiver);" },
       #subNumber:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_send(ctx, &{Name mangleSelector: #integerSub:}, ctx->frame[0], 1, ctx->receiver);" },
       -- The real stuff
       #asFloat
-          -> { signature: [],
+          -> { signature: [], vars: 0,
                body: "foo_unimplemented(\"Integer#asFloat\");" },
-      #debug -> {signature: [],
+      #debug -> {signature: [], vars: 0,
                  body: "printf(\"#<Integer %\" PRId64 \">\", ctx->receiver.datum.int64);
 return ctx->receiver;"},
       #integerAdd:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Integer_new(ctx->receiver.datum.int64 + ctx->frame[0].datum.int64);" },
       #integerDiv:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "int64_t div = ctx->frame[0].datum.int64;
 if (div)
     return foo_Integer_new(ctx->receiver.datum.int64 / div);
 else
     foo_unimplemented(\"DivideByZero handling\");" },
       #integerEq:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.int64 == ctx->frame[0].datum.int64);" },
       #integerGt:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.int64 > ctx->frame[0].datum.int64);" },
       #integerGte:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.int64 >= ctx->frame[0].datum.int64);" },
       #integerLt:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.int64 < ctx->frame[0].datum.int64);" },
       #integerLte:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Boolean_new(ctx->receiver.datum.int64 <= ctx->frame[0].datum.int64);" },
       #integerMul:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Integer_new(ctx->receiver.datum.int64 * ctx->frame[0].datum.int64);" },
       #integerSub:
-          -> { signature: [Integer],
+          -> { signature: [Integer], vars: 0,
                body: "return foo_Integer_new(ctx->receiver.datum.int64 - ctx->frame[0].datum.int64);" },
       #toString
-          -> {signature: [],
+          -> {signature: [], vars: 0,
               body: "foo_unimplemented(\"Integer#toString\");"} }!

--- a/foo/impl/transpiler/string.foo
+++ b/foo/impl/transpiler/string.foo
@@ -2,11 +2,11 @@ import .name.Name
 
 define InstanceMethods {
     #debug
-        -> {signature: [],
+        -> {signature: [], vars: 0,
             body: "printf(\"#<String %s>\", (char*)PTR(FooBytes, ctx->receiver.datum)->data);
 return ctx->receiver;"},
     #from:to:
-        -> {signature: [Integer, Integer],
+        -> {signature: [Integer, Integer], vars: 0,
             body: "int64_t start = ctx->frame[0].datum.int64 - 1;
 int64_t end = ctx->frame[1].datum.int64;
 // FIXME: errors instead!
@@ -14,6 +14,6 @@ assert(start <= end);
 assert(end <= PTR(FooBytes, ctx->receiver.datum)->size);
 return foo_String_new((size_t)(end-start), (char*)PTR(FooBytes, ctx->receiver.datum)->data+start);"},
     #size
-        -> {signature: [],
+        -> {signature: [], vars: 0,
             body: "return foo_Integer_new(PTR(FooBytes, ctx->receiver.datum)->size);"}
 }!

--- a/host/main.c
+++ b/host/main.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <setjmp.h>

--- a/host/main.c
+++ b/host/main.c
@@ -17,11 +17,6 @@
 #include <fcntl.h>
 #endif
 
-#define FOO_ALLOC(type) \
-  ((type*)foo_alloc(1, sizeof(type)))
-#define FOO_ALLOC_ARRAY(n, type) \
-  ((type*)foo_alloc((n), sizeof(type)))
-
 #define PTR(type, datum) \
   ((struct type*)datum.ptr)
 
@@ -32,6 +27,10 @@
 #endif
 
 #define FOO_PANIC(...) { printf("PANIC: " __VA_ARGS__); fflush(stdout); _Exit(1); }
+
+struct FooContext;
+void* foo_alloc(size_t bytes);
+void foo_maybe_gc(struct FooContext* ctx);
 
 void foo_unimplemented(const char* message) __attribute__ ((noreturn));
 void foo_unimplemented(const char* message) {
@@ -47,15 +46,6 @@ void foo_abort(const char* message) {
   fflush(stdout);
   fflush(stderr);
   _Exit(1);
-}
-
-void* foo_alloc(size_t n, size_t size) {
-  void* new = calloc(n, size);
-  if (new) {
-    return new;
-  } else {
-    foo_abort("foo_alloc failed!");
-  }
 }
 
 union FooDatum {
@@ -96,7 +86,7 @@ struct FooSelector {
 #include "generated_selectors.h"
 
 struct FooSelector* foo_intern_new_selector(const struct FooCString* name) {
-  struct FooSelector* new = FOO_ALLOC(struct FooSelector);
+  struct FooSelector* new = calloc(1, sizeof(struct FooSelector));
   new->name = name;
   new->next = FOO_InternedSelectors;
   FOO_InternedSelectors = new;
@@ -134,19 +124,6 @@ struct FooLayout {
   struct FooSlot slots[];
 };
 
-struct FooProcess {
-  size_t size;
-  struct Foo vars[];
-};
-
-struct FooProcess* foo_process_new(size_t size) {
-  struct FooProcess* process
-    = foo_alloc(1, sizeof(struct FooProcess) + size * sizeof(struct Foo));
-  process->size = size;
-  return process;
-}
-
-struct FooContext;
 struct FooCleanup;
 typedef void (*FooCleanupFunction)(struct FooContext*, struct FooCleanup*);
 
@@ -172,8 +149,9 @@ struct FooContext {
   struct FooContext* sender;
   struct FooContext* outer_context;
   // FIXME: Doesn't really belong in context, but easier right now.
-  struct FooProcess* process;
+  struct FooArray* vars;
   struct FooCleanup* cleanup;
+  struct Foo return_value;
   // Only for methods, for others this is NULL.
   jmp_buf* ret;
   size_t size;
@@ -182,7 +160,7 @@ struct FooContext {
 
 struct FooContext* foo_alloc_context(size_t size) {
   struct FooContext* ctx
-    = foo_alloc(1, sizeof(struct FooContext) + size * sizeof(struct Foo));
+    = foo_alloc(sizeof(struct FooContext) + size * sizeof(struct Foo));
   ctx->size = size;
   return ctx;
 }
@@ -196,7 +174,7 @@ char* foo_debug_context(struct FooContext* ctx) {
   return s;
 }
 
-typedef struct Foo (*FooMethodFunction)(struct FooContext*, size_t, va_list);
+typedef struct Foo (*FooMethodFunction)(struct FooContext*);
 typedef struct Foo (*FooBlockFunction)(struct FooContext*);
 
 struct Foo foo_lexical_ref(struct FooContext* context, size_t index, size_t frame) {
@@ -250,30 +228,17 @@ struct Foo foo_Float_new(double f);
 struct Foo foo_Integer_new(int64_t n);
 struct Foo foo_String_new(size_t len, const char* s);
 struct Foo foo_vtable_typecheck(struct FooVtable* vtable, struct Foo obj);
+struct Foo FooGlobal_True;
+struct Foo FooGlobal_False;
 struct FooContext* foo_context_new_block(struct FooContext* ctx);
 
-struct FooContext* foo_context_new_main(struct FooProcess* process) {
+struct FooContext* foo_context_new_main(struct FooArray* vars) {
   struct FooContext* context = foo_alloc_context(0);
   context->info = "main";
+  context->receiver = FooGlobal_False;
   context->sender = NULL;
-  context->receiver = foo_Integer_new(0); // should be Main?
-  context->size = 0;
   context->outer_context = NULL;
-  context->process = process;
-  return context;
-}
-
-struct FooContext* foo_context_new_method(const struct FooMethod* method, struct FooContext* sender, struct Foo receiver, size_t nargs) {
-  if (method->argCount != nargs) {
-    FOO_PANIC("Wrong number of arguments to %s. Wanted: %zu, got: %zu.",
-              method->selector->name->data, method->argCount, nargs);
-  }
-  struct FooContext* context = foo_alloc_context(method->frameSize);
-  context->info = "method";
-  context->sender = sender;
-  context->receiver = receiver;
-  context->outer_context = NULL;
-  context->process = sender->process;
+  context->vars = vars;
   return context;
 }
 
@@ -281,10 +246,10 @@ struct FooContext* foo_context_new_block(struct FooContext* sender) {
   struct FooBlock* block = sender->receiver.datum.ptr;
   struct FooContext* context = foo_alloc_context(block->frameSize);
   context->info = "block";
-  context->sender = sender;
   context->receiver = block->context->receiver;
+  context->sender = sender;
   context->outer_context = block->context;
-  context->process = sender->process;
+  context->vars = sender->vars;
   for (size_t i = 0; i < block->argCount; ++i)
     context->frame[i] = sender->frame[i];
   return context;
@@ -293,9 +258,10 @@ struct FooContext* foo_context_new_block(struct FooContext* sender) {
 struct FooContext* foo_context_new_unwind(struct FooContext* ctx, struct FooBlock* block) {
   struct FooContext* context = foo_alloc_context(block->frameSize);
   context->info = "#finally:";
-  context->sender = ctx;
   context->receiver = block->context->receiver;
+  context->sender = ctx;
   context->outer_context = block->context;
+  context->vars = ctx->vars;
   assert(block->argCount == 0);
   return context;
 }
@@ -317,7 +283,7 @@ void foo_finally(struct FooContext* sender, struct FooCleanup* cleanup) {
 
 void foo_unbind(struct FooContext* sender, struct FooCleanup* cleanup) {
   struct FooUnbind* unbind = (struct FooUnbind*)cleanup;
-  sender->process->vars[unbind->index] = unbind->value;
+  sender->vars->data[unbind->index] = unbind->value;
 }
 
 struct FooInterface {
@@ -330,10 +296,13 @@ struct FooVtableList {
   struct FooVtable** data;
 };
 
+typedef void (*FooMarkFunction)(union FooDatum Foo);
+
 struct FooVtable {
   struct FooCString* name;
   struct Foo* classptr;
   struct FooVtableList inherited;
+  FooMarkFunction mark;
   size_t size;
   struct FooMethod methods[];
 };
@@ -381,31 +350,58 @@ struct Foo foo_return(struct FooContext* ctx, struct Foo value) {
     ctx = ctx->sender;
   }
   foo_cleanup(ctx);
-  return_context->receiver = value;
+  return_context->return_value = value;
   longjmp(*(jmp_buf*)return_context->ret, 1);
   FOO_PANIC("longjmp() fell through!")
 }
 
+struct FooContext* foo_context_new_method(const struct FooMethod* method,
+                                          struct FooContext* sender,
+                                          struct Foo receiver,
+                                          size_t nargs, va_list arguments) {
+  if (method->argCount != nargs) {
+    FOO_PANIC("Wrong number of arguments to %s. Wanted: %zu, got: %zu.",
+              method->selector->name->data, method->argCount, nargs);
+  }
+  if (method->frameSize < nargs) {
+    FOO_PANIC("Method %s frame too small: %zu, got %zu arguments!",
+              method->selector->name->data,
+              method->frameSize,
+              nargs);
+  }
+  assert(method->frameSize >= nargs);
+  struct FooContext* context = foo_alloc_context(method->frameSize);
+  context->info = method->selector->name->data;
+  context->sender = sender;
+  context->receiver = receiver;
+  context->outer_context = NULL;
+  context->vars = sender->vars;
+  for (size_t i = 0; i < nargs; i++) {
+    context->frame[i] = va_arg(arguments, struct Foo);
+  }
+  return context;
+}
+
 struct Foo foo_send(struct FooContext* sender,
                     const struct FooSelector* selector,
-                    struct Foo receiver, size_t nargs, ...) {
+                    struct Foo receiver,
+                    size_t nargs, ...) {
   FOO_DEBUG("/foo_send(?, %s, ...)", selector->name->data);
   va_list arguments;
   va_start(arguments, nargs);
   assert(receiver.vtable);
   const struct FooMethod* method = foo_vtable_find_method(receiver.vtable, selector);
   if (method) {
-    struct FooContext* context = foo_context_new_method(method, sender, receiver, nargs);
+    struct FooContext* context = foo_context_new_method(method, sender, receiver, nargs, arguments);
+    foo_maybe_gc(context);
     jmp_buf ret;
     context->ret = &ret;
     int jmp = setjmp(ret);
     if (jmp) {
       FOO_DEBUG("/foo_send -> non-local return from %s", selector->name->data);
-      struct Foo return_value = context->receiver;
-      context->receiver = receiver;
-      return return_value;
+      return context->return_value;
     } else {
-      struct Foo res = method->function((struct FooContext*)context, nargs, arguments);
+      struct Foo res = method->function((struct FooContext*)context);
       FOO_DEBUG("/foo_send -> local return from %s", selector->name->data);
       return res;
     }
@@ -419,7 +415,7 @@ struct Foo foo_block_new(struct FooContext* context,
                          FooBlockFunction function,
                          size_t argCount,
                          size_t frameSize) {
-  struct FooBlock* block = FOO_ALLOC(struct FooBlock);
+  struct FooBlock* block = foo_alloc(sizeof(struct FooBlock));
   block->context = context;
   block->function = function;
   block->argCount = argCount;
@@ -439,8 +435,14 @@ struct Foo FooGlobal_False =
    .datum = { .boolean = 0 }
   };
 
+struct FooArray* foo_Array_alloc(size_t size) {
+  struct FooArray* array = foo_alloc(sizeof(struct FooArray) + size*sizeof(struct Foo));
+  array->size = size;
+  return array;
+}
+
 struct Foo foo_Array_new(size_t size) {
-  struct FooArray* array = foo_alloc(1, sizeof(struct FooArray) + size*sizeof(struct Foo));
+  struct FooArray* array = foo_alloc(sizeof(struct FooArray) + size*sizeof(struct Foo));
   array->size = size;
   for (size_t i = 0; i < size; ++i) {
     array->data[i] = FooGlobal_False;
@@ -461,7 +463,7 @@ struct Foo foo_Float_new(double f) {
 }
 
 struct Foo foo_String_new(size_t len, const char* s) {
-  struct FooBytes* bytes = (struct FooBytes*)foo_alloc(1, sizeof(struct FooBytes) + len + 1);
+  struct FooBytes* bytes = (struct FooBytes*)foo_alloc(sizeof(struct FooBytes) + len + 1);
   bytes->size = len;
   memcpy(bytes->data, s, len);
   return (struct Foo) { .vtable = &FooInstanceVtable_String, .datum = { .ptr = bytes } };
@@ -483,6 +485,166 @@ void fooinit(void) {
   _setmode(_fileno(stdout), O_BINARY);
   _setmode(_fileno(stderr), O_BINARY);
 #endif
+}
+
+/**
+   GC
+
+ */
+
+enum FooMark {
+  RED = 0,
+  BLUE = 1
+};
+
+static enum FooMark current_live_mark = RED;
+
+void foo_flip_mark() {
+  current_live_mark = !current_live_mark;
+}
+
+struct FooAlloc {
+  struct FooAlloc* next;
+  enum FooMark mark;
+  size_t size;
+  char data[];
+};
+
+bool foo_mark_ptr(void* ptr) {
+  const size_t offset = offsetof(struct FooAlloc, data);
+  struct FooAlloc* alloc = (void*)((char*)ptr-offset);
+  bool new_mark = alloc->mark == current_live_mark;
+  alloc->mark = current_live_mark;
+  return new_mark;
+}
+
+void foo_mark_context(struct FooContext* ctx);
+
+void foo_mark_object(struct Foo obj) {
+  if (obj.vtable) {
+    obj.vtable->mark(obj.datum);
+  }
+}
+
+void foo_mark_noop(union FooDatum datum) {
+  (void)datum;
+}
+
+void foo_mark_array(union FooDatum datum) {
+  struct FooArray* array = PTR(FooArray, datum);
+  if (foo_mark_ptr(array)) {
+    for (size_t i = 0; i < array->size; i++) {
+      foo_mark_object(array->data[i]);
+    }
+  }
+}
+
+void foo_mark_block(union FooDatum datum) {
+  struct FooBlock* block = PTR(FooBlock, datum);
+  if (foo_mark_ptr(block)) {
+    foo_mark_context(block->context);
+  }
+}
+
+void foo_mark_cleanup(struct FooCleanup* cleanup) {
+  if (!cleanup) {
+      return;
+  }
+  if (cleanup->function == foo_finally) {
+    return foo_mark_block((union FooDatum){ .ptr = cleanup });
+  }
+  if (cleanup->function == foo_unbind) {
+    return foo_mark_object(((struct FooUnbind*)cleanup)->value);
+  }
+  FOO_PANIC("invalid cleanup");
+}
+
+void foo_mark_context(struct FooContext* ctx) {
+  if (!ctx) {
+    return;
+  }
+  if (foo_mark_ptr(ctx)) {
+    foo_mark_object(ctx->receiver);
+    foo_mark_object(ctx->return_value);
+    foo_mark_context(ctx->sender);
+    foo_mark_context(ctx->outer_context);
+    // vars are shared between all contexts, foo_mark() processes
+    // them directly.
+    foo_mark_cleanup(ctx->cleanup);
+    for (size_t i = 0; i < ctx->size; i++) {
+      foo_mark_object(ctx->frame[i]);
+    }
+  }
+}
+
+static struct FooAlloc* allocations = NULL;
+static size_t allocation_count_since_gc = 0;
+static size_t allocation_bytes_since_gc = 0;
+static size_t allocation_bytes = 0;
+static size_t allocation_count = 0;
+
+// Intentionally low threshold so that GC gets exercised even for trivial tests.
+const size_t gc_threshold = 512;
+const bool gc_verbose = false;
+
+void foo_sweep() {
+  struct FooAlloc** tail = &allocations;
+  struct FooAlloc* head = *tail;
+  size_t freed_count = 0;
+  size_t freed_bytes = 0;
+  while (head) {
+    struct FooAlloc* next = head->next;
+    if (current_live_mark != head->mark) {
+      *tail = next;
+      freed_bytes += head->size;
+      freed_count += 1;
+      // free(head);
+    }
+    head = next;
+  }
+  if (freed_count > 0) {
+    allocation_bytes -= freed_bytes;
+    allocation_count -= freed_count;
+    if (gc_verbose) {
+      fprintf(stderr, "** GC'd %zu bytes in %zu objects, %zu bytes in %zu objects remain.\n",
+              freed_bytes, freed_count,
+              allocation_bytes, allocation_count);
+      fprintf(stderr, "** %zu bytes in %zu objects allocated since last gc.\n",
+              allocation_bytes_since_gc, allocation_count_since_gc);
+    }
+    allocation_count_since_gc = 0;
+    allocation_bytes_since_gc = 0;
+  }
+}
+
+void foo_maybe_gc(struct FooContext* ctx) {
+  if (allocation_bytes_since_gc > gc_threshold) {
+    foo_flip_mark();
+    if (ctx->vars) {
+      foo_mark_array((union FooDatum){ .ptr = ctx->vars });
+    }
+    foo_mark_context(ctx);
+    foo_sweep();
+  }
+}
+
+void* foo_alloc(size_t size) {
+  size_t bytes = sizeof(struct FooAlloc) + size;
+  struct FooAlloc* p = calloc(1, bytes);
+  if (!p) {
+    foo_abort("calloc");
+  }
+  p->next = allocations;
+  p->size = bytes;
+  p->mark = current_live_mark;
+  allocations = p;
+
+  allocation_bytes_since_gc += bytes;
+  allocation_bytes += bytes;
+  allocation_count_since_gc += 1;
+  allocation_count += 1;
+
+  return p->data;
 }
 
 #include "generated_classes.c"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -98,6 +98,7 @@ impl<'a> Parser<'a> {
                 return Unwind::error(&format!("Could not read file: {}", file.to_string_lossy()))
             }
         };
+        // println!("PARSE:\n{}", &source);
         let mut parser = Parser::new_with_path(file, &source, root);
         fun(&mut parser)
     }
@@ -942,6 +943,7 @@ fn parse_block_or_dictionary(parser: &Parser) -> Result<Expr, Unwind> {
     } else if end == Token::EOF {
         parser.eof_error("Unexpected EOF while pasing a block: expected } as block terminator")
     } else {
+        // println!("{}", &parser.source[source_location.get_span()]);
         parser.error("Expected } as block terminator")
     }
 }


### PR DESCRIPTION
  Spaghetti-stack makes this trivial.

  Biggest effort in changing codegen so that heap allocated object are
  always visible in context frame.
