### PR TITLE
towards self-hosting: getting #testRuntimeClass to pass, partially

### DIFF
--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -186,9 +186,9 @@ define Builtins [
      Builtin
          type: Class
          value: Class
-         mark: "foo_mark_none" -- FIXME: need gc flag in classes
+         mark: "foo_mark_class"
          directMethods: Dictionary new
-         instanceMethods: class.Methods,
+         instanceMethods: class.InstanceMethods,
      Builtin
          type: Class
          value: Clock
@@ -291,6 +291,7 @@ end
 define AlwaysEmittedSelectors
     [#__doSelectors:,
      #perform:with:,
+     #selector,
      #writeString:]!
 
 define $home
@@ -398,7 +399,7 @@ class CTranspiler { output selectorMap closureFunctions
     method _methodDeclaration: aMethod
         output print: "struct Foo ".
         output print: (Name mangleMethod: aMethod).
-        output println: "(struct FooContext*);"!
+        output println: "(const struct FooMethod*, struct FooContext*);"!
 
     method writeDefinitions
         -- Processing a definition can produce new global references. Visit
@@ -829,12 +830,14 @@ class CTranspiler { output selectorMap closureFunctions
             = self _generateInheritance: anInterface forMetaclass: True.
         let classInheritance
             = self _generateInheritance: anInterface forMetaclass: False.
+        let metaclassNameString = "{anInterface name} interface".
         output println: "struct FooClass {metaclassName} = ".
         output println: "\{".
-        output println: "    .name = &FOO_CSTRING({anInterface name displayString}\" interface\"),".
+        output println: "    .name = &{self constantCName: metaclassNameString in: env},".
         output println: "    .inherited = &{metaclassInheritance},".
-        output println: "    .size = {directMethods size},".
         output println: "    .mark = foo_mark_none,".
+        output println: "    .gc = false,".
+        output println: "    .size = {directMethods size},".
         output println: "    .methods = \{".
         directMethods
             do: { |each|
@@ -842,7 +845,8 @@ class CTranspiler { output selectorMap closureFunctions
                   output println: "                            .class = &{each methodHomeName},".
                   output println: "                            .argCount = {each arity},".
                   output println: "                            .frameSize = {each frameSize},".
-                  output println: "                            .function = &{each methodFunctionName} }," }.
+                  output println: "                            .function = &{each methodFunctionName},".
+                  output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL } } }," }.
         output println: "    }".
         output println: "};".
         output newline.
@@ -850,10 +854,11 @@ class CTranspiler { output selectorMap closureFunctions
         -- FIXME: for runtime instantiation of classes we need to add the instance methods here!
         output println: "struct FooClass {className} = ".
         output println: "\{".
-        output println: "    .name = &FOO_CSTRING({anInterface name displayString}),".
+        output println: "    .name = &{self constantCName: anInterface name in: env},".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
-        output println: "    .mark = NULL,". -- FIXME!
+        output println: "    .mark = foo_mark_none,".
+        output println: "    .gc = false,".
         output println: "    .size = 0,".
         output println: "    .methods = \{}".
         output println: "};".
@@ -878,8 +883,9 @@ class CTranspiler { output selectorMap closureFunctions
                       methodFunctionName: (Name mangleMethod: ctorProto) }.
         output print: "struct Foo ".
         output println: ctor methodFunctionName.
-        output println: "    (struct FooContext* ctx)".
+        output println: "    (const struct FooMethod* method, struct FooContext* ctx)".
         output println: "\{".
+        output println: "    (void)method;".
         output println: "    (void)ctx;".
         output println: "    struct FooArray* new = FooArray_alloc({aClass slots size} * sizeof(struct Foo));".
         aClass slots
@@ -931,8 +937,11 @@ class CTranspiler { output selectorMap closureFunctions
  * {classNote}
  *
  */".
+        let isTheClass = aClass isBuiltin and: aClass name == "Class".
         let className = Name mangleClass: aClass.
-        let metaclassName = Name mangleMetaclass: aClass.
+        let metaclassName = isTheClass
+                                ifTrue: { className }
+                                ifFalse: { Name mangleMetaclass: aClass }.
         let globalName = Name mangleGlobal: aClass.
         -- Augmented later with: constructor (aka ctor), #includes:, and #name
         let directMethods = aClass directMethods asList.
@@ -944,38 +953,46 @@ class CTranspiler { output selectorMap closureFunctions
             do: { |each| self _writeMethod: each _for: aClass name }.
         aClass isBuiltin
             ifFalse: { directMethods add: (self _generateClassConstructor: aClass) }.
-        directMethods add: (self _generateClassIncludes: aClass).
-        directMethods add: (self _generateClassClassOf: aClass).
-        directMethods add: (self _generateClassName: aClass).
+        let classMethods = isTheClass
+                               ifTrue: { instanceMethods }
+                               ifFalse:{ directMethods }.
+        classMethods add: (self _generateClassIncludes: aClass).
+        classMethods add: (self _generateClassClassOf: aClass).
+        classMethods add: (self _generateClassName: aClass).
         instanceMethods add: (self _generateInstanceClassOf: aClass).
-        -- Interfaces
-        let metaclassInheritance
-            = self _generateInheritance: aClass forMetaclass: True.
-        let classInheritance
-            = self _generateInheritance: aClass forMetaclass: False.
-        -- Class metaclass
-        output println: "struct FooClass {metaclassName} = ".
-        output println: "\{".
-        output println: "    .name = &FOO_CSTRING({aClass name displayString}\" class\"),".
-        output println: "    .metaclass = &FooClass_Class,".
-        output println: "    .inherited = &{metaclassInheritance},".
-        output println: "    .mark = foo_mark_none,".
-        output println: "    .size = {directMethods size},".
-        output println: "    .methods = \{".
-        directMethods
-            do: { |each|
-                  output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
-                  output println: "                            .class = &{each methodHomeName},".
-                  output println: "                            .argCount = {each arity},".
-                  output println: "                            .frameSize = {each frameSize},".
-                  output println: "                            .function = &{each methodFunctionName} }," }.
-        output println: "    }".
-        output println: "};".
-        output newline.
+        isTheClass
+            ifFalse: { -- Class metaclass
+                       let metaclassInheritance
+                           = self _generateInheritance: aClass forMetaclass: True.
+                       let metaclassNameString = "{aClass name} class".
+                       output println: "struct FooClass {metaclassName} = ".
+                       output println: "\{".
+                       output println: "    .name = &{self constantCName: metaclassNameString in: env}, /* a */".
+                       output println: "    .metaclass = &FooClass_Class,".
+                       output println: "    .inherited = &{metaclassInheritance},".
+                       output println: "    .mark = foo_mark_none,".
+                       output println: "    .gc = false,".
+                       output println: "    .size = {directMethods size},".
+                       output println: "    .methods = \{".
+                       directMethods
+                           do: { |each|
+                                 output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
+                                 output println: "                            .class = &{each methodHomeName},".
+                                 output println: "                            .argCount = {each arity},".
+                                 output println: "                            .frameSize = {each frameSize},".
+                                 output println: "                            .function = &{each methodFunctionName},".
+                                 output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL } } }," }.
+                       output println: "    }".
+                       output println: "};".
+                       output newline }.
         -- Instance Class
+        let classInheritance = isTheClass
+                                   ifTrue: { "FooClassInheritance_Class" }
+                                   ifFalse: { self _generateInheritance: aClass forMetaclass: False }.
+
         output println: "struct FooClass {className} = ".
         output println: "\{".
-        output println: "    .name = &FOO_CSTRING({aClass name displayString}),".
+        output println: "    .name = &{self constantCName: aClass name in: env}, /* b */".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
         output println: "    .mark = {aClass markFunction},".
@@ -987,13 +1004,15 @@ class CTranspiler { output selectorMap closureFunctions
                   output println: "                            .class = &{each methodHomeName},".
                   output println: "                            .argCount = {each arity},".
                   output println: "                            .frameSize = {each frameSize},".
-                  output println: "                            .function = &{each methodFunctionName} }," }.
+                  output println: "                            .function = &{each methodFunctionName},".
+                  output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL \}\}\}," }.
         -- #__doSelectors
         output println: "        (struct FooMethod)\{ .selector = &FOO_____doSelectors_,".
         output println: "                            .class = NULL,".
         output println: "                            .argCount = 1,".
         output println: "                            .frameSize = 1,".
