### PR TITLE
simplify imports in AST and Parser

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -98,17 +98,38 @@ class AstDefine { name body frameSize isDynamic env }
         visitor visitDefine: self!
 end
 
-class AstImport { spec }
+-- FIXME: Would it be better to have ImportDescription and
+-- compose that into both AstImport and SyntaxImport?
+class AstImport { syntax }
     is AstDefinition
 
     method defineIn: env
-        self!
+        let name = self name.
+        name is False
+            => { return env import: self module
+                                 relative: self relative }.
+        name == "*"
+            => { return env importAll: self module
+                            relative: self relative }.
+        env import: name
+            from: self module
+            relative: self relative
+            source: syntax source!
 
-    method eval
-        self!
+    method name
+        syntax name!
+
+    method relative
+        syntax relative!
+
+    method module
+        syntax module!
+
+    method spec
+        syntax spec!
 
     method toString
-        "#<AstImport {spec}>"!
+        "#<AstImport {self spec}>"!
 end
 
 class AstExtend { type interfaces directMethods instanceMethods }

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -680,28 +680,19 @@ class ImportToken { precedence string first last }
         let relative = parts first == ""
                            ifTrue: { parts popFirst.
                                      True }.
-        let body = parser parseDefinitions.
-        -- FIXME: Syntax change imminent
+        let source = parser sourceFrom: first to: specLast.
+        -- FIXME: https://github.com/nikodemus/foolang/issues/674
         parts last first isLowercase
-            ifTrue: { return SyntaxModuleImport
+            ifTrue: { return SyntaxImport
+                          name: False
                           module: parts
                           relative: relative
-                          body: body }.
-        let name = parts last.
-        name == "*"
-            ifTrue: { return SyntaxWildcardImport
-                          module: parts butlast
-                          relative: relative
-                          body: body }.
-        SyntaxNameImport
-            name: name
+                          source: source }.
+        SyntaxImport
+            name: parts last
             module: parts butlast
             relative: relative
-            body: body
-            source: (SourceString
-                         string: parser source
-                         first: specFirst
-                         last: specLast)!
+            source: source!
 end
 
 class SyntaxTable { where tokens }

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -390,35 +390,27 @@ class SyntaxKeyword { receiver selector arguments source }
         stream print: "#<{Self} {selector}>"!
 end
 
-class SyntaxModuleImport { module relative body }
+class SyntaxImport { name module relative source }
     is Syntax
 
     method visitBy: visitor
-        visitor visitModuleImport: self!
+        visitor visitImport: self!
+
+    method spec
+        StringOutput
+            with: { |out|
+                    relative is True ifTrue: { out print: "." }.
+                    module do: { |each| out print: each }
+                           interleaving: { out print: "." }.
+                    name is False
+                        ifFalse: { out print: ".".
+                                   out print: name } }!
 
     method parts
-        [module, relative, body]!
-end
+        [name, module, relative]!
 
-class SyntaxNameImport { name module relative body source }
-    is Syntax
-
-    method visitBy: visitor
-        visitor visitNameImport: self!
-
-    method parts
-        -- ignore source?
-        [name, module, body]!
-end
-
-class SyntaxWildcardImport { module relative body }
-    is Syntax
-
-    method visitBy: visitor
-        visitor visitWildcardImport: self!
-
-    method parts
-        [module, body]!
+    method toString
+        "#<SyntaxImport {self spec}>"!
 end
 
 class SyntaxExternalRef { module name source }

