### PR TITLE
SyntaxPrinter improvements

### DIFF
--- a/foo/format.foo
+++ b/foo/format.foo
@@ -12,10 +12,10 @@ class Main {}
     direct method format: path
         let source = path readString.
         let syntaxList = Parser parseDefinitions: source.
-        path forWrite
+        path truncateExisting forWrite
             open: { |stream|
                     syntaxList
                         do: { |each|
-                              SyntaxPrinter print: each to: stream }
-                        interleaving: { stream newline } }!
+                              -- stream println: "-- {each classOf name}".
+                              SyntaxPrinter print: each to: stream } }!
 end

--- a/foo/format.foo
+++ b/foo/format.foo
@@ -17,5 +17,6 @@ class Main {}
                     syntaxList
                         do: { |each|
                               -- stream println: "-- {each classOf name}".
-                              SyntaxPrinter print: each to: stream } }!
+                              SyntaxPrinter print: each to: stream.
+                              stream newline } }!
 end

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -534,23 +534,6 @@ interface AstNode
     required method visitBy: visitor
 end
 
-class AstComment { comment value source }
-    is AstNode
-    is AstDefinition
-
-    method visitBy: visitor
-        visitor visitComment: self!
-
-    method defineIn: env
-        value defineIn: env!
-
-    method eval
-        value eval!
-
-    method parts
-        [comment, value]!
-end
-
 class AstArray { entries }
     is AstNode
 

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -233,9 +233,6 @@ class AstInterpreter { context process }
                                     source: aSend source
                                     context: context }} !
 
-    method visitComment: aComment
-        aComment value visitBy: self!
-
     method visitBlock: aBlock
         -- Debug println: "\nblock args: {aBlock argumentCount}, size: {aBlock frameSize}".
         AstBlockClosure

--- a/foo/impl/astVisitor.foo
+++ b/foo/impl/astVisitor.foo
@@ -6,7 +6,6 @@ interface AstVisitor
     required method visitSeq: aSeq
     required method visitReturn: aReturn
     required method visitSend: aSend
