### PR TITLE
SyntaxPrinter: add space to records and dictionaries

### DIFF
--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -131,7 +131,7 @@ class SyntaxPrinter { output
         last = #paren!
 
     method visitRecord: aRecord
-        self print: "\{".
+        self print: "\{ ".
         let printer = self indentHere.
         aRecord entries
             do: { |entry|
@@ -139,18 +139,23 @@ class SyntaxPrinter { output
                   printer print: " ".
                   entry value visitBy: printer }
             interleaving: { printer println: "," }.
-        self print: "}".
+        self print: " }".
         last = #paren!
 
     method visitDictionary: aDictionary
-        self print: "\{".
+        self print: "\{ ".
+        let printer = self indentHere.
         aDictionary entries
             do: { |entry|
-                  entry key visitBy: self.
-                  self print: " -> ".
-                  entry value visitBy: self }
-            interleaving: { self print: ", " }.
-        self print: "}".
+                  entry key visitBy: printer.
+                  let value = entry value.
+                  let valuePrinter = value isSimple
+                                         ifTrue: { printer }
+                                         ifFalse: { printer newline }.
+                  valuePrinter print: " -> ".
+                  value visitBy: valuePrinter }
+            interleaving: { printer println: "," }.
+        self print: " }".
         last = #paren!
 
     method visitSeq: aSeq

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -29,7 +29,25 @@ class TestFoolang { system ok onFailure }
             eval: "TestInterface3 includes: (TestInterface3Impl new foo)"
             expect: True!
 
-    method test_Line_comments_before_define
+    method test_Format_dictionary_with_small_values
+        self parse: "\{ 1 -> 100, 2 -> 200 \}"
+             expect:
+                 "\{ 1 -> 100,
+  2 -> 200 \}"!
+
+    method test_Format_dictionary_with_big_value
+        self parse: "\{ 1 -> \{ this: \"is\",
+                                a: \"big\",
+                                thing: \"verily\" },
+                        2 -> 200 \}"
+        expect:
+        "\{ 1
+   -> \{ this: \"is\",
+        a: \"big\",
+        thing: \"verily\" },
+  2 -> 200 \}"!
+
+    method test_Format_line_comments_before_define
         self parse: "-- foo
                      -- bar
                      define Foo 1!"
@@ -500,7 +518,7 @@ end
 end
 "!
 
-    method test0_Format_suffix_comment_in_keyword_message
+    method test_Format_suffix_comment_in_keyword_message
         self parse: "receiver arg: arg1 -- the first arg
                               arg: arg2"
              expect: "receiver


### PR DESCRIPTION
   Particularly split lines for big values in dictionaries.
