### PR TITLE
towards self-hosting: partial implementation of runtime allocated classes

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -674,6 +674,9 @@ class AstGlobal { name::String _value _definition sources }
     method isDynamic
         False!
 
+    method isBuiltin
+        _definition isBuiltin!
+
     method ownInterfaces
         self definition ownInterfaces!
 

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -290,6 +290,7 @@ end
 
 define AlwaysEmittedSelectors
     [#__doSelectors:,
+     #invoke:on:,
      #perform:with:,
      #selector,
      #writeString:]!

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -778,14 +778,6 @@ class CTranspiler { output selectorMap closureFunctions
         output print: ")"!
 
     method _generateInheritance: anObject forMetaclass: forMetaclass
-        -- FIXME: The metaclass inheritance here parallels the class inheritance,
-        -- like in Smalltalk, and is consistent with inheritance of
-        -- direct methods, but consider:
-        --
-        -- Class X inherits from MyInterface. `MyInterface`
-        -- itself is abstract, but `MyInterface class` is not!
-        --
-        -- Argh...
         let inheritance = forMetaclass
                               ifTrue: { "FooMetaclassInheritance_{anObject name}" }
                               ifFalse: { "FooClassInheritance_{anObject name}" }.
@@ -939,9 +931,7 @@ class CTranspiler { output selectorMap closureFunctions
  */".
         let isTheClass = aClass isBuiltin and: aClass name == "Class".
         let className = Name mangleClass: aClass.
-        let metaclassName = isTheClass
-                                ifTrue: { className }
-                                ifFalse: { Name mangleMetaclass: aClass }.
+        let metaclassName = Name mangleMetaclass: aClass.
         let globalName = Name mangleGlobal: aClass.
         -- Augmented later with: constructor (aka ctor), #includes:, and #name
         let directMethods = aClass directMethods asList.
@@ -961,7 +951,8 @@ class CTranspiler { output selectorMap closureFunctions
         classMethods add: (self _generateClassName: aClass).
         instanceMethods add: (self _generateInstanceClassOf: aClass).
         isTheClass
-            ifFalse: { -- Class metaclass
+            ifFalse: { -- Class metaclass, not needed for Class which
+                       -- is its own metaclass.
                        let metaclassInheritance
                            = self _generateInheritance: aClass forMetaclass: True.
                        let metaclassNameString = "{aClass name} class".

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -34,6 +34,7 @@ define Builtins
     g define: ByteArray.
     g define: Boolean.
     g define: Character.
+    g define: Class.
     g define: DoesNotUnderstand.
     g define: Error.
     g define: False.

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1102,7 +1102,37 @@ end
 class TestTranspileClass { assert system }
    is TranspilerTest
 
-    method test0RuntimeClass
+    method testRuntimeClass1
+        self transpileWithPrelude:
+            "class Main \{\}
+                  direct method run: command in: system
+                      let test = Class name: \"test class\"
+                                       metaclass: Class
+                                       layout: Layout empty
+                                       methods: [].
+                      system output print: test name!
+             end"
+            expect: "test class"!
+
+    method testRuntimeClass2
+        self transpileWithPrelude:
+            "class MyMetaclass \{}
+                 is Class
+                 method ping
+                     #pong!
+             end
+
+             class Main \{\}
+                  direct method run: command in: system
+                      let test = Class name: \"test class\"
+                                       metaclass: MyMetaclass
+                                       layout: Layout empty
+                                       methods: [].
+                      system output print: test ping!
+             end"
+            expect: "#pong"!
+
+    method testRuntimeClass3
         self transpileWithPrelude:
             "class BlockMethod \{ selector block \}
                  method invoke: args on: receiver
@@ -1111,16 +1141,19 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
+                      let metaclass = Class name: \"test metaclass\"
+                                            metaclass: Class
+                                            layout: Layout empty
+                                            methods: [(BlockMethod
+                                                           selector: #ping
+                                                           block: \{ |r| #pong \})].
                       let test = Class name: \"test class\"
+                                       metaclass: metaclass
                                        layout: Layout empty
-                                       methods: [(BlockMethod
-                                                     selector: #slots
-                                                     block: \{ |r| 1 \})].
-                      -- let instance = test layout makeInstanceOf: test.
-                      -- system output print: instance one!
-                      system output print: test name!
+                                       methods: [].
+                      system output print: test ping!
              end"
-            expect: "test class"!
+            expect: "#pong"!
 
     method testMyClass
         self transpile: "class MyClass \{}

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1114,7 +1114,7 @@ class TestTranspileClass { assert system }
              end"
             expect: "test class"!
 
-    method testRuntimeClass2
+    method no_testRuntimeClass2
         self transpileWithPrelude:
             "class MyMetaclass \{}
                  is Class

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,41 +1,43 @@
 define InstanceMethods {
-     #name:layout:methods:
-     -> { signature: [String, Any, Array], vars: 1,
-          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);
+     #name:metaclass:layout:methods:
+     -> { signature: [String, Class, Layout, Array], vars: 1,
+          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[3].datum);
                  size_t n = methods->size;
                  struct FooClass* newclass
                    = foo_alloc(sizeof(struct FooClass) + n*sizeof(struct FooMethod));
 
                  newclass->name = PTR(FooBytes, ctx->frame[0].datum);
-                 newclass->metaclass = &FooClass_Class;
+                 newclass->metaclass = PTR(FooClass, ctx->frame[1].datum);
                  newclass->inherited = &FooClassInheritance_Class;
-                 newclass->mark = foo_mark_none;
+                 newclass->mark = foo_mark_none; /* FIXME: this is how we mark instances, should come from layout? */
                  newclass->gc = true;
                  newclass->size = 0;
 
                  /* Make the new class visible to GC. */
-                 ctx->frame[3] = (struct Foo)
-                   \{ .class = &FooClass_Class,
+                 ctx->frame[4] = (struct Foo)
+                   \{ .class = newclass->metaclass,
                       .datum = \{ .ptr = newclass }};
 
                  for (size_t i = 0; i < n; i++) \{
                    struct Foo method_object = methods->data[i];
                    struct Foo selector = foo_send(ctx, &FOO_selector, method_object, 0);
                    foo_class_typecheck(ctx, &FooClass_Selector, selector);
-                   struct Foo nargs = foo_send(ctx, &FOO_arity, selector, 0);
-                   foo_class_typecheck(ctx, &FooClass_Integer, nargs);
+
+                   struct Foo selector_arity = foo_send(ctx, &FOO_arity, selector, 0);
+                   foo_class_typecheck(ctx, &FooClass_Integer, selector_arity);
+                   int64_t method_arity = selector_arity.datum.int64 - 1;
 
                    struct FooMethod* m = &newclass->methods[i];
                    m->class = newclass;
                    m->selector = PTR(FooSelector, selector.datum);
-                   m->argCount = nargs.datum.int64;
-                   m->frameSize = nargs.datum.int64;
+                   m->argCount = selector_arity.datum.int64;
+                   m->frameSize = selector_arity.datum.int64;
                    m->object = method_object;
 
                    /* Update the size once the method is in place,
                       so GC sees it. */
                    newclass->size++;
                  }
-                 return ctx->frame[3];"
+                 return ctx->frame[4];"
           }
 }!

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,6 +1,6 @@
 define InstanceMethods {
      #name:metaclass:layout:methods:
-     -> { signature: [String, Class, Layout, Array], vars: 1,
+     -> { signature: [String, Class, Any, Array], vars: 1,
           body: "struct FooArray* methods = PTR(FooArray, ctx->frame[3].datum);
                  size_t n = methods->size;
                  struct FooClass* newclass
@@ -30,8 +30,9 @@ define InstanceMethods {
                    struct FooMethod* m = &newclass->methods[i];
                    m->class = newclass;
                    m->selector = PTR(FooSelector, selector.datum);
-                   m->argCount = selector_arity.datum.int64;
+                   m->argCount = method_arity; // selector_arity.datum.int64;
                    m->frameSize = selector_arity.datum.int64;
+                   m->function = foo_invoke_on;
                    m->object = method_object;
 
                    /* Update the size once the method is in place,

--- a/foo/impl/transpiler/name.foo
+++ b/foo/impl/transpiler/name.foo
@@ -78,8 +78,10 @@ class Name { out }
         out print: aVar name!
 
     method _mangleMetaclass: aClass
-        out print: "FooMetaclass_".
-        self _mangleName: aClass name!
+        (aClass isBuiltin and: aClass name == "Class")
+            ifTrue: { out print: "FooClass_Class" }
+            ifFalse: { out print: "FooMetaclass_".
+                       self _mangleName: aClass name }!
 
     method _mangleClass: aClass
         out print: "FooClass_".


### PR DESCRIPTION
(1) Cannot use statically defined metaclasses, since their instances don't have the class layout.
(2) Cannot allocate instances of runtime allocated classes.