### PR TITLE
towards self hosting: one step closer to transpiling evaluator

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -267,6 +267,9 @@ class AstInterface { name _interfaces _directMethods _instanceMethods _allInterf
     method _readerMethods
         []!
 
+    method slots
+        []!
+
     method _allInterfaces
         _allInterfaces!
 

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -558,7 +558,8 @@ class CTranspiler { output selectorMap closureFunctions
         -- Tracer _targetClassOf: value.
         (Record includes: value)
             ifTrue: { return self _recordClassFromRecord: value }.
-        (Class includes: value)
+        -- This seems wrong, but is needed. Why?
+        ((Class includes: value) or: (Interface includes: value))
             ifTrue: { return env global: value name }.
         env global: value classOf name!
 
@@ -572,6 +573,7 @@ class CTranspiler { output selectorMap closureFunctions
                                    slots: keys }!
 
     method _writeValue: value _in: env _to: out
+        -- Tracer _writeValue: value.
         (Class includes: value)
             ifTrue: { out print: "(struct Foo)\{ .vtable = &{Name mangleDirectVtable: (self _targetClassOf: value _in: env)}, .datum = \{ " }
             ifFalse: { out print: "(struct Foo)\{ .vtable = &{Name mangleInstanceVtable: (self _targetClassOf: value _in: env)}, .datum = \{ " }.

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -15,8 +15,12 @@ class Globals { dictionary }
         self dictionary: Dictionary new!
     method define: builtin
         let name = builtin name.
+        let global = AstGlobal
+                         name: name
+                         definition: (AstBuiltin value: builtin).
+        global value. -- finalize
         dictionary
-            put: (AstGlobal name: name definition: (AstBuiltin value: builtin))
+            put: global
             at: name!
 end
 


### PR DESCRIPTION
   Fix Globals so that values defined there are finalized immediately:
   transpiler otherwise runs into problems trying to dump the dictionary
   containing <pending> AstGlobals.

   (Though this does smell of phase confusion, I cannot actually see it.)

   Next issue is that Class and Interface are globals undefined in self hosted
   implementation, including the transpiler.
