### PR TITLE
test that shows a problem in transpiled parser

### DIFF
--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -976,8 +976,10 @@ interface X
         42!
 end
 \".
-                     system output print: defs!
-
+                     system output print: defs.
+                     let dictDefs = parser.Parser parseDefinitions:
+                         (system files / \"foo/lang/test_dictionary.foo\") readString.
+                     system output println: dictDefs size!
              end"
                 expect: "[#<SyntaxLiteral 123>][#<SyntaxInterface interface X
     method y


### PR DESCRIPTION
  test_dictionary.foo does not parse with transpiled parser,
  but does when the same self-hosted parser is running on bootstrap
  host or through eval.foo.

