### PR TITLE
Better error for failing to compile the compiler

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -630,7 +630,7 @@ interface AstGlobalVariable
     method assertDefined: wanted
         self isDefined is wanted
             ifFalse: { wanted
-                           ifTrue: { Error raise: "Undefined global in AST: {self name}" }
+                           ifTrue: { Error raise: self noteUndefined }
                            ifFalse: { Error raise: "Global is already defined: {self name}" } }!
 
     method value
@@ -665,12 +665,14 @@ interface AstGlobalVariable
             ifTrue: { "<undefined>" }.
         self _value!
 
+    method noteUndefined
+        (self sources isEmpty not) assert.
+        let note = "Undefined variable: {self name}".
+        "{note}\n{self sources first note: note}"!
+
     method warnIfUndefined
         self isUndefined
-            ifTrue: { let note = "Undefined variable: {self name}".
-                      (self sources isEmpty not) assert.
-                      Output debug
-                          println: "\nWARNING: {note}\n{self sources first note: note}" }!
+            ifTrue: { Output debug println: "\nWARNING: {self noteUndefined}" }!
 
     method withSource: sourceLocation
         self sources add: sourceLocation.

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -666,7 +666,8 @@ interface AstGlobalVariable
         self _value!
 
     method noteUndefined
-        (self sources isEmpty not) assert.
+        self sources
+            ifEmpty: { Error raise: "No source for global: {self name}" }.
         let note = "Undefined variable: {self name}".
         "{note}\n{self sources first note: note}"!
 

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -156,12 +156,6 @@ class Builtin { type value markFunction _interfaces
         "#<Builtin{type name} {self name}>"!
 end
 
-class System {}
-end
-
-class SystemRandom {}
-end
-
 define Builtins [
      Builtin
          type: Class
@@ -267,13 +261,17 @@ define Builtins [
          instanceMethods: string.InstanceMethods,
     Builtin
          type: Class
-         value: System
+         value: (Foolang isSelfHosted
+                     ifTrue: { System }
+                     ifFalse: { { name: "System" } })
          mark: "foo_mark_none"
          directMethods: system.DirectMethods
          instanceMethods: system.InstanceMethods,
     Builtin
          type: Class
-         value: SystemRandom
+         value: (Foolang isSelfHosted
+                     ifTrue: { SystemRandom }
+                     ifFalse: { { name: "SystemRandom" } })
          mark: "foo_mark_none"
          directMethods: system_random.DirectMethods
          instanceMethods: system_random.InstanceMethods,

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -693,10 +693,20 @@ class CTranspiler { output selectorMap closureFunctions
                     out println: " }".
                     out println: "};" }!
 
+    method _printStringAsComment: s0 to: out
+        -- KLUDGE ARRGH do this properly FIXME
+        let s1 = s0 replace: "\\" with: "\\\\".
+        let s2 = s1 replace: "\n" with: "\\n".
+        let s3 = s2 replace: "\r" with: "\\r".
+        let s4 = s3 replace: "\"" with: "\\\"".
+        let s5 = s4 replace: "\{" with: "\\\{".
+        out println: "// \"{s5}\""!
+
     method _stringDefinition: value _called: cname
         StringOutput
             with: { |out|
-                    out println: "/* {value} */".
+                    value lines
+                        do: { |each| self _printStringAsComment: each to: out }.
                     out println: "struct FooBytes {cname} =".
                     out println: "\{".
                     out println: "    .gc = false,".
@@ -879,7 +889,7 @@ class CTranspiler { output selectorMap closureFunctions
         let metaclassNameString = "{anInterface name} interface".
         output println: "struct FooClass {metaclassName} = ".
         output println: "\{".
-        output println: "    .name = &{self constantCName: metaclassNameString in: env}, /* {metaclassNameString} */".
+        output println: "    .name = &{self constantCName: metaclassNameString in: env}, // {metaclassNameString}".
         output println: "    .metaclass = &FooClass_Class,".
         output println: "    .inherited = &{metaclassInheritance},".
         output println: "    .layout = &TheClassLayout,".
@@ -902,7 +912,7 @@ class CTranspiler { output selectorMap closureFunctions
         -- FIXME: for runtime instantiation of classes we need to add the instance methods here!
         output println: "struct FooClass {className} = ".
         output println: "\{".
-        output println: "    .name = &{self constantCName: anInterface name in: env}, /* {anInterface name} */".
+        output println: "    .name = &{self constantCName: anInterface name in: env}, // {anInterface name}".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = NULL,". -- FIXME
@@ -1024,7 +1034,7 @@ class CTranspiler { output selectorMap closureFunctions
                        let metaclassNameString = "{aClass name} class".
                        output println: "struct FooClass {metaclassName} = ".
                        output println: "\{".
-                       output println: "    .name = &{self constantCName: metaclassNameString in: env}, /* {metaclassNameString} */".
+                       output println: "    .name = &{self constantCName: metaclassNameString in: env}, // {metaclassNameString}".
                        output println: "    .metaclass = &FooClass_Class,".
                        output println: "    .inherited = &{metaclassInheritance},".
                        output println: "    .layout = &TheClassLayout,".
@@ -1053,7 +1063,7 @@ class CTranspiler { output selectorMap closureFunctions
         -- Debug println: "{aClass} => {aClass markFunction}".
         output println: "struct FooClass {className} = ".
         output println: "\{".
-        output println: "    .name = &{self constantCName: aClass name in: env}, /* {aClass name} */".
+        output println: "    .name = &{self constantCName: aClass name in: env}, // {aClass name}".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = {layout},".

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -224,11 +224,11 @@ class Environment { parent
                             name: moduleName last
                             module: module]!
 
-    method import: name from: moduleName relative: relative
+    method import: name from: moduleName relative: relative source: source
         (self depth is 1) assert.
         let global = (modules at: moduleName relative: relative in: self)
                          global: name.
-        self addGlobals: [global]!
+        self addGlobals: [global withSource: source]!
 
     method importAll: moduleName relative: relative
         (self depth is 1) assert.

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -288,12 +288,13 @@ class Environment { parent
     method reference: name
         self reference: name from: depth!
 
-    method reference: name inModule: module
+    method reference: name inModule: module source: source
         -- FIXME: should keep this distinct from regular bindings, now
         -- let foo ... will shadow import foo, even if the latter cannot
         -- be used on its own
-        (self reference: module from: depth)
-            global: name!
+        ((self reference: module from: depth)
+             global: name)
+        withSource: source!
 
     method reference: name from: useDepth
         -- Debug println: "ref? {name} at {depth}?".

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -697,7 +697,11 @@ class ImportToken { precedence string first last }
             name: name
             module: parts butlast
             relative: relative
-            body: body!
+            body: body
+            source: (SourceString
+                         string: parser source
+                         first: specFirst
+                         last: specLast)!
 end
 
 class SyntaxTable { where tokens }

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -400,13 +400,14 @@ class SyntaxModuleImport { module relative body }
         [module, relative, body]!
 end
 
-class SyntaxNameImport { name module relative body }
+class SyntaxNameImport { name module relative body source }
     is Syntax
 
     method visitBy: visitor
         visitor visitNameImport: self!
 
     method parts
+        -- ignore source?
         [name, module, body]!
 end
 

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -37,11 +37,12 @@ class SyntaxTranslator { env currentMethod }
                          import: module
                          relative: relative)!
 
-    method import: name from: module relative: relative
+    method import: name from: module relative: relative source: source
         self child: (env
                          import: name
                          from: module
-                         relative: relative)!
+                         relative: relative
+                         source: source)!
 
     method importAll: module relative: relative
         self child: (env
@@ -260,7 +261,8 @@ class SyntaxTranslator { env currentMethod }
         let bodyVisitor = self
                               import: anImport name
                               from: anImport module
-                              relative: anImport relative.
+                              relative: anImport relative
+                              source: anImport source.
         AstDefinitionList
             new: (bodyVisitor _visitEach: anImport body)!
 

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -276,7 +276,9 @@ class SyntaxTranslator { env currentMethod }
 
     method visitExternalRef: aRef
         -- Tracer visitExternalRef: aRef.
-        env reference: aRef name inModule: aRef module!
+        env reference: aRef name
+            inModule: aRef module
+            source: aRef source!
 
     method _visitType: aType
         -- Tracer _visitType: aType name.

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -949,7 +949,7 @@ class TestTranspileGlobals { assert system }
                                  list.ThisIsReallyUndefined bang!
                          end"
             expectCompilerError: "Undefined variable: ThisIsReallyUndefined
-002                          class Main {}
+002                          class Main \{}
 003                              direct method run: command in: system
 004                                  list.ThisIsReallyUndefined bang!
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsReallyUndefined

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -89,6 +89,20 @@ interface TranspilerTest
              ok: False
              expect: output!
 
+    method transpileWithError: string
+        { let res = self prelude: False transpile: string.
+          Output debug println: "WTF:\{string}\n==>\n{res}".
+          return False }
+            on: Error
+            do: { |e|
+                  return e description }.
+        Error raise: "Expected transpiler error, but nothing happened:\n{string}"!
+
+    method transpile: string expectCompilerError: output::String
+        assert that: { self transpileWithError: string }
+               equals: output
+               testing: "transpile:expectCompilerError:"!
+
     method transpileWithPrelude: string expect: output
         self prelude: ["lang", "prelude"] asList
              transpile: string
@@ -823,10 +837,10 @@ class TestTranspileKeyword { assert system }
             expect: "#<Integer 45>"!
 end
 
-class TestTranspileDefine { assert system }
+class TestTranspileGlobals { assert system }
     is TranspilerTest
 
-    method testDefineArray1
+    method test_Define_global_array
         self transpile: "define MyArray [1,2,3]!
                          class Main \{}
                              direct method run: command in: system
@@ -834,7 +848,7 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "[#<Integer 1>, #<Integer 2>, #<Integer 3>]"!
 
-    method testDefineArray2
+    method test_Define_global_nested_array
         self transpile: "define MyArray [[1],[[1]],[[[1]]]]!
                          class Main \{}
                              direct method run: command in: system
@@ -842,7 +856,7 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "[[#<Integer 1>], [[#<Integer 1>]], [[[#<Integer 1>]]]]"!
 
-    method testDefineBoolean
+    method test_Define_global_boolean
         self transpile: "define MyBoolean True!
                          class Main \{}
                              direct method run: command in: system
@@ -850,7 +864,7 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "#<Boolean True>"!
 
-    method testDefineClassInstance
+    method test_Define_global_class_instance
         self transpileWithPrelude:
             "class MyClass \{ x y }
                  is Object
@@ -867,7 +881,7 @@ class TestTranspileDefine { assert system }
              end"
             expect: "#<Integer 1242>#<Integer 40>"!
 
-    method testDefineFloat
+    method test_Define_global_float
         self transpile: "define MyFloat 12.34!
                          class Main \{}
                              direct method run: command in: system
@@ -875,7 +889,7 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "#<Float 12.34>"!
 
-    method testDefineInteger
+    method test_Define_global_integer
         self transpile: "define MyInteger 1234!
                          class Main \{}
                              direct method run: command in: system
@@ -883,7 +897,7 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "#<Integer 1234>"!
 
-    method testDefineSelector
+    method test_Define_global_selector
         self transpile: "define MySelector #foobar!
 
                          class Main \{}
@@ -892,13 +906,41 @@ class TestTranspileDefine { assert system }
                          end"
             expect: "#<Selector foobar>"!
 
-    method testDefineString
+    method test_Define_global_string
         self transpile: "define MyString \"foobar\"!
                          class Main \{}
                              direct method run: command in: system
                                  MyString debug!
                          end"
             expect: "#<String foobar>"!
+
+    method test_Undefined_variable
+        self transpile: "class Main \{\}
+                             direct method run: command in: system
+                                 ThisIsUndefined bang!
+                         end"
+            expectCompilerError: "Undefined variable: ThisIsUndefined
+001 class Main \{}
+002                              direct method run: command in: system
+003                                  ThisIsUndefined bang!
+                                     ^^^^^^^^^^^^^^^ Undefined variable: ThisIsUndefined
+004                          end
+"!
+
+    method test0_Undefined_import
+        self transpile: "import lang.list.ThisIsUndefinedToo
+                         class Main \{\}
+                             direct method run: command in: system
+                                 ThisIsUndefinedToo bang!
+                         end"
+            expectCompilerError: "Undefined variable: ThisIsUndefinedToo
+001 import lang.list.ThisIsUndefinedToo
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsUndefinedToo
+002                          class Main \{\}
+003                              direct method run: command in: system
+004                                  ThisIsUndefinedToo bang!
+005                          end
+"!
 end
 
 class TestTranspileBlock { assert system }
@@ -2292,12 +2334,12 @@ class Main {}
             "--boolean" -> TestTranspileBoolean,
             "--byte-array" -> TestTranspileByteArray,
             "--class" -> TestTranspileClass,
-            "--define" -> TestTranspileDefine,
             "--dictionary" -> TestTranspileDictionary,
             "--dynamic" -> TestTranspileDynamic,
             "--extend" -> TestTranspileExtend,
             "--finally" -> TestTranspileFinally,
             "--float" -> TestTranspileFloat,
+            "--globals" -> TestTranspileGlobals,
             "--integer" -> TestTranspileInteger,
             "--includes" -> TestTranspileIncludes,
             "--interface" -> TestTranspileInterface,

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -927,7 +927,7 @@ class TestTranspileGlobals { assert system }
 004                          end
 "!
 
-    method test0_Undefined_import
+    method test_Undefined_import
         self transpile: "import lang.list.ThisIsUndefinedToo
                          class Main \{\}
                              direct method run: command in: system
@@ -939,6 +939,20 @@ class TestTranspileGlobals { assert system }
 002                          class Main \{\}
 003                              direct method run: command in: system
 004                                  ThisIsUndefinedToo bang!
+005                          end
+"!
+
+    method test_Undefined_external
+        self transpile: "import lang.list
+                         class Main \{\}
+                             direct method run: command in: system
+                                 list.ThisIsReallyUndefined bang!
+                         end"
+            expectCompilerError: "Undefined variable: ThisIsReallyUndefined
+002                          class Main {}
+003                              direct method run: command in: system
+004                                  list.ThisIsReallyUndefined bang!
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsReallyUndefined
 005                          end
 "!
 end

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -337,7 +337,7 @@ class TestTranspileDictionary { assert system }
             expect: "\{ 1 -> \"one\",
   2 -> \"two\" }"!
 
-    method test0_Dictionary_constructor
+    method test_Dictionary_constructor
         self transpile: "import lang.dictionary2.Dictionary
                          import lang.string
                          import lang.character_ext

--- a/foo/impl/utils.foo
+++ b/foo/impl/utils.foo
@@ -13,6 +13,9 @@ class FileModuleDictionary { _dict }
             ifExists: { |foopath|
                         foopath file forRead open: { |f| f readString } }
             ifDoesNotExist: block!
+
+    method toString
+        "#<FileModuleDictionary {_dict keys}>"!
 end
 
 extend Dictionary


### PR DESCRIPTION
Previously: `Undefined global in AST: InstanceMethods`

Now: 

```
Undefined variable: InstanceMethods,
163          mark: "foo_mark_array"
164          directMethods: array.DirectMethods
165          instanceMethods: array.InstanceMethods,
                              ^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: InstanceMethods,
166      Builtin
167          type: Class
```