--- a/foo/impl/syntaxPrinter.foo
+++ b/foo/impl/syntaxPrinter.foo
@@ -376,35 +376,11 @@ class SyntaxPrinter { output
         self newline.
         last = #def!
 
-    method _printModule: path
-        self print: ("." join: path)!
-
-    method visitModuleImport: anImport
+    method visitImport: anImport
         self print: "import ".
-        anImport relative
-            ifTrue: { self print: "." }.
-        self _printModule: anImport module.
+        self print: anImport spec.
         self newline.
-        last = #import.
-        self _visitEach: anImport body!
-
-    method visitNameImport: anImport
-        self print: "import ".
-        anImport relative
-            ifTrue: { self print: "." }.
-        self _printModule: anImport module.
-        self println: ".{anImport name}".
-        last = #import.
-        self _visitEach: anImport body!
-
-    method visitWildcardImport: anImport
-        self print: "import ".
-        anImport relative
-            ifTrue: { self print: "." }.
-        self _printModule: anImport module.
-        self println: ".*".
-        last = #import.
-        self _visitEach: anImport body!
+        last = #import!
 
     method visitExternalRef: aRef
         self print: aRef module.

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -32,23 +32,6 @@ class SyntaxTranslator { env currentMethod }
     method addVariable: name type: type
         self child: (env addVariable: name type: type)!
 
-    method import: module relative: relative
-        self child: (env
-                         import: module
-                         relative: relative)!
-
-    method import: name from: module relative: relative source: source
-        self child: (env
-                         import: name
-                         from: module
-                         relative: relative
-                         source: source)!
-
-    method importAll: module relative: relative
-        self child: (env
-                         importAll: module
-                         relative: relative)!
-
     method visitSelector: aSelector
         AstConstantRef value: (Selector intern: aSelector name)
                        env: env!
@@ -248,31 +231,8 @@ class SyntaxTranslator { env currentMethod }
             frameSize: bodyVisitor env frame size
             isDynamic: aDefine variable isDynamic!
 
-    method visitModuleImport: anImport
-        -- Tracer visitModuleImport: anImport module.
-        let bodyVisitor = self
-                              import: anImport module
-                              relative: anImport relative.
-        AstDefinitionList
-            new: (bodyVisitor _visitEach: anImport body)!
-
-    method visitNameImport: anImport
-        -- Tracer visitNameImport: anImport module.
-        let bodyVisitor = self
-                              import: anImport name
-                              from: anImport module
-                              relative: anImport relative
-                              source: anImport source.
-        AstDefinitionList
-            new: (bodyVisitor _visitEach: anImport body)!
-
-    method visitWildcardImport: anImport
-        -- Tracer visitWildCardImport: anImport module.
-        let bodyVisitor = self
-                              importAll: anImport module
-                              relative: anImport relative.
-        AstDefinitionList
-            new: (bodyVisitor _visitEach: anImport body)!
+    method visitImport: anImport
+        AstImport syntax: anImport!
 
     method visitExternalRef: aRef
         -- Tracer visitExternalRef: aRef.

--- a/foo/impl/syntaxVisitor.foo
+++ b/foo/impl/syntaxVisitor.foo
@@ -17,8 +17,7 @@ interface SyntaxVisitor
     required method visitLet: aLet
     required method visitLiteral: aLiteral
     required method visitMethod: aMethod
-    required method visitModuleImport: aNode
-    required method visitNameImport: aNode
+    required method visitImport: aNode
     required method visitParens: aParens
     required method visitPrefixComment: aComment
     required method visitPrefixMessage: aMessage
@@ -30,5 +29,4 @@ interface SyntaxVisitor
     required method visitSuffixComment: aComment
     required method visitUnaryMessage: aMessage
     required method visitVariable: aVariable
-    required method visitWildcardImport: aNode
 end

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -935,7 +935,7 @@ class TestTranspileGlobals { assert system }
                          end"
             expectCompilerError: "Undefined variable: ThisIsUndefinedToo
 001 import lang.list.ThisIsUndefinedToo
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsUndefinedToo
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined variable: ThisIsUndefinedToo
 002                          class Main \{\}
 003                              direct method run: command in: system
 004                                  ThisIsUndefinedToo bang!


### PR DESCRIPTION
  Instead of having rest of the file be the "body" of an
  import, instead treat imports similarly to other toplevel
  definitions.

  Fixes #673
