### PR TITLE
More pretty printing work

### DIFF
--- a/foo/format.foo
+++ b/foo/format.foo
@@ -14,9 +14,5 @@ class Main {}
         let syntaxList = Parser parseDefinitions: source.
         path truncateExisting forWrite
             createOrOpen: { |stream|
-                    syntaxList
-                        do: { |each|
-                              -- stream println: "-- {each classOf name}".
-                              SyntaxPrinter print: each to: stream.
-                              stream newline } }!
+                            SyntaxPrinter printAll: syntaxList to: stream }!
 end

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -136,7 +136,7 @@ class TokenHexInteger { string first last }
           do: { |pos|
                 n = n * 16 + ((string at: pos) digit: 16) }.
         -- Want to retain the format info, hence not SyntaxLiteral.
-        SyntaxHexLiteral value: n!
+        SyntaxHexLiteral string: string value: n!
 end
 
 class TokenBinaryInteger { string first last }
@@ -150,7 +150,7 @@ class TokenBinaryInteger { string first last }
           do: { |pos|
                 n = n * 2 + ((string at: pos) digit: 2) }.
         -- Want to retain the format info, hence not SyntaxLiteral.
-        SyntaxBinaryLiteral value: n!
+        SyntaxBinaryLiteral string: string value: n!
 end
 
 class TokenEof { position }

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -107,20 +107,18 @@ class SyntaxFloatLiteral { string value }
 end
 
 
-class SyntaxHexLiteral { value }
+class SyntaxHexLiteral { string value }
     is Literal
 
     method valueDisplayString
-        Integer printBase: 16
-                do: { value toString }!
+        string!
 end
 
-class SyntaxBinaryLiteral { value }
+class SyntaxBinaryLiteral { string value }
     is Literal
 
     method valueDisplayString
-        Integer printBase: 2
-                do: { value toString }!
+        string!
 end
 
 class SyntaxStringInterpolation { parts }

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -101,7 +101,9 @@ class SyntaxPrinter { output
         anArray entries
             do: { |element| element visitBy: printer }
             interleaving: { printer print: ",".
-                            flat ifFalse: { printer newline } }.
+                            flat
+                                ifTrue: { printer print: " " }
+                                ifFalse: { printer newline } }.
         printer print: "]".
         last = #paren!
 

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -256,7 +256,8 @@ class SyntaxPrinter { output
                   printer print: part.
                   printer print: ": ".
                   arg visitBy: printer }