-    required method visitComment: aComment
     required method visitBlock: aBlock
     required method visitSelfClass: aSelf
     required method visitSelfInstance: aSelf

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -1174,11 +1174,6 @@ class CTranspiler { output selectorMap closureFunctions
              _for: ret value.
         output print: ")"!
 
-    method visitComment: aComment
-        -- Tracer trace: #visitComment:.
-        -- FIXME: Include comments in generated source.
-        aComment value visitBy: self!
-
     method visitConstant: aConstant
         -- Tracer visitConstant: aConstant.
         self _writeValue: aConstant value _in: aConstant env _to: output!

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -97,29 +97,10 @@ class TokenString { string first last }
         { next < string size }
             whileTrue: { next = self _literalFrom: next into: parts.
                          next = self _interpolatedFrom: next into: parts }.
-        -- Debug println: "parts: {parts}".
-        parts = parts
-            collect: { |each|
-                       (SyntaxLiteral includes: each)
-                           ifTrue: { each }
-                           ifFalse: { let value
-                                          = SyntaxUnary
-                                              receiver: each
-                                              selector: #value
-                                              source: "<interpolation #value>".
-                                      SyntaxUnary
-                                          receiver: value
-                                          selector: #toString
-                                          source: "<interpolation #toString" } }.
-        (parts size > 0) assert.
-        let res = parts pop.
-        { parts isEmpty }
-            whileFalse: { res = SyntaxKeyword
-                              receiver: (parts pop)
-                              selector: (#append:)
-                              arguments: [res]
-                              source: "<interpolation #append>" }.
-        res!
+        (parts size is 1 and: (SyntaxLiteral includes: parts first))
+            ifTrue: { return parts first }.
+        SyntaxStringInterpolation
+            parts: parts!
 end
 
 class TokenFloat { string first last }

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -51,10 +51,13 @@ interface Syntax
         False!
 
     method isSimple
-        self isLeaf!
+        self weight <= 2!
 
-    method isLeaf
-        self isLiteral!
+    method isTiny
+        self weight <= 1!
+
+    method weight
+        10!
 
     method displayOn: stream
         stream print: "#<{self classOf name} ".
@@ -81,6 +84,9 @@ interface Literal
 
     method isLiteral
         True!
+
+    method weight
+        0!
 
     method parts
         [self value]!
@@ -120,8 +126,8 @@ end
 class SyntaxStringInterpolation { parts }
     is Syntax
 
-    method isLeaf
-        True!
+    method weight
+        parts sum: #weight!
 
     method visitBy: visitor
         visitor visitStringInterpolation: self!
@@ -133,6 +139,9 @@ class SyntaxValueTypeDeclaration { value type }
     method visitBy: visitor
         visitor visitValueTypeDeclaration: self!
 
+    method weight
+        value weight + 1!
+
     method parts
         [value, type]!
 end
@@ -140,15 +149,15 @@ end
 interface SyntaxCollection
     is Syntax
 
+    method weight
+        entries sum: #weight!
+
     method parts
         self entries!
 end
 
 class SyntaxArray { entries }
     is SyntaxCollection
-
-    method isSimple
-        entries allSatisfy: #isLeaf!
 
     method visitBy: visitor
         visitor visitArray: self!
@@ -159,6 +168,10 @@ class SyntaxRecord { entries }
 
     method visitBy: visitor
         visitor visitRecord: self!
+
+    method weight
+        entries size + ((entries collect: #value)
+                            sum: #weight)!
 end
 
 class SyntaxDictionary { entries }
@@ -174,6 +187,9 @@ class SyntaxSeq { first then }
     method visitBy: visitor
         visitor visitSeq: self!
 
+    method weight
+        first weight + then weight!
+
     method parts
         [first, then]!
 end
@@ -184,8 +200,8 @@ class SyntaxReturn { value }
     method visitBy: visitor
         visitor visitReturn: self!
 
-    method isSimple
-        value isSimple!
+    method weight
+        value weight + 1!
 
     method parts
         [value]!
@@ -197,8 +213,8 @@ class SyntaxPanic { value }
     method visitBy: visitor
         visitor visitPanic: self!
 
-    method isSimple
-        value isSimple!
+    method weight
+        value weight + 1!
 
     method parts
         [value]!
@@ -213,6 +229,9 @@ class SyntaxPrefixComment { comment value source fence }
             value: value
             source: source
             fence: False!
+
+    method weight
+        value weight!
 
     method visitBy: visitor
         visitor visitPrefixComment: self!
@@ -312,8 +331,8 @@ class SyntaxBinary { receiver selector argument source }
     method visitBy: visitor
         visitor visitBinaryMessage: self!
 
-    method isSimple
-        receiver isLeaf and: argument isLeaf!
+    method weight
+        receiver weight + argument weight + 1!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.
@@ -328,15 +347,16 @@ class SyntaxKeyword { receiver selector arguments source }
     method visitBy: visitor
         visitor visitKeywordMessage: self!
 
-    method isSimple
-        receiver isLeaf
-            and: (selector parts size is 1)
-            and: (arguments allSatisfy: #isSimple)!
+    method weight
+        receiver weight + (arguments sum: #weight) + arguments size!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal,
         -- and might not do so after pretty-printing.
         [receiver, selector, arguments]!
+
+    method displayOn: stream
+        stream print: "#<{Self} {selector}>"!
 end
 
 class SyntaxModuleImport { module relative body }
@@ -375,6 +395,9 @@ class SyntaxExternalRef { module name source }
     method visitBy: visitor
         visitor visitExternalRef: self!
 
+    method weight
+        0!
+
     method parts
         -- Source ignored, since that can change with pretty-printing.
         [module, name]!
@@ -386,8 +409,8 @@ class SyntaxIs { left right }
     method visitBy: visitor
         visitor visitIs: self!
 
-    method isSimple
-        left isSimple and: right isSimple!
+    method weight
+        left weight + right weight + 1!
 
     method parts
         [left, right]!
@@ -411,8 +434,8 @@ class SyntaxSelfInstance {}
     method visitBy: visitor
         visitor visitSelfInstance: self!
 
-    method isLeaf
-        True!
+    method weight
+        0!
 
     method parts
         []!
@@ -424,8 +447,8 @@ class SyntaxSelfClass {}
     method visitBy: visitor
         visitor visitSelfClass: self!
 
-    method isLeaf
-        True!
+    method weight
+        0!
 
     method parts
         []!
@@ -440,8 +463,8 @@ class SyntaxVariable { name::String source }
     method isDynamic
         False!
 
-    method isLeaf
-        True!
+    method weight
+        0!
 
     method type
         Any!
@@ -462,8 +485,8 @@ class SyntaxTypedVariable { name type }
     method isDynamic
         False!
 
-    method isLeaf
-        True!
+    method weight
+        1!
 
     method parts
         [name]!
@@ -478,8 +501,8 @@ class SyntaxDynamicVariable { name::String source }
     method isDynamic
         True!
 
-    method isLeaf
-        True!
+    method weight
+        0!
 
     method type
         SyntaxLiteral value: Any!
@@ -495,6 +518,9 @@ class SyntaxAssign { variable value }
     method visitBy: visitor
         visitor visitAssign: self!
 
+    method weight
+        value weight + 1!
+
     method parts
         [variable, value]!
 end
@@ -505,6 +531,9 @@ class SyntaxParens { body }
     method visitBy: visitor
         visitor visitParens: self!
 
+    method weight
+        body weight + 1!
+
     method parts
         [body]!
 end
@@ -514,6 +543,9 @@ class SyntaxBlock { parameters returnType body }
 
     method visitBy: visitor
         visitor visitBlock: self!
+
+    method weight
+        body weight + 1!
 
     method parts
         [parameters, returnType, body]!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -26,7 +26,7 @@ interface Syntax
 
     method withSuffixComment: comment::String commentSource: source
         SyntaxSuffixComment
-            comment: comment
+            comments: (List with: comment)
             value: self
             source: source!
 
@@ -43,6 +43,18 @@ interface Syntax
 
     method toString
         self displayString!
+
+    method isSuffixComment
+        False!
+
+    method isLiteral
+        False!
+
+    method isSimple
+        self isLeaf!
+
+    method isLeaf
+        self isLiteral!
 
     method displayOn: stream
         stream print: "#<{self classOf name} ".
@@ -66,6 +78,9 @@ interface Literal
 
     method visitBy: visitor
         visitor visitLiteral: self!
+
+    method isLiteral
+        True!
 
     method parts
         [self value]!
@@ -102,6 +117,16 @@ class SyntaxBinaryLiteral { value }
                 do: { value toString }!
 end
 
+class SyntaxStringInterpolation { parts }
+    is Syntax
+
+    method isLeaf
+        True!
+
+    method visitBy: visitor
+        visitor visitStringInterpolation: self!
+end
+
 class SyntaxValueTypeDeclaration { value type }
     is Syntax
 
@@ -121,6 +146,9 @@ end
 
 class SyntaxArray { entries }
     is SyntaxCollection
+
+    method isSimple
+        entries allSatisfy: #isLeaf!
 
     method visitBy: visitor
         visitor visitArray: self!
@@ -156,6 +184,9 @@ class SyntaxReturn { value }
     method visitBy: visitor
         visitor visitReturn: self!
 
+    method isSimple
+        value isSimple!
+
     method parts
         [value]!
 end
@@ -165,6 +196,9 @@ class SyntaxPanic { value }
 
     method visitBy: visitor
         visitor visitPanic: self!
+
+    method isSimple
+        value isSimple!
 
     method parts
         [value]!
@@ -191,15 +225,25 @@ class SyntaxPrefixComment { comment value source fence }
         "#<SyntaxPrefixComment value: {value}>"!
 end
 
-class SyntaxSuffixComment { comment value source }
+class SyntaxSuffixComment { comments value source }
     is Syntax
+
+    method withSuffixComment: comment::String commentSource: source
+        comments add: comment.
+        self!
 
     method visitBy: visitor
         visitor visitSuffixComment: self!
 
+    method isSuffixComment
+        True!
+
+    method isSimple
+        value isSimple!
+
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.
-        [comment, value]!
+        [comments, value]!
 
     method displayString
         "#<SyntaxSuffixComment value: {value}>"!
@@ -253,6 +297,9 @@ class SyntaxUnary { receiver selector source }
     method visitBy: visitor
         visitor visitUnaryMessage: self!
 
+    method isSimple
+        receiver isSimple!
+
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.
         [receiver, selector]!
@@ -264,6 +311,9 @@ class SyntaxBinary { receiver selector argument source }
 
     method visitBy: visitor
         visitor visitBinaryMessage: self!
+
+    method isSimple
+        receiver isLeaf and: argument isLeaf!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.
@@ -277,6 +327,11 @@ class SyntaxKeyword { receiver selector arguments source }
 
     method visitBy: visitor
         visitor visitKeywordMessage: self!
+
+    method isSimple
+        receiver isLeaf
+            and: (selector parts size is 1)
+            and: (arguments allSatisfy: #isSimple)!
 
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal,
@@ -331,6 +386,9 @@ class SyntaxIs { left right }
     method visitBy: visitor
         visitor visitIs: self!
 
+    method isSimple
+        left isSimple and: right isSimple!
+
     method parts
         [left, right]!
 end
@@ -353,6 +411,9 @@ class SyntaxSelfInstance {}
     method visitBy: visitor
         visitor visitSelfInstance: self!
 
+    method isLeaf
+        True!
+
     method parts
         []!
 end
@@ -362,6 +423,9 @@ class SyntaxSelfClass {}
 
     method visitBy: visitor
         visitor visitSelfClass: self!
+
+    method isLeaf
+        True!
 
     method parts
         []!
@@ -375,6 +439,9 @@ class SyntaxVariable { name::String source }
 
     method isDynamic
         False!
+
+    method isLeaf
+        True!
 
     method type
         Any!
@@ -395,6 +462,9 @@ class SyntaxTypedVariable { name type }
     method isDynamic
         False!
 
+    method isLeaf
+        True!
+
     method parts
         [name]!
 end
@@ -406,6 +476,9 @@ class SyntaxDynamicVariable { name::String source }
         visitor visitDynamicVariable: self!
 
     method isDynamic
+        True!
+
+    method isLeaf
         True!
 
     method type
@@ -551,7 +624,7 @@ interface SyntaxMethod
 
     direct method signature: signature body: body
         self
-            comment: False
+            comments: List new
             signature: signature
             body: body!
 
@@ -587,24 +660,25 @@ interface SyntaxMethod
         [self signature, self body]!
 end
 
-class SyntaxInstanceMethod { comment signature body }
+class SyntaxInstanceMethod { comments signature body }
     is SyntaxMethod
 
     method addTo: thing
         thing instanceMethods add: self!
 
     method comment: aSpec
-        comment = aSpec!
+        comments add: aSpec!
+
 end
 
-class SyntaxDirectMethod { comment signature body }
+class SyntaxDirectMethod { comments signature body }
     is SyntaxMethod
-
-    method comment: aSpec
-        comment = aSpec!
 
     method addTo: thing
         thing directMethods add: self!
+
+    method comment: aSpec
+        comments add: aSpec!
 
     method isDirect
         True!

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -150,7 +150,7 @@ interface SyntaxCollection
     is Syntax
 
     method weight
-        entries sum: #weight!
+        self entries sum: #weight!
 
     method parts
         self entries!

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -92,21 +92,25 @@ class SyntaxPrinter { output
         last = #declaration!
 
     method visitArray: anArray
+        let flat = anArray entries allSatisfy: #isTiny.
         self print: "[".
+        let printer = self indentHere.
         anArray entries
-            do: { |element| element visitBy: self }
-            interleaving: { self print: ", " }.
-        self print: "]".
+            do: { |element| element visitBy: printer }
+            interleaving: { printer print: ",".
+                            flat ifFalse: { printer newline } }.
+        printer print: "]".
         last = #paren!
 
     method visitRecord: aRecord
         self print: "\{".
+        let printer = self indentHere.
         aRecord entries
             do: { |entry|
-                  self print: entry key.
-                  self print: " ".
-                  entry value visitBy: self }
-            interleaving: { self print: ", " }.
+                  printer print: entry key.
+                  printer print: " ".
+                  entry value visitBy: printer }
+            interleaving: { printer println: "," }.
         self print: "}".
         last = #paren!
 
@@ -128,14 +132,6 @@ class SyntaxPrinter { output
              followedBy: ".".
         self newline.
         aSeq then visitBy: self!
-
-    method visitMaybeSuffixComment: syntax followedBy: mark
-        syntax isSuffixComment
-            ifTrue: { syntax value visitBy: self.
-                      self print: mark.
-                      self printSuffixComments: syntax comments }
-            ifFalse: { syntax visitBy: self.
-                       self print: mark }!
 
     method visitStringInterpolation: anInterpolation
         self print: "\"".
@@ -168,6 +164,14 @@ class SyntaxPrinter { output
         valueVisitor setLast: #comment.
         aComment value visitBy: valueVisitor!
 
+    method visitMaybeSuffixComment: syntax followedBy: mark
+        syntax isSuffixComment
+            ifTrue: { syntax value visitBy: self.
+                      self print: mark.
+                      self printSuffixComments: syntax comments }
+            ifFalse: { syntax visitBy: self.
+                       self print: mark }!
+
     method printSuffixComments: comments
         let commentPrinter = self indentHere.
         comments
@@ -180,7 +184,8 @@ class SyntaxPrinter { output
     method visitSuffixComment: aComment
         self handleBlockStart.
         aComment value visitBy: self.
-        self printSuffixComments: aComment comments!
+        self printSuffixComments: aComment comments.
+        self newline!
 
     method visitPrefixMessage: aMessage
         self print: aMessage selector name.
@@ -190,7 +195,10 @@ class SyntaxPrinter { output
     method visitUnaryMessage: aMessage
         aMessage receiver visitBy: self.
         let printer = (last == #paren or: last == #comment)
-                          ifTrue: { self indentBody newline }
+                          ifTrue: { let p = self indentBody.
+                                    last == #paren
+                                        ifTrue: { p newline }
+                                        ifFalse: { p doIndent } }
                           ifFalse: { self print: " " }.
         printer print: aMessage selector name.
         last = #unary!
@@ -207,7 +215,7 @@ class SyntaxPrinter { output
         let receiver = aMessage receiver.
         receiver visitBy: self.
         let parts = aMessage selector parts.
-        (receiver isLeaf and: parts size is 1)
+        (receiver isTiny and: parts size is 1)
             ifTrue: {
                       return parts
                           with: aMessage arguments
@@ -216,10 +224,13 @@ class SyntaxPrinter { output
                                 self print: part.
                                 self print: " ".
                                 arg visitBy: self } }.
-        let printer = (receiver isLeaf and: printed <= indent + 4)
+        let printer = (receiver isTiny and: printed <= indent + 4)
                           ifTrue: { (self print: " ")
                                         indentHere }
-                          ifFalse: { self indentBody newline }.
+                          ifFalse: { let p = self indentBody.
+                                     last == #comment
+                                         ifTrue: { p doIndent }
+                                         ifFalse: { p newline } }.
         parts
             with: aMessage arguments
             do: { |part arg|
@@ -285,7 +296,6 @@ class SyntaxPrinter { output
         last = #paren!
 
     method visitBlock: aBlock
-        let finish = self indentHere.
         self print: "\{".
         let bodyPrinter = self indentOne.
         let header = False.
@@ -304,12 +314,11 @@ class SyntaxPrinter { output
             ifTrue: { bodyPrinter print: " " }
             ifFalse: { bodyPrinter newline }.
         aBlock body visitBy: bodyPrinter.
-        -- If the block ended in a non-block comment add an ugly
-        -- newline.
+        -- If the block ended in a non-block comment add an extra
+        -- space to align up.
         bodyPrinter last == #comment
-            ifTrue: { finish newline }
-            ifFalse: { finish print: " " }.
-        self print: "}".
+            ifTrue: { self print: "}" }
+            ifFalse: { self print: " }" }.
         last = #paren!
 
     method visitDefine: aDefine
@@ -318,11 +327,11 @@ class SyntaxPrinter { output
         let bodyVisitor = self indentBody.
         aDefine variable visitBy: bodyVisitor.
         let body = aDefine body.
-        body isLeaf
+        body isTiny
             ifTrue: { bodyVisitor print: " "}
             ifFalse: { bodyVisitor newline }.
-        aDefine body visitBy: bodyVisitor.
-        self print: "!".
+        bodyVisitor visitMaybeSuffixComment: body
+                    followedBy: "!".
         last = #def!
 
     method _printModule: path

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -1,6 +1,10 @@
 import .syntaxVisitor.SyntaxVisitor
 
-class SyntaxPrinter { output indent printed blockStart suffixComment }
+class SyntaxPrinter { output
+                      indent
+                      printed
+                      blockStart
+                      last }
     is SyntaxVisitor
 
     direct method print: syntax to: output
@@ -9,7 +13,8 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
                              indent: 0
                              printed: 0
                              blockStart: False
-                             suffixComment: False)!
+                             last: False).
+        output newline!
 
     method toString
         "#<SyntaxPrinter>"!
@@ -20,7 +25,7 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             indent: indent + 4
             printed: printed
             blockStart: False
-            suffixComment: False!
+            last: False!
 
     method indentHere
         SyntaxPrinter
@@ -28,7 +33,15 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             indent: printed
             printed: printed
             blockStart: False
-            suffixComment: False!
+            last: False!
+
+    method indentOne
+        SyntaxPrinter
+            output: output
+            indent: printed + 1
+            printed: printed
+            blockStart: False
+            last: False!
 
     method indentBlock
         SyntaxPrinter
@@ -36,16 +49,28 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             indent: printed
             printed: printed
             blockStart: True
-            suffixComment: False!
+            last: False!
 
     method newline
         output println: "".
-        indent times: { output print: " " }.
-        printed = indent!
+        printed = 0.
+        self doIndent.
+        self!
+
+    method doIndent
+        indent - printed times: { output print: " " }.
+        printed = indent.
+        self!
+
+    method skipline
+        output println: "".
+        printed = 0.
+        self!
 
     method print: string::String
         output print: string.
-        printed = printed + string size!
+        printed = printed + string size.
+        self!
 
     method println: string::String
         self print: string.
@@ -56,25 +81,23 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifTrue: { self newline.
                       blockStart = False }!
 
-    method handleSuffixComment
-        suffixComment is False
-            ifFalse: { self print: suffixComment.
-                       suffixComment = False }!
-
     method visitLiteral: aLiteral
-        self print: aLiteral valueDisplayString!
+        self print: aLiteral valueDisplayString.
+        last = #literal!
 
     method visitValueTypeDeclaration: aNode
         aNode value visitBy: self.
         self print: "::".
-        aNode type visitBy: self!
+        aNode type visitBy: self.
+        last = #declaration!
 
     method visitArray: anArray
         self print: "[".
         anArray entries
             do: { |element| element visitBy: self }
             interleaving: { self print: ", " }.
-        self print: "]"!
+        self print: "]".
+        last = #paren!
 
     method visitRecord: aRecord
         self print: "\{".
@@ -84,7 +107,8 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
                   self print: " ".
                   entry value visitBy: self }
             interleaving: { self print: ", " }.
-        self print: "}"!
+        self print: "}".
+        last = #paren!
 
     method visitDictionary: aDictionary
         self print: "\{".
@@ -94,15 +118,34 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
                   self print: " -> ".
                   entry value visitBy: self }
             interleaving: { self print: ", " }.
-        self print: "}"!
+        self print: "}".
+        last = #paren!
 
     method visitSeq: aSeq
         self handleBlockStart.
-        aSeq first visitBy: self.
-        self print: ".".
-        self handleSuffixComment.
+        let first = aSeq first.
+        self visitMaybeSuffixComment: first
+             followedBy: ".".
         self newline.
         aSeq then visitBy: self!
+
+    method visitMaybeSuffixComment: syntax followedBy: mark
+        syntax isSuffixComment
+            ifTrue: { syntax value visitBy: self.
+                      self print: mark.
+                      self printSuffixComments: syntax comments }
+            ifFalse: { syntax visitBy: self.
+                       self print: mark }!
+
+    method visitStringInterpolation: anInterpolation
+        self print: "\"".
+        anInterpolation parts
+            do: { |each|
+                  each isLiteral
+                      ifTrue: { self print: each value }
+                      ifFalse: { each visitBy: self } }.
+        self print: "\"".
+        last = #string!
 
     method visitReturn: aReturn
         self print: "return ".
@@ -112,6 +155,9 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
         self print: "panic ".
         aPanic value visitBy: self!
 
+    method setLast: newLast
+        last = newLast!
+
     method visitPrefixComment: aComment
         self handleBlockStart.
         let valueVisitor = self indentHere.
@@ -119,44 +165,75 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifTrue: { self visitLineComment: aComment }
             ifFalse: { self visitBlockComment: aComment }.
         valueVisitor newline.
+        valueVisitor setLast: #comment.
         aComment value visitBy: valueVisitor!
+
+    method printSuffixComments: comments
+        let commentPrinter = self indentHere.
+        comments
+            do: { |each|
+                  commentPrinter print: " --".
+                  commentPrinter print: each.
+                  last = #comment }
+            interleaving: { commentPrinter newline }!
 
     method visitSuffixComment: aComment
         self handleBlockStart.
-        suffixComment not assert.
-        suffixComment = " --{aComment comment}".
-        aComment value visitBy: self!
+        aComment value visitBy: self.
+        self printSuffixComments: aComment comments!
 
     method visitPrefixMessage: aMessage
         self print: aMessage selector name.
-        aMessage receiver visitBy: self!
+        aMessage receiver visitBy: self.
+        last = #prefix!
 
     method visitUnaryMessage: aMessage
         aMessage receiver visitBy: self.
-        self print: " ".
-        self print: aMessage selector name!
+        let printer = (last == #paren or: last == #comment)
+                          ifTrue: { self indentBody newline }
+                          ifFalse: { self print: " " }.
+        printer print: aMessage selector name.
+        last = #unary!
 
     method visitBinaryMessage: aMessage
         aMessage receiver visitBy: self.
         self print: " ".
         self print: aMessage selector name.
         self print: " ".
-        aMessage argument visitBy: self!
+        aMessage argument visitBy: self.
+        last = #binary!
 
     method visitKeywordMessage: aMessage
-        aMessage receiver visitBy: self.
-        aMessage selector parts
+        let receiver = aMessage receiver.
+        receiver visitBy: self.
+        let parts = aMessage selector parts.
+        (receiver isLeaf and: parts size is 1)
+            ifTrue: {
+                      return parts
+                          with: aMessage arguments
+                          do: { |part arg|
+                                self print: " ".
+                                self print: part.
+                                self print: " ".
+                                arg visitBy: self } }.
+        let printer = (receiver isLeaf and: printed <= indent + 4)
+                          ifTrue: { (self print: " ")
+                                        indentHere }
+                          ifFalse: { self indentBody newline }.
+        parts
             with: aMessage arguments
             do: { |part arg|
-                  self print: " ".
-                  self print: part.
-                  self print: " ".
-                  arg visitBy: self }!
+                  printer print: part.
+                  printer print: " ".
+                  arg visitBy: printer }
+            interleaving: { printer newline }.
+        last = #keyword!
 
     method visitIs: anIs
         anIs left visitBy: self.
         self print: " is ".
-        anIs right visitBy: self!
+        anIs right visitBy: self.
+        last = #binary!
 
     method visitDynamicLet: aLet
         self visitLet: aLet!
@@ -166,9 +243,8 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
         self print: "let ".
         aLet variable visitBy: self.
         self print: " = ".
-        aLet value visitBy: self.
-        self print: ".".
-        self handleSuffixComment.
+        self indentHere visitMaybeSuffixComment: aLet value
+                        followedBy: ".".
         self newline.
         aLet body visitBy: self!
 
@@ -178,19 +254,24 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
         aVar type visitBy: self!
 
     method visitUntypedVariable: aVar
-        self print: aVar name!
+        self print: aVar name.
+        last = #var!
 
     method visitSelfClass: aSelf
-        self print: "Self"!
+        self print: "Self".
+        last = #var!
 
     method visitSelfInstance: aSelf
-        self print: "self"!
+        self print: "self".
+        last = #var!
 
     method visitVariable: aVariable
-        self print: aVariable name!
+        self print: aVariable name.
+        last = #var!
 
     method visitDynamicVariable: aVariable
-        self print: aVariable name!
+        self print: aVariable name.
+        last = #var!
 
     method visitAssign: anAssign
         self print: anAssign variable name.
@@ -200,31 +281,49 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
     method visitParens: aParens
         self print: "(".
         aParens body visitBy: self indentHere.
-        self print: ")"!
+        self print: ")".
+        last = #paren!
 
     method visitBlock: aBlock
-        self print: "\{ ".
-        let bodyPrinter = self indentBlock.
+        let finish = self indentHere.
+        self print: "\{".
+        let bodyPrinter = self indentOne.
+        let header = False.
         aBlock parameters
-            ifNotEmpty: { self print: "|".
+            ifNotEmpty: { bodyPrinter print: " |".
                           aBlock parameters
-                              do: { |param| param visitBy: self }
-                              interleaving: { self print: " " }.
-                          self print: "| " }.
+                              do: { |param| param visitBy: bodyPrinter }
+                              interleaving: { bodyPrinter print: " " }.
+                          bodyPrinter print: "|".
+                          header = True }.
         aBlock returnType is Any
-            ifFalse: { self print: " -> ".
-                       aBlock returnType visitBy: self.
-                       self print: " " }.
+            ifFalse: { bodyPrinter print: " -> ".
+                       aBlock returnType visitBy: bodyPrinter.
+                       header = True }.
+        (header not or: aBlock body isSimple)
+            ifTrue: { bodyPrinter print: " " }
+            ifFalse: { bodyPrinter newline }.
         aBlock body visitBy: bodyPrinter.
-        self print: " }"!
+        -- If the block ended in a non-block comment add an ugly
+        -- newline.
+        bodyPrinter last == #comment
+            ifTrue: { finish newline }
+            ifFalse: { finish print: " " }.
+        self print: "}".
+        last = #paren!
 
     method visitDefine: aDefine
+        self _maybeToplevelNewline.
         self print: "define ".
         let bodyVisitor = self indentBody.
         aDefine variable visitBy: bodyVisitor.
-        self newline.
+        let body = aDefine body.
+        body isLeaf
+            ifTrue: { bodyVisitor print: " "}
+            ifFalse: { bodyVisitor newline }.
         aDefine body visitBy: bodyVisitor.
-        self println: "!"!
+        self print: "!".
+        last = #def!
 
     method _printModule: path
         self print: ("." join: path)!
@@ -235,6 +334,7 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifTrue: { self print: "." }.
         self _printModule: anImport module.
         self newline.
+        last = #import.
         self _visitEach: anImport body!
 
     method visitNameImport: anImport
@@ -243,6 +343,7 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifTrue: { self print: "." }.
         self _printModule: anImport module.
         self println: ".{anImport name}".
+        last = #import.
         self _visitEach: anImport body!
 
     method visitWildcardImport: anImport
@@ -251,16 +352,19 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifTrue: { self print: "." }.
         self _printModule: anImport module.
         self println: ".*".
+        last = #import.
         self _visitEach: anImport body!
 
     method visitExternalRef: aRef
         self print: aRef module.
         self print: ".".
-        self print: aRef name!
+        self print: aRef name.
+        last = #var!
 
     method visitLineComment: comment
         self print: "--".
-        self print: comment comment!
+        self print: comment comment.
+        last = #comment!
 
     method visitBlockComment: comment
         let lines = comment comment.
@@ -284,13 +388,23 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
                     self newline.
                     self print: (lines at: i) }.
         self newline.
-        self print: comment fence!
+        self print: comment fence.
+        last = #blockComment!
+
+    method skipIfNotEmpty
+        printed > 1
+            ifTrue: { self skipline }!
 
     method visitMethod: aMethod
         -- Debug println: "/pp method {aMethod signature selector}".
-        aMethod comment is False
-            ifFalse: { aMethod comment visitBy: self.
-                       self newline }.
+        aMethod comments
+            ifNotEmpty: { self skipIfNotEmpty.
+                          aMethod comments reversed
+                              do: { |each|
+                                    self newline.
+                                    each visitBy: self }.
+                          self skipline }.
+        self newline.
         aMethod isRequired
             ifTrue: { self print: "required " }.
         aMethod isDirect
@@ -311,15 +425,22 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
             ifFalse: { self print: " -> ".
                        signature returnType visitBy: self }.
         aMethod isRequired
-            ifFalse: { let bodyVisitor = self indentBody.
-                       bodyVisitor println: "".
-                       aMethod body visitBy: bodyVisitor.
-                       bodyVisitor print: "!".
-                       -- no newline!
-                       bodyVisitor handleSuffixComment }!
+            ifFalse: { let bodyVisitor = self indentBody newline.
+                       bodyVisitor visitMaybeSuffixComment: aMethod body
+                                   followedBy: "!"
+                                       -- no newline!
+                     }.
+        last = #method!
+
+    method _maybeToplevelNewline
+        (last == #def)
+            ifTrue: { self skipline }.
+        (last is False or: last == #comment)
+            ifFalse: { self newline }!
 
     method visitClass: aClass
         -- Debug println: "/pp class {aClass name}".
+        self _maybeToplevelNewline.
         self print: "class ".
         self print: aClass name.
         let slots = aClass slots.
@@ -334,56 +455,47 @@ class SyntaxPrinter { output indent printed blockStart suffixComment }
                                                    slot visitBy: self.
                                                    self print: " " }}.
                        self print: "}" }.
-        self _visitTypeBody: aClass.
-        self newline.
-        self print: "end".
-        self handleSuffixComment.
-        self newline!
+        self _visitTypeBody: aClass!
 
     method visitInterfaceRef: aRef
+        self newline.
         self print: "is ".
         aRef name visitBy: self!
 
     method visitInterface: anInterface
+        self _maybeToplevelNewline.
         self print: "interface ".
         self print: anInterface name.
-        self _visitTypeBody: anInterface.
-        self newline.
-        self print: "end".
-        self handleSuffixComment.
-        self newline!
+        self _visitTypeBody: anInterface!
 
     method visitExtend: anExtend
+        self _maybeToplevelNewline.
         self print: "extend ".
         self print: anExtend name.
-        self _visitTypeBody: anExtend.
-        self newline.
-        self print: "end".
-        self handleSuffixComment.
-        self newline!
+        self _visitTypeBody: anExtend!
+
+    method _visitGroup: group in: parent
+        group
+            do: { |each| each visitBy: self }.
+        group
+            ifNotEmpty: { self skipline }!
 
     method _visitTypeBody: aType
         -- Debug println: "/pp methods of {aType name}".
         let bodyVisitor = self indentBody.
-        aType interfaces
-            do: { |each|
-                  bodyVisitor newline.
-                  each visitBy: bodyVisitor }.
-        (aType directMethods select: #isRequired)
-            do: { |m|
-                  bodyVisitor newline.
-                  m visitBy: bodyVisitor }.
-        (aType instanceMethods select: #isRequired)
-            do: { |m|
-                  bodyVisitor newline.
-                  m visitBy: bodyVisitor }.
-        (aType directMethods select: #isDefined)
-            do: { |m|
-                  bodyVisitor newline.
-                  m visitBy: bodyVisitor }.
-        (aType instanceMethods select: #isDefined)
-            do: { |m|
-                  bodyVisitor newline.
-                  m visitBy: bodyVisitor }!
+        bodyVisitor _visitGroup: aType interfaces
+                    in: self.
+        bodyVisitor _visitGroup: (aType directMethods select: #isRequired)
+                    in: self.
+        bodyVisitor _visitGroup: (aType instanceMethods select: #isRequired)
+                    in: self.
+        let defs = (aType directMethods select: #isDefined)
+                       concat: (aType instanceMethods select: #isDefined).
+        defs
+            do: { |def| def visitBy: bodyVisitor }
+            interleaving: { bodyVisitor skipline }.
+        bodyVisitor skipIfNotEmpty.
+        self print: "end".
+        last = #def!
 
 end

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -13,8 +13,7 @@ class SyntaxPrinter { output
                              indent: 0
                              printed: 0
                              blockStart: False
-                             last: False).
-        output newline!
+                             last: False)!
 
     method toString
         "#<SyntaxPrinter>"!

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -127,18 +127,10 @@ class SyntaxTranslator { env currentMethod }
         AstPanic value: (aPanic value visitBy: self)!
 
     method visitPrefixComment: aComment
-        -- Tracer trace: #visitPrefixComment:.
-        AstComment
-            comment: aComment comment
-            value: (aComment value visitBy: self)
-            source: aComment source!
+           aComment value visitBy: self!
 
     method visitSuffixComment: aComment
-        -- Tracer trace: #visitSuffixComment:.
-        AstComment
-            comment: aComment comment
-            value: (aComment value visitBy: self)
-            source: aComment source!
+           aComment value visitBy: self!
 
     method visitLet: aLet
         -- Tracer trace: #visitLet:.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -52,6 +52,33 @@ class SyntaxTranslator { env currentMethod }
         -- Tracer trace: #visitLiteral:.
         AstConstantRef value: aLiteral value env: env!
 
+    method visitStringInterpolation: anInterpolation
+        let parts
+            = anInterpolation parts
+                collect: { |each|
+                           let node = each visitBy: self.
+                           each isLiteral
+                               ifTrue: { node }
+                               ifFalse: { let value
+                                              = AstSend
+                                                  receiver: node
+                                                  selector: #value
+                                                  arguments: []
+                                                  source: "#<interpolation #valie>".
+                                          AstSend
+                                              receiver: value
+                                              selector: #toString
+                                              arguments: []
+                                              source: "#<interpolation #toString>" } }.
+        let res = parts pop.
+        { parts isEmpty }
+            whileFalse: { res = AstSend
+                              receiver: parts pop
+                              selector: (#append:)
+                              arguments: [res]
+                              source: "<interpolation #append>" }.
+        res!
+
     method visitValueTypeDeclaration: aNode
         -- Tracer trace: #visitValueTypeDeclaration.
         AstTypecheck

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -29,28 +29,120 @@ class TestFoolang { system ok onFailure }
             eval: "TestInterface3 includes: (TestInterface3Impl new foo)"
             expect: True!
 
-    method testInterface4
-        -- pretty-print
+    method test1_Line_comments_before_define
+        self parse: "-- foo
+                     -- bar
+                     define Foo 1!"
+            expect:
+                "-- foo
+-- bar
+define Foo 1!
+"!
+
+    method test1_Format_class_with_just_interfaces
+        self parse: "class TestInterface5Impl \{}
+                        is Object
+                        is TestInterface5
+                    end"
+            expect:
+                "class TestInterface5Impl \{}
+    is Object
+    is TestInterface5
+end
+"!
+
+    method test1_Line_comments_before_class
+        self parse: "-- foo
+                     -- bar
+                     class Foo \{\}
+                     end"
+            expect:
+                "-- foo
+-- bar
+class Foo \{\}
+end
+"!
+
+    method test_Line_comments_before_interface
+        self parse: "-- foo
+                     -- bar
+                     interface Foo
+                     end"
+            expect:
+                "-- foo
+-- bar
+interface Foo
+end
+"!
+
+    method test_Line_comments_before_extend
+        self parse: "-- foo
+                     -- bar
+                     extend Foo
+                     end"
+            expect:
+                "-- foo
+-- bar
+extend Foo
+end
+"!
+
+    method test_Multiple_line_comments_inside_class
+        self parse: "class Foo \{\}
+                        -- foo
+                        -- bar
+                        method quux
+                           42!
+                     end"
+            expect:
+                "class Foo \{\}
+
+    -- foo
+    -- bar
+
+    method quux
+        42!
+end
+"!
+
+    method test_Interface_format
         self parse: "interface TestInterface4
                         required direct method fooR
+                        required direct method fooRR
                         direct method foo
                             42!
+                        direct method foo2
+                            42!
                         required method barR
+                        required method barRR
                         method bar
+                            42!
+                        method bar2
                             42!
                     end"
              expect: "interface TestInterface4
     required direct method fooR
+    required direct method fooRR
+
     required method barR
+    required method barRR
+
     direct method foo
         42!
+
+    direct method foo2
+        42!
+
     method bar
+        42!
+
+    method bar2
         42!
 end
 "
                 !
 
-    method testInterface5
+    method test_Interface_required_method_missing_detected
         self load: "interface TestInterface5
                         required method fooxx
                         method bar
@@ -236,91 +328,173 @@ end
             eval: "ReturnTest test: True"
             expect: 42!
 
-    method testComment1
-        -- Prefix comment to let value
+    method test_Prefix_comment_to_let_value_format
         self
             parse: "           let x = -- boop\n 21.     x     *  2"
-            expect: "let x = -- boop\n        21.\nx * 2"!
+            expect: "let x = -- boop\n        21.\nx * 2\n"!
 
-    method testComment2
-        -- Suffix comment to let value
+    method test1_Suffix_comment_to_let_value_format
         self
             parse: "let x = 21 -- boop\n.\nx * 2"
-            expect: "let x = 21. -- boop\nx * 2".
+            expect: "let x = 21. -- boop\nx * 2\n".
         self
             parse: "let x = 21. -- boop\n\nx * 2"
-            expect: "let x = 21. -- boop\nx * 2"!
+            expect: "let x = 21. -- boop\nx * 2\n"!
 
-    method testComment3
-        -- Prefix comment in sequence
+    method test_Prefix_comment_in_sequence_format
         self
             parse: "    doo daa.\n    -- boop\n   self bar. \n x * 2"
-            expect: "doo daa.\n-- boop\nself bar.\nx * 2"!
+            expect: "doo daa.\n-- boop\nself bar.\nx * 2\n"!
 
-    method testComment4
-        -- Suffix comment in sequence
+    method test1_Suffix_comment_in_sequence_format
         self
             parse: "self bar. -- boop\n x * 2"
-            expect: "self bar. -- boop\nx * 2".
-        self
-            parse: "self bar -- boop\n. x * 2"
-            expect: "self bar. -- boop\nx * 2"!
+            expect: "self bar. -- boop\nx * 2\n"!
 
-    method testComment5
-        -- Prefix comment to class
+    method test1_Suffix_comment_to_keyword_message_in_sequence_format
+        self
+            parse: "self bleep: bar. -- boop\n x * 2"
+            expect: "self bleep: bar. -- boop\nx * 2\n"!
+
+    method test_Prefix_comment_to_class_format
         self
             parse: "-- boop\n    class   X   \{}   end"
-            expect: "-- boop\nclass X \{}\nend\n"!
+            expect: "-- boop
+class X \{\}
+end
+"!
 
-    method testComment6
-        -- Suffix comment to class
+    method test1_Suffix_comment_to_class_format
         self
             parse: "class   X   \{}   end -- boop"
             expect: "class X \{}\nend -- boop\n"!
 
-    method testComment7
-        -- Suffix comment to method signature == prefix comment to body
+    method test1_Prefix_comment_to_method_body_format
         self
-            parse: "class   X   \{}method bar -- boop\n42!\nend"
-            expect: "class X \{}\n    method bar\n        -- boop\n        42!\nend\n"!
+            parse: "class   X   \{}method bar -- boop
+42! end"
+            expect: "class X \{}
+    method bar
+        -- boop
+        42!
+end
+"!
 
-    method testComment8
-        -- Suffix comment to method body
+    method test0_Format_suffix_comment_to_method_body
         self
-            parse: "class X \{} method bar\n42! -- boop\nend"
-            expect: "class X \{}\n    method bar\n        42! -- boop\nend\n"!
+            parse: "class X \{}
+                        method bar
+                            42! -- boop
+                    end"
+            expect: "class X \{}
+    method bar
+        42! -- boop
+end
+"!
 
-    method testComment9
-        -- Prefix comment to method (does not work currently!)
+    method test0_Format_let_body_in_method
+        self
+            parse: "class Droop \{\}
+                        method bar
+                            let x = 123.
+                            x + x!
+                    end"
+            expect: "class Droop \{\}
+    method bar
+        let x = 123.
+        x + x!
+end
+"!
+
+    method test1_Format_suffix_comment_to_define
+        self
+            parse: "define ThisOne 312! -- oh yeah"
+            expect: "define ThisOne 312! -- oh yeah\n"!
+
+    method test_Prefix_comment_to_method_format
         self
             parse: "class X \{} -- boop\n method bar\n 42!\n end\n"
-            expect: "class X \{}\n    -- boop\n    method bar\n        42!\nend\n"!
+            expect: "class X \{}
 
-    method testComment10
-        -- block comment
+    -- boop
+
+    method bar
+        42!
+end
+"!
+
+    method test1_Format_comments_between_keyword_and_receiver
+        self parse: "asdas
+                                 -- deep
+                                 -- stuff
+                                 ifSo: ayay
+                                 ifElse: block"
+            expect: "asdas -- deep
+      -- stuff
+    ifSo: ayay
+    ifElse: block
+"!
+
+    method test1_Format_comments_between_unary_and_receiver
+        self parse: "asdas
+                                 -- deep
+                                 -- stuff
+                            doopdoop"
+            expect: "asdas -- deep
+      -- stuff
+    doopdoop
+"!
+
+    method test1_Format_single_comment_between_unary_and_receiver
+        self parse: "asdas -- deep
+                            doopdoop"
+            expect: "asdas -- deep
+    doopdoop
+"!
+
+    method test_Format_inside_class_comment_after_interface
+        self parse: "class Foo \{\}
+                        is A
+                        is B
+
+                        -- This is important
+                        -- This too
+
+                        method asdads
+                            129!
+                     end"
+            expect: "class Foo \{\}
+    is A
+    is B
+
+    -- This is important
+    -- This too
+
+    method asdads
+        129!
+end
+"!
+
+    method test_Block_comment_in_eval
         self eval: "---
                     This is a test.
                     ---
                     42"
             expect: 42!
 
-    method testComment11
-        -- block comment
+    method test_Block_comment_format
         self parse: "---\nThis is a test.\n---\n      42"
-            expect: "---\nThis is a test.\n---\n42"!
+            expect: "---\nThis is a test.\n---\n42\n"!
 
-    method testComment12
-        -- Line comment without space after
+    method test_Line_comment_in_eval
         self eval: "--> 42\n 42"
              expect: 42!
 
-    method testComment13
-        -- Block comment without space after
+    method test_Block_comment_without_space_in_eval
         self eval: "---XXX 42--- 42"
              expect: 42!
 
-    method testComment14
-        -- long comment fences
+    method test_Long_comment_fences_in_eval
         self eval: "----
                     --- This is a test.
                     ----
@@ -668,7 +842,7 @@ end
                        (p description == "foo") assert.
                        return True }!
 
-    method testExtend1
+    method test_Can_extend_class_with_direct_method
         self load: "class Foo \{}
                     end
                     extend Foo
@@ -678,7 +852,7 @@ end
             eval: "Foo bar"
             expect: 42!
 
-    method testExtend2
+    method test_Can_extend_class_with_instance_method
         self load: "class Foo \{}
                     end
                     extend Foo
@@ -688,7 +862,7 @@ end
             eval: "Foo new bar"
             expect: 42!
 
-    method testExtend3
+    method test_Can_extend_interface_with_interface
         self load: "interface Foo
                     end
                     extend Integer

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -29,17 +29,16 @@ class TestFoolang { system ok onFailure }
             eval: "TestInterface3 includes: (TestInterface3Impl new foo)"
             expect: True!
 
-    method test__Line_comments_before_define
+    method test_Line_comments_before_define
         self parse: "-- foo
                      -- bar
                      define Foo 1!"
             expect:
                 "-- foo
 -- bar
-define Foo 1!
-"!
+define Foo 1!"!
 
-    method test__Format_class_with_just_interfaces
+    method test_Format_class_with_just_interfaces
         self parse: "class TestInterface5Impl \{}
                         is Object
                         is TestInterface5
@@ -48,10 +47,9 @@ define Foo 1!
                 "class TestInterface5Impl \{}
     is Object
     is TestInterface5
-end
-"!
+end"!
 
-    method test__Line_comments_before_class
+    method test_Line_comments_before_class
         self parse: "-- foo
                      -- bar
                      class Foo \{\}
@@ -60,8 +58,7 @@ end
                 "-- foo
 -- bar
 class Foo \{\}
-end
-"!
+end"!
 
     method test_Line_comments_before_interface
         self parse: "-- foo
@@ -72,8 +69,7 @@ end
                 "-- foo
 -- bar
 interface Foo
-end
-"!
+end"!
 
     method test_Line_comments_before_extend
         self parse: "-- foo
@@ -84,8 +80,7 @@ end
                 "-- foo
 -- bar
 extend Foo
-end
-"!
+end"!
 
     method test_Multiple_line_comments_inside_class
         self parse: "class Foo \{\}
@@ -102,8 +97,7 @@ end
 
     method quux
         42!
-end
-"!
+end"!
 
     method test_Interface_format
         self parse: "interface TestInterface4
@@ -138,9 +132,7 @@ end
 
     method bar2
         42!
-end
-"
-                !
+end"!
 
     method test_Interface_required_method_missing_detected
         self load: "interface TestInterface5
@@ -331,45 +323,44 @@ end
     method test_Prefix_comment_to_let_value_format
         self
             parse: "           let x = -- boop\n 21.     x     *  2"
-            expect: "let x = -- boop\n        21.\nx * 2\n"!
+            expect: "let x = -- boop\n        21.\nx * 2"!
 
-    method test__Suffix_comment_to_let_value_format
+    method test_Suffix_comment_to_let_value_format
         self
             parse: "let x = 21 -- boop\n.\nx * 2"
-            expect: "let x = 21. -- boop\nx * 2\n".
+            expect: "let x = 21. -- boop\nx * 2".
         self
             parse: "let x = 21. -- boop\n\nx * 2"
-            expect: "let x = 21. -- boop\nx * 2\n"!
+            expect: "let x = 21. -- boop\nx * 2"!
 
     method test_Prefix_comment_in_sequence_format
         self
             parse: "    doo daa.\n    -- boop\n   self bar. \n x * 2"
-            expect: "doo daa.\n-- boop\nself bar.\nx * 2\n"!
+            expect: "doo daa.\n-- boop\nself bar.\nx * 2"!
 
-    method test__Suffix_comment_in_sequence_format
+    method test_Suffix_comment_in_sequence_format
         self
             parse: "self bar. -- boop\n x * 2"
-            expect: "self bar. -- boop\nx * 2\n"!
+            expect: "self bar. -- boop\nx * 2"!
 
-    method test__Suffix_comment_to_keyword_message_in_sequence_format
+    method test_Suffix_comment_to_keyword_message_in_sequence_format
         self
             parse: "self bleep: bar. -- boop\n x * 2"
-            expect: "self bleep: bar. -- boop\nx * 2\n"!
+            expect: "self bleep: bar. -- boop\nx * 2"!
 
     method test_Prefix_comment_to_class_format
         self
             parse: "-- boop\n    class   X   \{}   end"
             expect: "-- boop
 class X \{\}
-end
-"!
+end"!
 
-    method test__Suffix_comment_to_class_format
+    method test_Suffix_comment_to_class_format
         self
             parse: "class   X   \{}   end -- boop"
-            expect: "class X \{}\nend -- boop\n\n"!
+            expect: "class X \{}\nend -- boop\n"!
 
-    method test__Prefix_comment_to_method_body_format
+    method test_Prefix_comment_to_method_body_format
         self
             parse: "class   X   \{}method bar -- boop
 42! end"
@@ -377,10 +368,14 @@ end
     method bar
         -- boop
         42!
-end
-"!
+end"!
 
-    method test__Format_suffix_comment_to_method_body
+    method test_Formatted_single_expression_has_no_trailing_newline
+        self
+            parse: "123"
+            expect: "123"!
+
+    method test_Format_suffix_comment_to_method_body
         self
             parse: "class X \{}
                         method bar
@@ -389,10 +384,9 @@ end
             expect: "class X \{}
     method bar
         42! -- boop
-end
-"!
+end"!
 
-    method test__Format_block_with_suffix_comment_after_literal
+    method test_Format_block_with_suffix_comment_after_literal
         self parse: "class X \{\}
                          method beep
                              \{ panic \"dundun\" -- oops
@@ -402,10 +396,9 @@ end
     method beep
         \{ panic \"dundun\" -- oops
           \}!
-end
-"!
+end"!
 
-    method test__Format_let_body_in_method
+    method test_Format_let_body_in_method
         self
             parse: "class Droop \{\}
                         method bar
@@ -416,27 +409,25 @@ end
     method bar
         let x = 123.
         x + x!
-end
-"!
+end"!
 
     method test_Format_suffix_comment_to_define
         self
             parse: "define ThisOne 312! -- oh yeah"
-            expect: "define ThisOne 312! -- oh yeah\n\n"!
+            expect: "define ThisOne 312! -- oh yeah\n"!
 
     method test_Prefix_comment_to_method_format
         self
-            parse: "class X \{} -- boop\n method bar\n 42!\n end\n"
+            parse: "class X \{} -- boop\n method bar\n 42!\n end"
             expect: "class X \{}
 
     -- boop
 
     method bar
         42!
-end
-"!
+end"!
 
-    method test__Format_comments_between_keyword_and_receiver
+    method test_Format_comments_between_keyword_and_receiver
         self parse: "asdasasd
                                  -- deep
                                  -- stuff
@@ -445,10 +436,9 @@ end
             expect: "asdasasd -- deep
          -- stuff
     ifSo: ayay
-    ifElse: block
-"!
+    ifElse: block"!
 
-    method test__Format_comments_between_keywors_and_short_receiver
+    method test_Format_comments_between_keywors_and_short_receiver
         self parse: "class Q \{\}
          method ding
            self
@@ -463,25 +453,22 @@ end
              -- of tests. Should either explain the rational or return False.
             ifTrue: { True }
             ifFalse: block!
-end
-"!
+end"!
 
-    method test__Format_comments_between_unary_and_receiver
+    method test_Format_comments_between_unary_and_receiver
         self parse: "asdas
                                  -- deep
                                  -- stuff
                             doopdoop"
             expect: "asdas -- deep
       -- stuff
-    doopdoop
-"!
+    doopdoop"!
 
-    method test__Format_single_comment_between_unary_and_receiver
+    method test_Format_single_comment_between_unary_and_receiver
         self parse: "asdas -- deep
                             doopdoop"
             expect: "asdas -- deep
-    doopdoop
-"!
+    doopdoop"!
 
     method test_Format_inside_class_comment_after_interface
         self parse: "class Foo \{\}
@@ -503,8 +490,7 @@ end
 
     method asdads
         129!
-end
-"!
+end"!
 
     method test_Block_comment_in_eval
         self eval: "---
@@ -515,7 +501,7 @@ end
 
     method test_Block_comment_format
         self parse: "---\nThis is a test.\n---\n      42"
-            expect: "---\nThis is a test.\n---\n42\n"!
+            expect: "---\nThis is a test.\n---\n42"!
 
     method test_Line_comment_in_eval
         self eval: "--> 42\n 42"

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -29,7 +29,7 @@ class TestFoolang { system ok onFailure }
             eval: "TestInterface3 includes: (TestInterface3Impl new foo)"
             expect: True!
 
-    method test1_Line_comments_before_define
+    method test__Line_comments_before_define
         self parse: "-- foo
                      -- bar
                      define Foo 1!"
@@ -39,7 +39,7 @@ class TestFoolang { system ok onFailure }
 define Foo 1!
 "!
 
-    method test1_Format_class_with_just_interfaces
+    method test__Format_class_with_just_interfaces
         self parse: "class TestInterface5Impl \{}
                         is Object
                         is TestInterface5
@@ -51,7 +51,7 @@ define Foo 1!
 end
 "!
 
-    method test1_Line_comments_before_class
+    method test__Line_comments_before_class
         self parse: "-- foo
                      -- bar
                      class Foo \{\}
@@ -333,7 +333,7 @@ end
             parse: "           let x = -- boop\n 21.     x     *  2"
             expect: "let x = -- boop\n        21.\nx * 2\n"!
 
-    method test1_Suffix_comment_to_let_value_format
+    method test__Suffix_comment_to_let_value_format
         self
             parse: "let x = 21 -- boop\n.\nx * 2"
             expect: "let x = 21. -- boop\nx * 2\n".
@@ -346,12 +346,12 @@ end
             parse: "    doo daa.\n    -- boop\n   self bar. \n x * 2"
             expect: "doo daa.\n-- boop\nself bar.\nx * 2\n"!
 
-    method test1_Suffix_comment_in_sequence_format
+    method test__Suffix_comment_in_sequence_format
         self
             parse: "self bar. -- boop\n x * 2"
             expect: "self bar. -- boop\nx * 2\n"!
 
-    method test1_Suffix_comment_to_keyword_message_in_sequence_format
+    method test__Suffix_comment_to_keyword_message_in_sequence_format
         self
             parse: "self bleep: bar. -- boop\n x * 2"
             expect: "self bleep: bar. -- boop\nx * 2\n"!
@@ -364,12 +364,12 @@ class X \{\}
 end
 "!
 
-    method test1_Suffix_comment_to_class_format
+    method test__Suffix_comment_to_class_format
         self
             parse: "class   X   \{}   end -- boop"
-            expect: "class X \{}\nend -- boop\n"!
+            expect: "class X \{}\nend -- boop\n\n"!
 
-    method test1_Prefix_comment_to_method_body_format
+    method test__Prefix_comment_to_method_body_format
         self
             parse: "class   X   \{}method bar -- boop
 42! end"
@@ -380,7 +380,7 @@ end
 end
 "!
 
-    method test0_Format_suffix_comment_to_method_body
+    method test__Format_suffix_comment_to_method_body
         self
             parse: "class X \{}
                         method bar
@@ -392,7 +392,20 @@ end
 end
 "!
 
-    method test0_Format_let_body_in_method
+    method test__Format_block_with_suffix_comment_after_literal
+        self parse: "class X \{\}
+                         method beep
+                             \{ panic \"dundun\" -- oops
+                               }!
+                     end"
+            expect: "class X \{\}
+    method beep
+        \{ panic \"dundun\" -- oops
+          \}!
+end
+"!
+
+    method test__Format_let_body_in_method
         self
             parse: "class Droop \{\}
                         method bar
@@ -406,10 +419,10 @@ end
 end
 "!
 
-    method test1_Format_suffix_comment_to_define
+    method test_Format_suffix_comment_to_define
         self
             parse: "define ThisOne 312! -- oh yeah"
-            expect: "define ThisOne 312! -- oh yeah\n"!
+            expect: "define ThisOne 312! -- oh yeah\n\n"!
 
     method test_Prefix_comment_to_method_format
         self
@@ -423,19 +436,37 @@ end
 end
 "!
 
-    method test1_Format_comments_between_keyword_and_receiver
-        self parse: "asdas
+    method test__Format_comments_between_keyword_and_receiver
+        self parse: "asdasasd
                                  -- deep
                                  -- stuff
                                  ifSo: ayay
                                  ifElse: block"
-            expect: "asdas -- deep
-      -- stuff
+            expect: "asdasasd -- deep
+         -- stuff
     ifSo: ayay
     ifElse: block
 "!
 
-    method test1_Format_comments_between_unary_and_receiver
+    method test__Format_comments_between_keywors_and_short_receiver
+        self parse: "class Q \{\}
+         method ding
+           self
+           -- FIXME: returning True in the first leg seems strange, but breaks a couple
+           -- of tests. Should either explain the rational or return False.
+           ifTrue: { True }
+           ifFalse: block!
+       end"
+            expect: "class Q \{\}
+    method ding
+        self -- FIXME: returning True in the first leg seems strange, but breaks a couple
+             -- of tests. Should either explain the rational or return False.
+            ifTrue: { True }
+            ifFalse: block!
+end
+"!
+
+    method test__Format_comments_between_unary_and_receiver
         self parse: "asdas
                                  -- deep
                                  -- stuff
@@ -445,7 +476,7 @@ end
     doopdoop
 "!
 
-    method test1_Format_single_comment_between_unary_and_receiver
+    method test__Format_single_comment_between_unary_and_receiver
         self parse: "asdas -- deep
                             doopdoop"
             expect: "asdas -- deep

--- a/foo/impl/test_self_hosting.foo
+++ b/foo/impl/test_self_hosting.foo
@@ -57,7 +57,8 @@ interface TestSelfHosting
                          with: { |out|
                                  syntaxList1
                                      do: { |syntax|
-                                           SyntaxPrinter print: syntax to: out } }.
+                                           SyntaxPrinter print: syntax to: out }
+                                     interleaving: { out newline } }.
         -- Debug println: "/parse2".
         let syntaxList2 = block value: pretty.
         -- Debug println: pretty.
@@ -89,7 +90,8 @@ problem: {err description}" }.
         let printed
             = StringOutput
                   with: { |out|
-                          syntaxList1 do: { |syntax| SyntaxPrinter print: syntax to: out } }.
+                          syntaxList1 do: { |syntax| SyntaxPrinter print: syntax to: out }
+                                      interleaving: { out newline } }.
         printed == pretty
             ifFalse: { let printed2 = printed replace: "\n" with: "|\n".
                        let pretty2 = pretty replace: "\n" with: "|\n".

--- a/foo/impl/test_self_hosting.foo
+++ b/foo/impl/test_self_hosting.foo
@@ -91,10 +91,23 @@ problem: {err description}" }.
                   with: { |out|
                           syntaxList1 do: { |syntax| SyntaxPrinter print: syntax to: out } }.
         printed == pretty
-            ifFalse: { Error raise: "print inconsistent with desired pretty-print!
+            ifFalse: { let printed2 = printed replace: "\n" with: "|\n".
+                       let pretty2 = pretty replace: "\n" with: "|\n".
+                       printed size == pretty size
+                           ifTrue: { 1 to: pretty size
+                                       do: { |i|
+                                             let x = printed at: i.
+                                             let y = pretty at: i.
+                                             x == y
+                                                 ifFalse: { Error raise: "print inconsistent with desired pretty-print!
 source:\n{source}
-printed:\n{printed}
-pretty:\n{pretty}" }!
+printed({x} at: {i}):\n{printed2}
+pretty({y} at: {i}):\n{pretty2}" } }.
+                                    panic "Never" }
+                           ifFalse: { Error raise: "print inconsistent with desired pretty-print!
+source:\n{source}
+printed(size: {printed size}):\n{printed2}
+pretty(size: {pretty size}):\n{pretty2}" } }!
 
     method eval: exprSource expect: expected
         self checkParsingBy: { |source| Parser parseExpressions: source }

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -1,5 +1,11 @@
 define InstanceMethods
 {
+     #name
+     -> { signature: [], vars: 0,
+          body: "struct FooBytes* name = PTR(FooClass, ctx->receiver.datum)->name;
+                 return (struct Foo)\{ .class = &FooClass_String, .datum = \{ .ptr = name } };"
+        },
+
      #subclass:interfaces:methods:
      -> { signature: [String, Array, Array], vars: 1,
           body: "struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);

--- a/foo/lang/any.foo
+++ b/foo/lang/any.foo
@@ -1,16 +1,22 @@
 interface Any
     direct method includes: object
         True!
+
     direct method typecheck: object
         object!
+
     direct method == other
         self is other!
+
     direct method default
         False!
+
     direct method printOn: stream
         stream print: "Any"!
+
     direct method displayOn: stream
         stream print: "#<Any>"!
+
     method yourself
         self!
 end


### PR DESCRIPTION
 - Separate Syntax class for string interpolations, including SyntaxTranslator
   change required.

 - Whole bunch of aesthetic improvements

 - Fix format.foo to truncate the original file

 This seems to be enough to format things lang/[ab]*.foo pretty
 reasonably. character.foo is where things currently get unacceptable.

 Earlier there's the case of:


     1 <= x
         and: x <= size

 which is a bit irritating, but something I'm willing to live with for
 now -- better to fold keywords more than less.