-        output println: "                            .function = &foo_method_doSelectors_ }".
+        output println: "                            .function = &foo_method_doSelectors_,".
+        output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL \}\}\},".
         output println: "    }".
         output println: "};".
         output newline.
@@ -1021,8 +1040,9 @@ class CTranspiler { output selectorMap closureFunctions
         let $home = aMethod.
         output print: "struct Foo ".
         output println: name.
-        output println: "    (struct FooContext* ctx)".
+        output println: "    (const struct FooMethod* method, struct FooContext* ctx)".
         output println: "\{".
+        output println: "    (void)method;".
         output println: "    (void)ctx;".
         aMethod signature
             doWithIndex: { |type index|

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -800,18 +800,20 @@ class TestTranspileDefine { assert system }
             expect: "#<Boolean True>"!
 
     method testDefineClassInstance
-        self transpile: "class MyClass \{ x y }
-                             method value
-                                 x + y!
-                         end
+        self transpileWithPrelude:
+            "class MyClass \{ x y }
+                 is Object
+                 method value
+                     x + y!
+             end
 
-                         define MyValue MyClass x: 40 y: 1202!
+             define MyValue MyClass x: 40 y: 1202!
 
-                         class Main \{}
-                             direct method run: command in: system
-                                 MyValue value debug.
-                                 MyValue x debug!
-                         end"
+             class Main \{}
+                 direct method run: command in: system
+                     MyValue value debug.
+                     MyValue x debug!
+             end"
             expect: "#<Integer 1242>#<Integer 40>"!
 
     method testDefineFloat
@@ -1100,26 +1102,25 @@ end
 class TestTranspileClass { assert system }
    is TranspilerTest
 
-    method wip_testRuntimeClass
-        self transpile:
-            "class BlockMethod \{ name block \}
+    method test0RuntimeClass
+        self transpileWithPrelude:
+            "class BlockMethod \{ selector block \}
                  method invoke: args on: receiver
                      block apply: ([receiver] append: args)!
              end
 
              class Main \{\}
                   direct method run: command in: system
-                      let test = Class
-                                    new: \"test\"
-                                    slots: []
-                                    interfaces: []
-                                    directMethods: [(BlockMethod
-                                                         name: #one
-                                                         block: \{ |r| 1 \})]
-                                    instanceMethods: [].
-                      system output print: test one!
+                      let test = Class name: \"test class\"
+                                       layout: Layout empty
+                                       methods: [(BlockMethod
+                                                     selector: #slots
+                                                     block: \{ |r| 1 \})].
+                      -- let instance = test layout makeInstanceOf: test.
+                      -- system output print: instance one!
+                      system output print: test name!
              end"
-            expect: "1"!
+            expect: "test class"!
 
     method testMyClass
         self transpile: "class MyClass \{}

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,7 +1,41 @@
-define Methods {
-     #name
-     -> { signature: [], vars: 0,
-          body: "struct FooClass* class = PTR(FooClass, ctx->receiver.datum);
-                 struct FooCString* name = class->name;
-                 return foo_String_new(name->size, name->data);" }
+define InstanceMethods {
+     #name:layout:methods:
+     -> { signature: [String, Any, Array], vars: 1,
+          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);
+                 size_t n = methods->size;
+                 struct FooClass* newclass
+                   = foo_alloc(sizeof(struct FooClass) + n*sizeof(struct FooMethod));
+
+                 newclass->name = PTR(FooBytes, ctx->frame[0].datum);
+                 newclass->metaclass = &FooClass_Class;
+                 newclass->inherited = &FooClassInheritance_Class;
+                 newclass->mark = foo_mark_none;
+                 newclass->gc = true;
+                 newclass->size = 0;
+
+                 /* Make the new class visible to GC. */
+                 ctx->frame[3] = (struct Foo)
+                   \{ .class = &FooClass_Class,
+                      .datum = \{ .ptr = newclass }};
+
+                 for (size_t i = 0; i < n; i++) \{
+                   struct Foo method_object = methods->data[i];
+                   struct Foo selector = foo_send(ctx, &FOO_selector, method_object, 0);
+                   foo_class_typecheck(ctx, &FooClass_Selector, selector);
+                   struct Foo nargs = foo_send(ctx, &FOO_arity, selector, 0);
+                   foo_class_typecheck(ctx, &FooClass_Integer, nargs);
+
+                   struct FooMethod* m = &newclass->methods[i];
+                   m->class = newclass;
+                   m->selector = PTR(FooSelector, selector.datum);
+                   m->argCount = nargs.datum.int64;
+                   m->frameSize = nargs.datum.int64;
+                   m->object = method_object;
+
+                   /* Update the size once the method is in place,
+                      so GC sees it. */
+                   newclass->size++;
+                 }
+                 return ctx->frame[3];"
+          }
 }!

--- a/foo/lang/layout.foo
+++ b/foo/lang/layout.foo
@@ -1,0 +1,4 @@
+class Layout { slots }
+    direct method empty
+        self slots: []!
+end

--- a/foo/lang/prelude.foo
+++ b/foo/lang/prelude.foo
@@ -15,6 +15,7 @@ import .exception.Error
 import .exception.Panic
 import .exception.RequiredMethodMissing
 import .exception.TypeError
+import .layout.Layout
 import .file.File
 import .filepath.FilePath
 import .filestream.FileStream

--- a/foo/prelude.foo
+++ b/foo/prelude.foo
@@ -15,6 +15,7 @@ import .lang.exception.Error
 import .lang.exception.Panic
 import .lang.exception.RequiredMethodMissing
 import .lang.exception.TypeError
+import .lang.layout.Layout
 import .lang.file.File
 import .lang.filepath.FilePath
 import .lang.filestream.FileStream

--- a/src/classes/system.rs
+++ b/src/classes/system.rs
@@ -49,14 +49,14 @@ fn system_command(_receiver: &Object, args: &[Object], env: &Env) -> Eval {
     match output {
         Ok(output) => {
             let ok = output.status.success();
-            let stdout = std::str::from_utf8(&output.stdout).expect("Command stdout was not UTF-8");
-            let stderr = std::str::from_utf8(&output.stderr).expect("Command stderr was not UTF-8");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
             env.find_global_or_unwind("Record")?.send(
                 "ok:stdout:stderr:",
                 &[
                     env.foo.make_boolean(ok),
-                    env.foo.make_string(stdout),
-                    env.foo.make_string(stderr),
+                    env.foo.make_string(&stdout),
+                    env.foo.make_string(&stderr),
                 ],
                 env,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn foo_main() {
         for spec in values {
             let (name, root) = find_module_or_abort(spec, &app);
             if module_roots.contains_key(&name) && module_roots[&name] != root {
-                panic!("ERROR: module {} specified multiple times with inconsistent paths");
+                panic!("ERROR: module {} specified multiple times with inconsistent paths", name);
             }
             module_roots.insert(name.to_string(), root.to_path_buf());
         }

--- a/test_foo.sh
+++ b/test_foo.sh
@@ -10,6 +10,12 @@ run() {
     fi
 }
 
-run test_foolang.foo
-run test_prelude.foo
-run test_transpile.foo
+if [ -z "$@" ]; then
+    run test_foolang.foo
+    run test_prelude.foo
+    run test_transpile.foo
+else
+    for test in "$@"; do
+        run "test_$test.foo"
+    done
+fi


### PR DESCRIPTION
  Fixed #visitClassDefinition: for Class#case, so that Class is an
  instance of itself.

  Made Class.name struct FooBytes* instead of a FooCString, so that both allocation modes
  are handled correctly.

  Added support for methods implemented by objects.

  Preliminary version of Class name:layout:methods:, as per metaobject
  protocol, enough to allocate the class instances, but cannot do much
  with them.

  - Class name:metaclass:methods:
  - Accessing class layout.
  - Constructing new instances.
