### PR TITLE
get rid of struct FooCString

### DIFF
--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -454,7 +454,7 @@ class CTranspiler { output selectorMap closureFunctions
         selectorMap do: { |name cname|
                          output print: "struct FooSelector ".
                          output print: cname.
-                         output print: " = \{ .name = &FOO_CSTRING(".
+                         output print: " = \{ .name = FOO_CSTRING(".
                          output display: name.
                          output print: "), .next = ".
                          output print: prev.

--- a/foo/impl/transpiler/selector.foo
+++ b/foo/impl/transpiler/selector.foo
@@ -17,12 +17,12 @@ for (size_t i = 0; i < n; i++) \{
 return foo_Boolean_new(name1->size < name2->size);"},
     #debug
         -> {signature: [], vars: 0,
-            body: "const char* name = PTR(FooSelector, ctx->receiver.datum)->name->data;
+            body: "const char* name = (char*)PTR(FooSelector, ctx->receiver.datum)->name->data;
 printf(\"#<Selector %s>\", name);
 return ctx->receiver;"},
     #name
         -> {signature: [], vars: 0,
-            body: "const struct FooBytes* name = PTR(FooSelector, ctx->receiver.datum)->name;
+            body: "struct FooBytes* name = PTR(FooSelector, ctx->receiver.datum)->name;
 return (struct Foo)\{ .class = &FooClass_String, .datum = \{ .ptr = name } };"},
     #sendTo:with:
         -> {signature: [Any, Array], vars: 0,

--- a/foo/impl/transpiler/selector.foo
+++ b/foo/impl/transpiler/selector.foo
@@ -4,8 +4,8 @@ define DirectMethods
 define InstanceMethods {
     #<
         -> {signature: [Selector], vars: 0,
-            body: "const struct FooCString* name1 = PTR(FooSelector, ctx->receiver.datum)->name;
-const struct FooCString* name2 = PTR(FooSelector, ctx->frame[0].datum)->name;
+            body: "const struct FooBytes* name1 = PTR(FooSelector, ctx->receiver.datum)->name;
+const struct FooBytes* name2 = PTR(FooSelector, ctx->frame[0].datum)->name;
 size_t n = min_size(name1->size, name2->size);
 for (size_t i = 0; i < n; i++) \{
     uint8_t c1 = name1->data[i];
@@ -22,9 +22,7 @@ printf(\"#<Selector %s>\", name);
 return ctx->receiver;"},
     #name
         -> {signature: [], vars: 0,
-            body: "const struct FooCString* cname = PTR(FooSelector, ctx->receiver.datum)->name;
-struct FooBytes* name = FooBytes_alloc(cname->size);
-memcpy(name->data, cname->data, cname->size);
+            body: "const struct FooBytes* name = PTR(FooSelector, ctx->receiver.datum)->name;
 return (struct Foo)\{ .class = &FooClass_String, .datum = \{ .ptr = name } };"},
     #sendTo:with:
         -> {signature: [Any, Array], vars: 0,
@@ -32,7 +30,7 @@ return (struct Foo)\{ .class = &FooClass_String, .datum = \{ .ptr = name } };"},
 return foo_send_array(ctx->sender, selector, ctx->frame[0], ctx->frame[1]);"},
     #startsWith:
         -> {signature: [String], vars: 0,
-            body: "const struct FooCString* name = PTR(FooSelector, ctx->receiver.datum)->name;
+            body: "const struct FooBytes* name = PTR(FooSelector, ctx->receiver.datum)->name;
 struct FooBytes* string = PTR(FooBytes, ctx->frame[0].datum);
 return foo_Boolean_new(name->size >= string->size &&
                        !memcmp(name->data, string->data, string->size));"}

--- a/host/main.c
+++ b/host/main.c
@@ -98,34 +98,32 @@ struct Foo {
   union FooDatum datum;
 };
 
-/** Out of line allocation of data for compatibility with C string literals.
- *
- *  FIXME: I'd really like to replace these with String.
- *  The big issue is that these cannot be passed out from selectors without
- *  copying. At least a class is needed...
- */
-struct FooCString {
+struct FooBytes {
+  bool gc;
   size_t size;
-  char* data;
+  uint8_t data[];
 };
 
 #define FOO_CSTRING(literal) \
-  ((struct FooCString){ .size = sizeof(literal)-1, .data = literal })
+  ((struct FooBytes*) \
+  &((struct { bool gc; size_t size; const char data[sizeof(literal)]; }) \
+     { .gc = false, .size = sizeof(literal)-1, .data = literal }))
 
-bool foo_cstring_equal(const struct FooCString* a, const struct FooCString* b) {
+bool foo_bytes_equal(const struct FooBytes* a, const struct FooBytes* b) {
   return a->size == b->size && !memcmp(a->data, b->data, a->size);
 }
 
 /** Simple intrusive list for interning. O(N), but fine to start with.
  */
 struct FooSelector {
-  const struct FooCString* name;
   struct FooSelector* next;
+  const struct FooBytes* name;
 };
 
 #include "generated_selectors.h"
 
-struct FooSelector* foo_intern_new_selector(const struct FooCString* name) {
+struct FooSelector* foo_intern_new_selector(const struct FooBytes* name) {
+  name->gc = false; // prevent GC of the name!
   struct FooSelector* new = calloc(1, sizeof(struct FooSelector));
   new->name = name;
   new->next = FOO_InternedSelectors;
@@ -133,10 +131,10 @@ struct FooSelector* foo_intern_new_selector(const struct FooCString* name) {
   return new;
 }
 
-struct FooSelector* foo_intern(const struct FooCString* name) {
+struct FooSelector* foo_intern(const struct FooBytes* name) {
   struct FooSelector* selector = FOO_InternedSelectors;
   while (selector != NULL) {
-    if (foo_cstring_equal(selector->name, name)) {
+    if (foo_bytes_equal(selector->name, name)) {
       return selector;
     } else {
       selector = selector->next;
@@ -149,12 +147,6 @@ struct FooArray {
   bool gc;
   size_t size;
   struct Foo data[];
-};
-
-struct FooBytes {
-  bool gc;
-  size_t size;
-  uint8_t data[];
 };
 
 // FIXME: Don't like defining this in C.

--- a/host/main.c
+++ b/host/main.c
@@ -117,12 +117,12 @@ bool foo_bytes_equal(const struct FooBytes* a, const struct FooBytes* b) {
  */
 struct FooSelector {
   struct FooSelector* next;
-  const struct FooBytes* name;
+  struct FooBytes* name;
 };
 
 #include "generated_selectors.h"
 
-struct FooSelector* foo_intern_new_selector(const struct FooBytes* name) {
+struct FooSelector* foo_intern_new_selector(struct FooBytes* name) {
   name->gc = false; // prevent GC of the name!
   struct FooSelector* new = calloc(1, sizeof(struct FooSelector));
   new->name = name;
@@ -131,7 +131,7 @@ struct FooSelector* foo_intern_new_selector(const struct FooBytes* name) {
   return new;
 }
 
-struct FooSelector* foo_intern(const struct FooBytes* name) {
+struct FooSelector* foo_intern(struct FooBytes* name) {
   struct FooSelector* selector = FOO_InternedSelectors;
   while (selector != NULL) {
     if (foo_bytes_equal(selector->name, name)) {


### PR DESCRIPTION
   A bit of static allocation trickery to use FooBytes with data
   from a C string literal.
