### PR TITLE
CTranspiler: ANF transform before send to record constructor

### DIFF
--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -779,15 +779,23 @@ class CTranspiler { output selectorMap closureFunctions
     method visitRecord: aRecord
         -- Tracer visitRecord: aRecord.
         let recordClass = self _ensureRecordClass: aRecord.
+        output print: "(\{ ".
+        let argVars = aRecord values
+                          collect: { |each|
+                                     let index = self addTemp.
+                                     output print: "ctx->frame[{index}] =  ".
+                                     each visitBy: self.
+                                     output print: "; ".
+                                     index }.
         output print: "foo_send(ctx".
         output print: ", &{Name mangleSelector: aRecord name}".
         output print: ", {Name mangleGlobal: recordClass}".
-        output print: ", {aRecord values size}".
         output print: ", ".
-        aRecord values
-            do: { |each| each visitBy: self }
-            interleaving: { output print: ", " }.
-        output print: ")"!
+        output print: argVars size.
+        argVars
+            do: { |each|
+                  output print: ", ctx->frame[{each}]" }.
+        output print: "); })"!
 
     method _generateLayout: aClass
         aClass isBuiltin
@@ -1193,8 +1201,7 @@ class CTranspiler { output selectorMap closureFunctions
         output print: ", ".
         aSend receiver visitBy: self.
         output print: ", ".
-        output print: aSend arguments size.
-        output print: "ul".
+        output print: argVars size.
         argVars
             do: { |index|
                   output print: ", ctx->frame[{index}]" }.
@@ -1229,7 +1236,7 @@ class CTranspiler { output selectorMap closureFunctions
 
     method visitBindLexical: aBind
         -- Tracer trace: #visitBindLexical:.
-        output print: "(\{ ctx->frame[{aBind variable index - 1}ul] = ".
+        output print: "(\{ ctx->frame[{aBind variable index - 1}] = ".
         self _generateTypecheck: aBind variable type
              _for: aBind value.
         output print: ";".
@@ -1238,7 +1245,7 @@ class CTranspiler { output selectorMap closureFunctions
 
     method visitLexicalRef: aRef
         -- Tracer trace: #visitLexicalRef:.
-        output print: "foo_lexical_ref(ctx, {aRef variable index - 1}ul, {aRef frameOffset}ul)"!
+        output print: "foo_lexical_ref(ctx, {aRef variable index - 1}, {aRef frameOffset}ul)"!
 
     method visitLexicalSet: aSet
         -- Tracer trace: #visitLexicalSet:.

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -674,13 +674,22 @@ end
         self eval: "[]"
              expect: []!
 
-    method testRecord1
+    method test_Record_without_trailing_comma
         self eval: "\{foo: 42, bar: 123}"
              expect: {foo: 42, bar: 123}!
 
-    method testRecord2
+    method test_Record_with_trailing_comma
         self eval: "\{foo: 42, bar: 123,}"
              expect: {foo: 42, bar: 123}!
+
+    method test_Record_evaluation_order
+        self eval: "let x = List new.
+                    \{ a: (x add: 1),
+                       b: (x add: 2) }.
+                    \{ d: (x add: 3),
+                       c: (x add: 4) \}.
+                    x asArray"
+             expect: [1, 2, 3, 4]!
 
     method testDictionary1
         self eval: "let x = 42. let y = 13. \{ x -> y, y + 1 -> x * 2 }"

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -649,25 +649,6 @@ class TestTranspilePreludeOutput { assert system }
             expect: "Hello World!\n42"!
 end
 
-class TestTranspilePreludeRecord { assert system }
-    is TranspilerTest
-
-    method test
-        self transpile: "import lang.record_ext.*
-
-                         class Main \{}
-                             direct method run: command in: system
-                                 let a1 = \{ foo: 42 }.
-                                 let a2 = \{ foo: 42 }.
-                                 let b = \{ bar: 42 }.
-                                 let c = \{ foo: 42, bar: 42 }.
-                                 (a1 == a2) debug.
-                                 (a1 == b) debug.
-                                 (a1 == b) debug!
-                         end"
-            expect: "#<Boolean True>#<Boolean False>#<Boolean False>"!
-end
-
 class TestTranspilePreludeSelector { assert system }
     is TranspilerTest
 
@@ -881,17 +862,6 @@ class TestTranspileDefine { assert system }
                                  MyInteger debug!
                          end"
             expect: "#<Integer 1234>"!
-
-    method testDefineRecord
-        self transpile: "define MyRecord1 \{ foo: 42, bar: 123 }!
-                         define MyRecord2 \{ bar: 128947, foo: 99 }!
-
-                         class Main \{}
-                             direct method run: command in: system
-                                 MyRecord1 foo debug.
-                                 MyRecord2 foo debug!
-                         end"
-            expect: "#<Integer 42>#<Integer 99>"!
 
     method testDefineSelector
         self transpile: "define MySelector #foobar!
@@ -1559,7 +1529,48 @@ end
 class TestTranspileRecord { assert system }
     is TranspilerTest
 
-    method test
+    method test_Define_record_in_transpiler
+        self transpile: "define MyRecord1 \{ foo: 42, bar: 123 }!
+                         define MyRecord2 \{ bar: 128947, foo: 99 }!
+
+                         class Main \{}
+                             direct method run: command in: system
+                                 MyRecord1 foo debug.
+                                 MyRecord2 foo debug!
+                         end"
+            expect: "#<Integer 42>#<Integer 99>"!
+
+    method test0_Eval_order_in_transpiled_record
+        self transpile: "class Main \{ out }
+                             direct method run: command in: system
+                                 (self out: system output) run!
+                             method value: x
+                                 out writeString: x.
+                                 x!
+                             method run
+                                 \{ a: ( self value: \"1\" ),
+                                    b: ( self value: \"2\" ) }.
+                                 \{ d: ( self value: \"3\" ),
+                                    c: ( self value: \"4\" ) }!
+                         end"
+            expect: "1234"!
+
+    method test_Record_equality_in_transpiler
+        self transpile: "import lang.record_ext.*
+
+                         class Main \{}
+                             direct method run: command in: system
+                                 let a1 = \{ foo: 42 }.
+                                 let a2 = \{ foo: 42 }.
+                                 let b = \{ bar: 42 }.
+                                 let c = \{ foo: 42, bar: 42 }.
+                                 (a1 == a2) debug.
+                                 (a1 == b) debug.
+                                 (a1 == b) debug!
+                         end"
+            expect: "#<Boolean True>#<Boolean False>#<Boolean False>"!
+
+    method test_Simple_record_in_transpiler
         self transpile: "class Main \{}
                              direct method run: command in: system
                                  let r = \{ foo: 42 }.
@@ -2289,7 +2300,6 @@ class Main {}
             "--prelude-iterable" -> TestTranspilePreludeIterable,
             "--prelude-object" -> TestTranspilePreludeObject,
             "--prelude-output" -> TestTranspilePreludeOutput,
-            "--prelude-record" -> TestTranspilePreludeRecord,
             "--prelude-selector" -> TestTranspilePreludeSelector,
             "--prelude-string" -> TestTranspilePreludeString,
             "--prelude-string-output" -> TestTranspilePreludeStringOutput,


### PR DESCRIPTION
  C does not guarantee evaluation order, and the arguments were
  not visible to GC.

  Also unify "ul" suffix or not for frame references to "not".