-            interleaving: { printer newline }.
+            interleaving: { printer last == #comment
+                                ifFalse: { printer newline } }.
         last = #keyword!
 
     method visitIs: anIs

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -170,6 +170,8 @@ class SyntaxPrinter { output
         last = newLast!
 
     method visitPrefixComment: aComment
+        last == #import
+            ifTrue: { self skipline }.
         self handleBlockStart.
         let valueVisitor = self indentHere.
         aComment fence is False

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -62,6 +62,10 @@ class SyntaxPrinter { output
         self doIndent.
         self!
 
+    method reset
+        indent = 0.
+        self!
+
     method doIndent
         indent - printed times: { output print: " " }.
         printed = indent.
@@ -345,6 +349,7 @@ class SyntaxPrinter { output
             ifFalse: { bodyVisitor newline }.
         bodyVisitor visitMaybeSuffixComment: body
                     followedBy: "!".
+        self newline.
         last = #def!
 
     method _printModule: path
@@ -463,7 +468,7 @@ class SyntaxPrinter { output
 
     method _maybeToplevelNewline
         (last == #def)
-            ifTrue: { self skipline }.
+            ifTrue: { self reset }.
         (last is False or: last == #comment)
             ifFalse: { self newline }!
 
@@ -524,7 +529,7 @@ class SyntaxPrinter { output
             do: { |def| def visitBy: bodyVisitor }
             interleaving: { bodyVisitor skipline }.
         bodyVisitor skipIfNotEmpty.
-        self print: "end".
+        self println: "end".
         last = #def!
 
 end

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -7,6 +7,12 @@ class SyntaxPrinter { output
                       last }
     is SyntaxVisitor
 
+    direct method printAll: syntaxList to: output
+        syntaxList
+            do: { |each|
+                  SyntaxPrinter print: each to: output }
+            interleaving: { output newline }!
+
     direct method print: syntax to: output
         syntax visitBy: (self
                              output: output

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -99,7 +99,7 @@ end
 end
 "!
 
-    method test0_Format_small_array
+    method test_Format_small_array
         self parse: "[1,2,3,]"
             expect: "[1, 2, 3]"!
 
@@ -490,7 +490,7 @@ end
 end
 "!
 
-    method test0_Format_two_defines
+    method test_Format_two_defines
         self parseDefinitions:  "define A 100 foobar!
                                  define B 200 droopa!"
              expect:
@@ -501,7 +501,7 @@ define B
     200 droopa!
 "!
 
-    method test0_Format_two_classes
+    method test_Format_two_classes
         self parseDefinitions:  "class A \{\} end
                                  class B \{\} end"
             expect:

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -36,7 +36,8 @@ class TestFoolang { system ok onFailure }
             expect:
                 "-- foo
 -- bar
-define Foo 1!"!
+define Foo 1!
+"!
 
     method test_Format_class_with_just_interfaces
         self parse: "class TestInterface5Impl \{}
@@ -47,7 +48,8 @@ define Foo 1!"!
                 "class TestInterface5Impl \{}
     is Object
     is TestInterface5
-end"!
+end
+"!
 
     method test_Format_method_with_multipart_keyword_selector
         self parse: "class TestThis \{\}
@@ -58,7 +60,8 @@ end"!
                 "class TestThis \{\}
     method a: simple test: case
         52!
-end"!
+end
+"!
 
     method test_Format_method_with_binary_selector
         self parse: "class TestThisToo \{\}
@@ -69,7 +72,8 @@ end"!
                 "class TestThisToo \{\}
     method + x
         152!
-end"!
+end
+"!
 
     method test_Format_method_with_unary_selector
         self parse: "class TestThisTooYes \{\}
@@ -80,7 +84,8 @@ end"!
                 "class TestThisTooYes \{\}
     method beep
         15!
-end"!
+end
+"!
 
     method test_Format_method_with_prefix_selector
         self parse: "class TestThisTooYesYes \{\}
@@ -91,7 +96,8 @@ end"!
                 "class TestThisTooYesYes \{\}
     method prefix-
         1!
-end"!
+end
+"!
 
     method test0_Format_small_array
         self parse: "[1,2,3,]"
@@ -106,7 +112,8 @@ end"!
                 "-- foo
 -- bar
 class Foo \{\}
-end"!
+end
+"!
 
     method test_Line_comments_before_interface
         self parse: "-- foo
@@ -117,7 +124,8 @@ end"!
                 "-- foo
 -- bar
 interface Foo
-end"!
+end
+"!
 
     method test_Line_comments_before_extend
         self parse: "-- foo
@@ -128,7 +136,8 @@ end"!
                 "-- foo
 -- bar
 extend Foo
-end"!
+end
+"!
 
     method test_Multiple_line_comments_inside_class
         self parse: "class Foo \{\}
@@ -145,7 +154,8 @@ end"!
 
     method quux
         42!
-end"!
+end
+"!
 
     method test_Format_interface
         self parse: "interface TestInterface4
@@ -180,7 +190,8 @@ end"!
 
     method bar2
         42!
-end"!
+end
+"!
 
     method test_Interface_required_method_missing_detected
         self load: "interface TestInterface5
@@ -401,12 +412,16 @@ end"!
             parse: "-- boop\n    class   X   \{}   end"
             expect: "-- boop
 class X \{\}
-end"!
+end
+"!
 
     method test_Format_suffix_comment_to_class
         self
             parse: "class   X   \{}   end -- boop"
-            expect: "class X \{}\nend -- boop\n"!
+            expect: "class X \{}
+end
+ -- boop
+"!
 
     method test_Format_prefix_comment_to_method_body
         self
@@ -416,7 +431,8 @@ end"!
     method bar
         -- boop
         42!
-end"!
+end
+"!
 
     method test_Formatted_single_expression_has_no_trailing_newline
         self
@@ -432,7 +448,8 @@ end"!
             expect: "class X \{}
     method bar
         42! -- boop
-end"!
+end
+"!
 
     method test_Format_keyword_message_with_tiny_receiver_and_single_keyword
         self
@@ -456,7 +473,8 @@ end"!
     method beep
         \{ panic \"dundun\" -- oops
           \}!
-end"!
+end
+"!
 
     method test_Format_let_body_in_method
         self
@@ -469,12 +487,36 @@ end"!
     method bar
         let x = 123.
         x + x!
-end"!
+end
+"!
+
+    method test0_Format_two_defines
+        self parseDefinitions:  "define A 100 foobar!
+                                 define B 200 droopa!"
+             expect:
+                 "define A
+    100 foobar!
+
+define B
+    200 droopa!
+"!
+
+    method test0_Format_two_classes
+        self parseDefinitions:  "class A \{\} end
+                                 class B \{\} end"
+            expect:
+                "class A \{\}
+end
+
+class B \{\}
+end
+"!
 
     method test_Format_suffix_comment_to_define
         self
             parse: "define ThisOne 312! -- oh yeah"
-            expect: "define ThisOne 312! -- oh yeah\n"!
+            expect: "define ThisOne 312!
+ -- oh yeah\n"!
 
     method test_Format_prefix_comment_to_method
         self
@@ -485,7 +527,8 @@ end"!
 
     method bar
         42!
-end"!
+end
+"!
 
     method test_Format_comments_between_keyword_and_receiver
         self parse: "asdasasd
@@ -513,7 +556,8 @@ end"!
              -- of tests. Should either explain the rational or return False.
             ifTrue: { True }
             ifFalse: block!
-end"!
+end
+"!
 
     method test_Format_comments_between_unary_and_receiver
         self parse: "asdas
@@ -550,7 +594,8 @@ end"!
 
     method asdads
         129!
-end"!
+end
+"!
 
     method test_Block_comment_in_eval
         self eval: "---

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -39,6 +39,24 @@ class TestFoolang { system ok onFailure }
 define Foo 1!
 "!
 
+    method test_Format_import_and_define
+        self parseDefinitions: "import xyz
+                                define XYZ 42!"
+            expect: "import xyz
+
+define XYZ 42!
+"!
+
+    method test_Format_import_and_define_with_prefix_comment
+        self parseDefinitions: "import xyz
+                                -- Very Definitive
+                                define XYZ 42!"
+            expect: "import xyz
+
+-- Very Definitive
+define XYZ 42!
+"!
+
     method test_Format_class_with_just_interfaces
         self parse: "class TestInterface5Impl \{}
                         is Object
@@ -394,8 +412,14 @@ end
 
     method test_Format_prefix_comment_in_sequence
         self
-            parse: "    doo daa.\n    -- boop\n   self bar. \n x * 2"
-            expect: "doo daa.\n-- boop\nself bar.\nx * 2"!
+            parse: "doo daa.
+                    -- boop
+                    self bar.
+                    x * 2"
+            expect: "doo daa.
+-- boop
+self bar.
+x * 2"!
 
     method test_Format_suffix_comment_in_sequence
         self

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -500,6 +500,13 @@ end
 end
 "!
 
+    method test0_Format_suffix_comment_in_keyword_message
+        self parse: "receiver arg: arg1 -- the first arg
+                              arg: arg2"
+             expect: "receiver
+    arg: arg1 -- the first arg
+    arg: arg2"!
+
     method test_Format_let_body_in_method
         self
             parse: "class Droop \{\}

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -93,6 +93,10 @@ end"!
         1!
 end"!
 
+    method test0_Format_small_array
+        self parse: "[1,2,3,]"
+            expect: "[1, 2, 3]"!
+
     method test_Line_comments_before_class
         self parse: "-- foo
                      -- bar

--- a/foo/impl/test_self_hosting.foo
+++ b/foo/impl/test_self_hosting.foo
@@ -57,12 +57,12 @@ problem: {err description}" }.
         -- Debug println: "/done".
         res!
 
-    method parse: source expect: pretty
+    method parse: source using: selector expect: pretty
         -- Checks that parse pretty-prints as expected
         -- Debug println: "\n/parse source".
-        let syntaxList1 = Parser parseMixed: source.
+        let syntaxList1 = selector sendTo: Parser with: [source].
         -- Debug println: "\n/parse pretty".
-        let syntaxList2 = Parser parseMixed: pretty.
+        let syntaxList2 = selector sendTo: Parser with: [pretty].
         -- Debug println: "/check".
         { syntaxList1 checkEqual: syntaxList2 }
             on: Error
@@ -92,6 +92,12 @@ pretty({y} at: {i}):\n{pretty2}" } }.
 source:\n{source}
 printed(size: {printed size}):\n{printed2}
 pretty(size: {pretty size}):\n{pretty2}" } }!
+
+    method parse: source expect: pretty
+        self parse: source using: (#parseMixed:) expect: pretty!
+
+    method parseDefinitions: source expect: pretty
+        self parse: source using: (#parseDefinitions:) expect: pretty!
 
     method eval: exprSource expect: expected
         self checkParsingBy: { |source| Parser parseExpressions: source }

--- a/foo/impl/test_self_hosting.foo
+++ b/foo/impl/test_self_hosting.foo
@@ -71,11 +71,9 @@ problem: {err description}" }.
 source:\n{source}
 pretty:\n{pretty}
 problem: {err description}" }.
-        let printed
-            = StringOutput
-                  with: { |out|
-                          syntaxList1 do: { |syntax| SyntaxPrinter print: syntax to: out }
-                                      interleaving: { out newline } }.
+        let printed = StringOutput
+                          with: { |out|
+                                  SyntaxPrinter printAll: syntaxList1 to: out }.
         printed == pretty
             ifFalse: { let printed2 = printed replace: "\n" with: "|\n".
                        let pretty2 = pretty replace: "\n" with: "|\n".

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -982,7 +982,8 @@ end
                 expect: "[#<SyntaxLiteral 123>][#<SyntaxInterface interface X
     method y
         42!
-end>]"!
+end
+>]"!
 
     method test_Transpiled_SyntaxPrinter
         self transpileWithPrelude:

--- a/indent_lang.sh
+++ b/indent_lang.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+git checkout foo/lang/
+
+F=${1:-any.foo}
+
+while true
+do
+    cargo run -- foo/format.foo -- foo/lang/$F || break
+    git diff --exit-code foo/lang/$F || break
+    F=$(ls -1 foo/lang/ | grep -A1 ^$F | tail -n 1)
+done


### PR DESCRIPTION
- Suffix comments between keywords no longer get an extra newline
- Empty lines between toplevel defintions
- Prefix comments after an import get an extra newline between
- Retain leading zeros for hexadecimals and binary
- Add spaces between array elements

Plus some cleanups.
