### PR TITLE
motivational example for metaclasses

### DIFF
--- a/foo/lang/test.foo
+++ b/foo/lang/test.foo
@@ -3,6 +3,10 @@ import .exception.*
 import .output
 
 interface TestSuite
+    direct method run: command in: system
+        self runTests: (Assert reportingTo: system output)
+             in: system!
+
     direct method runTests: assert in: system
         (self assert: assert) runTestsIn: system!
 

--- a/foo/lib/assert.foo
+++ b/foo/lib/assert.foo
@@ -168,4 +168,10 @@ class Assert { output failed }
     method false: condition testing: thing
         self that: condition is: False testing: thing!
 
+    method true: condition
+        self that: condition is: True testing: "(anonymous test)"!
+
+    method false: condition
+        self that: condition is: False testing: "(anonymous test)"!
+
 end

--- a/foo/lib/substitute.foo
+++ b/foo/lib/substitute.foo
@@ -1,0 +1,35 @@
+---
+A quick and dirty NSubstitute -thingie
+
+See: https://nsubstitute.github.io/help/getting-started/
+---
+
+class Substitute { _methods _messages }
+    direct method new
+        self _methods: Dictionary new
+             _messages: Dictionary new!
+
+    direct method for: type
+        (Class new: "Substitute<{type name}>"
+               superclass: self
+               interfaces: [type])
+        new!
+
+    method on: selector returns: value
+        _methods at: selector name put: value!
+
+    method received: selector with: args
+        (_messages at: selector name ifNone: { return False })
+            includes: args!
+
+    method perform: selector with: args
+        let name = selector toSelector name.
+        let res = _methods
+                      at: name
+                      ifNone: { Error raise: "Substitute does not understand: {selector}" }.
+        let list = _messages
+                       at: name
+                       ifNonePut: { List new }.
+        list add: args.
+        res!
+end

--- a/foo/lib/test_substitute.foo
+++ b/foo/lib/test_substitute.foo
@@ -1,0 +1,27 @@
+import .substitute.Substitute
+import .assert.Assert
+
+interface MyInterface
+end
+
+class Main { assert }
+    is TestSuite
+
+    method test_Substitute_returns_as_specified
+        let sub = Substitute new.
+        sub on: (#add:to:) returns: 4212.
+        assert true: { 4212 == (sub add: 1 to: 2) }!
+
+    method test_Substitute_tracks_messages
+        let sub = Substitute new.
+        sub on: (#add:to:) returns: 4212.
+        sub add: 1 to: 2.
+        assert true: { sub received: (#add:to:) with: [1,2] }.
+        assert false: { sub received: (#add:to:) with: [2,1] }!
+
+    method test_Substitute_can_implement_interface
+        let sub = Substitute for: MyInterface.
+        sub on: #foo returns: #bar.
+        assert true: { MyInterface includes: sub }.
+        assert true: { #bar == sub foo }!
+end


### PR DESCRIPTION
A very simple mock / substitute implementation, which could support mocking specified interfaces once metaclass and runtime class instantiation support is finished.
