### PR TITLE
towards self-hosting: subclassing at runtime

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 # clang-format -i host/generated_*
 
+# This tricks clang into using the internal symbolizer, leaving path
+# empty leaves the addresses unsymbolized.
+export ASAN_SYMBOLIZER_PATH=0
+
 clang \
     -o tmp_transpile_test.exe \
     -fsanitize=address -fsanitize=undefined \

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -789,6 +789,19 @@ class CTranspiler { output selectorMap closureFunctions
             interleaving: { output print: ", " }.
         output print: ")"!
 
+    method _generateLayout: aClass
+        aClass isBuiltin
+            ifTrue: { return "NULL" }. -- FIXME: proper builtin layouts
+        -- FIXME: Since user doesn't have access to these layouts,
+        -- could/should intern them.
+        let name = "FooLayout_{aClass name}".
+        output println: "struct FooLayout {name} = \{".
+        output println: "    .mark = foo_mark_oops,".
+        output println: "    .gc = false,".
+        output println: "    .size = {aClass slots size}".
+        output println: "};".
+        return "&{name}"!
+
     method _generateInheritance: anObject forMetaclass: forMetaclass
         let inheritance = forMetaclass
                               ifTrue: { "FooMetaclassInheritance_{anObject name}" }
@@ -845,6 +858,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .name = &{self constantCName: metaclassNameString in: env}, /* {metaclassNameString} */".
         output println: "    .metaclass = &FooClass_Class,".
         output println: "    .inherited = &{metaclassInheritance},".
+        output println: "    .layout = &TheClassLayout,".
         output println: "    .mark = foo_mark_none,".
         output println: "    .gc = false,".
         output println: "    .size = {directMethods size},".
@@ -867,6 +881,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .name = &{self constantCName: anInterface name in: env}, /* {anInterface name} */".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
+        output println: "    .layout = NULL,". -- FIXME
         output println: "    .mark = foo_mark_none,".
         output println: "    .gc = false,".
         output println: "    .size = {instanceMethods size},".
@@ -988,6 +1003,7 @@ class CTranspiler { output selectorMap closureFunctions
                        output println: "    .name = &{self constantCName: metaclassNameString in: env}, /* {metaclassNameString} */".
                        output println: "    .metaclass = &FooClass_Class,".
                        output println: "    .inherited = &{metaclassInheritance},".
+                       output println: "    .layout = &TheClassLayout,".
                        output println: "    .mark = foo_mark_class,".
                        output println: "    .gc = false,".
                        output println: "    .size = {directMethods size},".
@@ -1007,12 +1023,16 @@ class CTranspiler { output selectorMap closureFunctions
         let classInheritance = isTheClass
                                    ifTrue: { "FooClassInheritance_Class" }
                                    ifFalse: { self _generateInheritance: aClass forMetaclass: False }.
+        let layout = isTheClass
+                         ifTrue: { "&TheClassLayout" }
+                         ifFalse: { self _generateLayout: aClass }.
         -- Debug println: "{aClass} => {aClass markFunction}".
         output println: "struct FooClass {className} = ".
         output println: "\{".
         output println: "    .name = &{self constantCName: aClass name in: env}, /* {aClass name} */".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
+        output println: "    .layout = {layout},".
         output println: "    .mark = {aClass markFunction},".
         output println: "    .gc = false,".
         output println: "    .size = {instanceMethods size + 1},".

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1303,7 +1303,8 @@ class TestTranspileClass { assert system }
                             methods: [].
                       let testClass2
                        = testMetaclass2
-                           subclass: \"*TestClass\"
+                           new: \"*TestClass\"
+                           layout: Layout empty
                            interfaces: []
                            methods: [].
                       system output print: testClass2 instancePing!

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -25,8 +25,9 @@ interface TranspilerTest
 
     method prelude: prelude transpile: string
         let env = Environment
-                      modules: { "lang" -> system files / "foo/lang",
-                                 "impl" -> system files / "foo/impl", }
+                      modules: { "impl" -> system files / "foo/impl",
+                                 "lang" -> system files / "foo/lang",
+                                 "lib" -> system files / "foo/lib", }
                       asFileModules.
         let c = CTranspiler transpile: string in: env with: prelude.
         (system files / "host/generated_selectors.h")
@@ -94,11 +95,23 @@ interface TranspilerTest
              ok: True
              expect: output!
 
+    method transpileWithPrelude: string check: block
+        self prelude: ["lang", "prelude"] asList
+             transpile: string
+             ok: True
+             check: block!
+
     method prelude: name transpile: string ok: maybe expect: output
         assert that: { let res = self prelude: name
                                       transpile: string.
                        [res ok, res stdout] }
                equals: [maybe, output]
+               testing: "transpiler"!
+
+    method prelude: name transpile: string ok: maybe check: block
+        assert true: { let res = self prelude: name
+                                      transpile: string.
+                       block value: res }
                testing: "transpiler"!
 end
 
@@ -132,6 +145,39 @@ class TestTranspileLet { assert system }
                                  n debug!
                         end"
              expect: "#<Integer 1142>"!
+end
+
+class TestTranspileLib { assert system }
+    is TranspilerTest
+
+    method checkLines: lines match: array
+        lines with: array
+              do: { |actual expected|
+                    (actual startsWith: expected)
+                        ifFalse: { system output println: "\ncheckLines: '{actual}' does not start with '{expected}'".
+                                   return False } }
+                        ifExhausted: { system output println: "\ncheckLines: size mismatch! {lines size} lines, expected {array size}".
+                                       system output println: "got: {lines}".
+                                       return False }.
+        True!
+
+    method test_Substitute
+        self
+            transpileWithPrelude:
+                "import lib.test_substitute.*
+                 import lib.assert
+
+                 class Main \{}
+                     direct method run: command in: system
+                         TestSubstitute run: command in: system!
+                 end"
+            check: { |res|
+                     res ok
+                         ifTrue: { self checkLines: (res stdout lines reject: #isEmpty)
+                                        match: ["- test_Substitute_can_implement_interface",
+                                                "- test_Substitute_returns_as_specified",
+                                                "- test_Substitute_tracks_messages"] }
+                        ifFalse: { False } }!
 end
 
 class TestTranspilePanic { assert system }
@@ -2195,6 +2241,7 @@ class Main {}
             "--interface" -> TestTranspileInterface,
             "--keyword" -> TestTranspileKeyword,
             "--let" -> TestTranspileLet,
+            "--lib" -> TestTranspileLib,
             "--panic" -> TestTranspilePanic,
             "--perform-with" -> TestTranspilePerformWith,
             "--prelude-any" -> TestTranspilePreludeAny,

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1193,8 +1193,7 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
-                      let test = Class new: \"test class\"
-                                       layout: Layout forClass
+                      let test = Class subclass: \"test class\"
                                        interfaces: []
                                        methods: [].
                       system output print: test name!
@@ -1241,8 +1240,7 @@ class TestTranspileClass { assert system }
                   direct method run: command in: system
                       let testMetaclass1
                         = Class
-                            new: \"*TestMetaClass1\"
-                            layout: Layout forClass
+                            subclass: \"*TestMetaClass1\"
                             interfaces: [MyInterface classOf]
                             methods: [].
                       let testClass1
@@ -1254,14 +1252,12 @@ class TestTranspileClass { assert system }
                       system output println: testClass1 directPing.
                       let testMetaclass2
                         = Class
-                            new: \"*TestMetaClass1\"
-                            layout: Layout forClass
+                            subclass: \"*TestMetaClass1\"
                             interfaces: [MyInterface]
                             methods: [].
                       let testClass2
                        = testMetaclass2
-                           new: \"*TestClass\"
-                           layout: Layout forClass
+                           subclass: \"*TestClass\"
                            interfaces: []
                            methods: [].
                       system output print: testClass2 instancePing!
@@ -1290,9 +1286,8 @@ class TestTranspileClass { assert system }
                       let layout = Layout new: 1.
                       let testMetaclass
                         = Class
-                            new: \"*TestSlotsMetaclass\"
-                            layout: Layout forClass
-                            interfaces: [Class]
+                            subclass: \"*TestSlotsMetaclass\"
+                            interfaces: []
                             methods: [(BlockMethod
                                         selector: (#new:)
                                         block: \{ |r a|
@@ -1313,9 +1308,8 @@ class TestTranspileClass { assert system }
                       let layout = Layout new: 3.
                       let testMetaclass
                         = Class
-                            new: \"*TestSlotsMetaclass\"
-                            layout: Layout forClass
-                            interfaces: [Class]
+                            subclass: \"*TestSlotsMetaclass\"
+                            interfaces: []
                             methods: [(BlockMethod
                                         selector: (#a:b:c:)
                                         block: \{ |r a b c|
@@ -1340,9 +1334,8 @@ class TestTranspileClass { assert system }
                       let layout = Layout empty.
                       let testMetaclass
                         = Class
-                            new: \"*TestMetaclass\"
-                            layout: Layout forClass
-                            interfaces: [Class]
+                            subclass: \"*TestMetaclass\"
+                            interfaces: []
                             methods: [(BlockMethod
                                         selector: (#new)
                                         block: \{ |r|
@@ -1375,8 +1368,7 @@ class TestTranspileClass { assert system }
 
              class Main \{\}
                   direct method run: command in: system
-                      let metaclass = Class new: \"test metaclass\"
-                                            layout: Layout forClass
+                      let metaclass = Class subclass: \"test metaclass\"
                                             interfaces: []
                                             methods: [(BlockMethod
                                                            selector: #ping

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,4 +1,64 @@
-define InstanceMethods {
+define InstanceMethods
+{
+     #subclass:interfaces:methods:
+     -> { signature: [String, Array, Array], vars: 1,
+          body: "struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);
+                 struct FooClass* newclass
+                   = foo_alloc(sizeof(struct FooClass)
+                               + methods->size * sizeof(struct FooMethod));
+                 struct FooClass* super = PTR(FooClass, ctx->receiver.datum);
+                 struct FooArray* interfaces = PTR(FooArray, ctx->frame[1].datum);
+                 struct FooPointerList* inherited = foo_ClassList_alloc(interfaces->size + 1);
+                 inherited->data[0] = super;
+                 for (size_t i = 0; i < interfaces->size; i++) \{
+                     struct Foo obj = interfaces->data[i];
+                     foo_class_typecheck(ctx, &FooClass_Class, obj);
+                     inherited->data[i+1] = obj.datum.ptr;
+                 \}
+
+                 if (!super->layout) \{
+                     assert(super->name);
+                     assert(super->name->data);
+                     foo_panicf(ctx, \"Superclass has no layout: %s\", super->name->data);
+                 \}
+
+                 newclass->name = PTR(FooBytes, ctx->frame[0].datum);
+                 newclass->metaclass = super->metaclass;
+                 newclass->inherited = inherited;
+                 newclass->layout = super->layout;
+                 newclass->mark = super->mark;
+                 newclass->gc = true;
+                 newclass->size = 0;
+
+                 /* Make the new class visible to GC. */
+                 ctx->frame[3] = (struct Foo)
+                   \{ .class = newclass->metaclass,
+                      .datum = \{ .ptr = newclass } };
+
+                 for (size_t i = 0; i < methods->size; i++) \{
+                   struct Foo method_object = methods->data[i];
+                   struct Foo selector = foo_send(ctx, &FOO_selector, method_object, 0);
+                   foo_class_typecheck(ctx, &FooClass_Selector, selector);
+
+                   struct Foo selector_arity = foo_send(ctx, &FOO_arity, selector, 0);
+                   foo_class_typecheck(ctx, &FooClass_Integer, selector_arity);
+                   int64_t method_arity = selector_arity.datum.int64 - 1;
+
+                   struct FooMethod* m = &newclass->methods[i];
+                   m->class = newclass;
+                   m->selector = PTR(FooSelector, selector.datum);
+                   m->argCount = method_arity;
+                   m->frameSize = selector_arity.datum.int64;
+                   m->function = foo_invoke_on;
+                   m->object = method_object;
+
+                   /* Update the size once the method is in place,
+                      so GC sees it. */
+                   newclass->size++;
+                 }
+                 return ctx->frame[3];"
+        },
+
      #new:layout:interfaces:methods:
      -> { signature: [String, Layout, Array, Array], vars: 1,
           body: "struct FooArray* methods = PTR(FooArray, ctx->frame[3].datum);
@@ -22,17 +82,10 @@ define InstanceMethods {
                  newclass->gc = true;
                  newclass->size = 0;
 
-                 /* Make the new class visible to GC. Null pointers
-                  * in inheritance list are allowed by GC. */
+                 /* Make the new class visible to GC. */
                  ctx->frame[4] = (struct Foo)
                    \{ .class = newclass->metaclass,
                       .datum = \{ .ptr = newclass } };
-
-                 for (size_t i = 0; i < interfaces->size; i++) \{
-                   struct Foo class_object = interfaces->data[i];
-                   foo_class_typecheck(ctx, &FooClass_Class, class_object);
-                   inherited->data[i] = PTR(FooClass, class_object.datum);
-                 }
 
                  for (size_t i = 0; i < methods->size; i++) \{
                    struct Foo method_object = methods->data[i];

--- a/foo/impl/transpiler/layout.foo
+++ b/foo/impl/transpiler/layout.foo
@@ -7,14 +7,6 @@ define DirectMethods
               "return (struct Foo)\{ .class = &FooClass_Layout,
                                      .datum = \{ .ptr = &TheEmptyLayout \}\};"
          },
-         #forClass ->
-         {
-              signature: [], vars: 0,
-              body:
-              "struct FooLayout* layout = foo_FooLayout_forClass();
-               return (struct Foo)\{ .class = &FooClass_Layout,
-                                     .datum = \{ .ptr = layout \}\};"
-         },
          #new: ->
          {
               signature: [Integer], vars: 0,

--- a/foo/lang/block_ext.foo
+++ b/foo/lang/block_ext.foo
@@ -1,0 +1,6 @@
+import .block.Block
+
+extend Block
+    method onPanic: other
+        self value!
+end

--- a/foo/lang/prelude.foo
+++ b/foo/lang/prelude.foo
@@ -3,6 +3,7 @@ import .array.Array
 import .array_ext
 import .block.Block
 import .block.Function
+import .block_ext
 import .boolean.Boolean
 import .byteArray.ByteArray
 import .character_ext.Character

--- a/foo/lib/assert.foo
+++ b/foo/lib/assert.foo
@@ -168,4 +168,16 @@ class Assert { output failed }
     method false: condition testing: thing
         self that: condition is: False testing: thing!
 
+    method true: condition
+        self that: condition is: True testing: "(anonymous test)"!
+
+    method false: condition
+        self that: condition is: False testing: "(anonymous test)"!
+
+end
+
+extend TestSuite
+    direct method run: command in: system
+        self runTests: (Assert reportingTo: system output)
+             in: system!
 end

--- a/foo/lib/substitute.foo
+++ b/foo/lib/substitute.foo
@@ -1,0 +1,35 @@
+---
+A quick and dirty NSubstitute -thingie
+
+See: https://nsubstitute.github.io/help/getting-started/
+---
+
+class Substitute { _methods _messages }
+    direct method new
+        self _methods: Dictionary new
+             _messages: Dictionary new!
+
+    direct method for: type
+        (self subclass: "Substitute<{type name}>"
+              interfaces: [type]
+              methods: [])
+        new!
+
+    method on: selector returns: value
+        _methods at: selector name put: value!
+
+    method received: selector with: args
+        (_messages at: selector name ifNone: { return False })
+            includes: args!
+
+    method perform: selector with: args
+        let name = selector toSelector name.
+        let res = _methods
+                      at: name
+                      ifNone: { Error raise: "Substitute does not understand: {selector}" }.
+        let list = _messages
+                       at: name
+                       ifNonePut: { List new }.
+        list add: args.
+        res!
+end

--- a/foo/lib/test_substitute.foo
+++ b/foo/lib/test_substitute.foo
@@ -1,0 +1,27 @@
+import .substitute.Substitute
+import .assert.Assert
+
+interface MyInterface
+end
+
+class TestSubstitute { assert }
+    is TestSuite
+
+    method test_Substitute_returns_as_specified
+        let sub = Substitute new.
+        sub on: (#add:to:) returns: 4212.
+        assert true: { 4212 == (sub add: 1 to: 2) }!
+
+    method test_Substitute_tracks_messages
+        let sub = Substitute new.
+        sub on: (#add:to:) returns: 4212.
+        sub add: 1 to: 2.
+        assert true: { sub received: (#add:to:) with: [1,2] }.
+        assert false: { sub received: (#add:to:) with: [2,1] }!
+
+    method test_Substitute_can_implement_interface
+        let sub = Substitute for: MyInterface.
+        sub on: #foo returns: #bar.
+        assert true: { MyInterface includes: sub }.
+        assert true: { #bar == sub foo }!
+end


### PR DESCRIPTION
  This cleans up nicely metaclass creation as well: instead of

     Class new: "mymeta"
           layout: Layout forClass
           interfaces: [Class]
           methods: []

  it's just

    Class subclass: "mymeta"
          interfaces: []
          methods: []

