### PR TITLE
Iterable#contains: uses #== instead of 'is'

### DIFF
--- a/foo/lang/iterable.foo
+++ b/foo/lang/iterable.foo
@@ -247,7 +247,7 @@ interface Iterable
 
     method contains: object
         self do: { |each|
-                   each is object
+                   each == object
                        ifTrue: { return True } }.
         False!
 

--- a/foo/lang/test_iterable.foo
+++ b/foo/lang/test_iterable.foo
@@ -106,6 +106,12 @@ interface TestIterable
                equals: [1, 10, 100, 123] asList
                testing: "with:collect:into: (size 3)"!
 
+    method testContains
+        assert true: { ["foo"] contains: "foo" }
+               testing: "contains: (true)".
+        assert false: { ["foo"] contains: "bar" }
+               testing: "contains: (false)"!
+
     method testCount
         assert that: { (self make: []) count: { |each| True }}
                equals: 0


### PR DESCRIPTION
   Plus add the missing test.
