### PR TITLE
Nicer class instantiation

### DIFF
--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -190,7 +190,7 @@ define Builtins [
          type: Class
          value: Class
          mark: "foo_mark_class"
-         directMethods: Dictionary new
+         directMethods: class.InstanceMethods -- class is its own instance
          instanceMethods: class.InstanceMethods,
      Builtin
          type: Class

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1188,8 +1188,7 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
-                      let test = Class name: \"test class\"
-                                       metaclass: Class
+                      let test = Class new: \"test class\"
                                        layout: Layout empty
                                        methods: [].
                       system output print: test name!
@@ -1209,10 +1208,10 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
-                      let test = Class name: \"test class\"
-                                       metaclass: MyMetaclass
-                                       layout: Layout empty
-                                       methods: [].
+                      let test = MyMetaclass
+                                     new: \"test class\"
+                                     layout: Layout empty
+                                     methods: [].
                       system output print: test ping!
              end"
             expect: "#pong"!
@@ -1233,16 +1232,14 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
-                      let metaclass = Class name: \"test metaclass\"
-                                            metaclass: Class
+                      let metaclass = Class new: \"test metaclass\"
                                             layout: Layout empty
                                             methods: [(BlockMethod
                                                            selector: #ping
                                                            block: \{ |r| #pong \})].
-                      let test = Class name: \"test class\"
-                                       metaclass: metaclass
-                                       layout: Layout empty
-                                       methods: [].
+                      let test = metaclass new: \"test class\"
+                                           layout: Layout empty
+                                           methods: [].
                       system output print: test ping!
              end"
             expect: "#pong"!

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,20 +1,20 @@
 define InstanceMethods {
-     #name:metaclass:layout:methods:
-     -> { signature: [String, Class, Any, Array], vars: 1,
-          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[3].datum);
+     #new:layout:methods:
+     -> { signature: [String, Any, Array], vars: 1,
+          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);
                  size_t n = methods->size;
                  struct FooClass* newclass
                    = foo_alloc(sizeof(struct FooClass) + n*sizeof(struct FooMethod));
 
                  newclass->name = PTR(FooBytes, ctx->frame[0].datum);
-                 newclass->metaclass = PTR(FooClass, ctx->frame[1].datum);
+                 newclass->metaclass = PTR(FooClass, ctx->receiver.datum);
                  newclass->inherited = &FooClassInheritance_Class;
                  newclass->mark = foo_mark_none; /* FIXME: this is how we mark instances, should come from layout? */
                  newclass->gc = true;
                  newclass->size = 0;
 
                  /* Make the new class visible to GC. */
-                 ctx->frame[4] = (struct Foo)
+                 ctx->frame[3] = (struct Foo)
                    \{ .class = newclass->metaclass,
                       .datum = \{ .ptr = newclass }};
 
@@ -39,6 +39,6 @@ define InstanceMethods {
                       so GC sees it. */
                    newclass->size++;
                  }
-                 return ctx->frame[4];"
+                 return ctx->frame[3];"
           }
 }!

--- a/host/main.c
+++ b/host/main.c
@@ -417,10 +417,6 @@ struct Foo foo_class_typecheck(struct FooContext* ctx,
     if (class == list->data[i]) {
       return obj;
   }
-  FOO_XXX("Object class: %s", obj.class->name->data);
-  for (size_t i = 0; i < list->size; i++) {
-    FOO_XXX("  is %s", list->data[i]->name->data);
-  }
   foo_panicf(ctx, "Type error! Wanted: %s, got: %s",
              class->name->data, obj.class->name->data);
 }


### PR DESCRIPTION
Instead of going through `Class name:metaclass:layout:methods:`, use the metaclass as the receiver.
