### PR TITLE
Parser: fix parsing of external references

### DIFF
--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -886,18 +886,15 @@ class TokenWord { precedence string first last }
     method parseAsPrefixWith: parser atPrecedence: _precedence
         (parser atChar: DotCharacter andThenNot: #isWhitespace)
             ifTrue: { parser advance.
-                      let nameFirst = parser position.
-                      let nameLast = parser
-                                         skipWhile: { (parser atWhitespace
-                                                           or: (parser atChar: BangCharacter))
-                                                      not }.
-                      let parts = (parser from: first to: nameLast)
-                                      splitBy: DotCharacter.
-                      (parts size is 2) assert.
+                      let name = parser nextToken.
+                      let source = parser sourceFrom: name first to: name last.
+                      (TokenWord includes: name)
+                          ifFalse: { let note = "Expected name".
+                                     Error raise: "{note}, got: {name string}\n{source note: note}" }.
                       let ref = SyntaxExternalRef
-                          module: parts first
-                          name: parts second
-                          source: (parser sourceFrom: first to: nameLast).
+                          module: string
+                          name: name string
+                          source: source.
                       return ref }.
         SyntaxVariable
             name: string

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -75,6 +75,19 @@ define XYZ 42!
 define XYZ 42!
 "!
 
+    method test_Format_external_references_in_list
+        self parse: "[ext.Name1, ext.Name2]"
+            expect: "[ext.Name1, ext.Name2]"!
+
+    method test_Parse_bad_external_reference
+        self parse: "[ext.1Name1, ext.Name2]"
+             expectError: Error
+             where: { |e|
+                      e description == "Expected name, got: 1
+001 [ext.1Name1, ext.Name2]
+         ^ Expected name
+" }!
+
     method test_Format_class_with_just_interfaces
         self parse: "class TestInterface5Impl \{}
                         is Object

--- a/foo/impl/test_self_hosting.foo
+++ b/foo/impl/test_self_hosting.foo
@@ -99,6 +99,15 @@ pretty(size: {pretty size}):\n{pretty2}" } }!
     method parseDefinitions: source expect: pretty
         self parse: source using: (#parseDefinitions:) expect: pretty!
 
+    method parse: source expectError: type where: test
+        let result = { Parser parseExpressions: source }
+                         on: type
+                         do: { |e|
+                               (test value: e)
+                                   ifTrue: { return True }
+                                   ifFalse: { Error raise: "Expected error did not pass test, got: {e}" } }.
+        Error raise: "Expected error, got: {result}"!
+
     method eval: exprSource expect: expected
         self checkParsingBy: { |source| Parser parseExpressions: source }
              for: exprSource.

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -952,7 +952,7 @@ class TestTranspileGlobals { assert system }
 002                          class Main \{}
 003                              direct method run: command in: system
 004                                  list.ThisIsReallyUndefined bang!
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsReallyUndefined
+                                          ^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsReallyUndefined
 005                          end
 "!
 end


### PR DESCRIPTION
  Previously parser would happily swallow trailing non-alphanumeric
  characters.

