### PR TITLE
Mark instance

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -386,7 +386,7 @@ class AstClass { name superclass _slots _interfaces _directMethods _instanceMeth
     method markFunction
         self
             ifSuperclass: { superclass definition markFunction }
-            ifNot: { "foo_mark_array" }!
+            ifNot: { "foo_mark_instance" }!
 
     method _readerMethods
         self _methodDictionary:

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -957,7 +957,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "\{".
         output println: "    (void)method;".
         output println: "    (void)ctx;".
-        output println: "    struct FooArray* new = FooArray_alloc({aClass slots size});".
+        output println: "    struct FooArray* new = FooInstance_alloc({aClass slots size});".
         aClass slots
             doWithIndex: { |each index|
                            let type = each type. -- FIXME: visit the type

--- a/host/main.c
+++ b/host/main.c
@@ -1114,6 +1114,17 @@ void foo_mark_array(void* ptr) {
   EXIT_TRACE();
 }
 
+void foo_mark_instance(void* ptr) {
+  ENTER_TRACE("mark_instance");
+  struct FooArray* array = ptr;
+  if (array->gc && foo_mark_live(array)) {
+    for (size_t i = 0; i < array->size; i++) {
+      foo_mark_object(array->data[i]);
+    }
+  }
+  EXIT_TRACE();
+}
+
 void foo_mark_layout(void* ptr) {
   struct FooLayout* layout = ptr;
   bool is_empty = layout == &TheEmptyLayout;

--- a/host/main.c
+++ b/host/main.c
@@ -286,6 +286,7 @@ struct FooClass FooClass_Selector;
 struct FooClass FooClass_String;
 struct FooPointerList FooClassInheritance_Class;
 struct FooArray* FooArray_alloc(size_t size);
+struct FooArray* FooArray_instance(size_t size);
 struct Foo foo_Float_new(double f);
 struct Foo foo_Integer_new(int64_t n);
 struct Foo foo_String_new(size_t len, const char* s);
@@ -903,6 +904,13 @@ struct FooProcessTimes* FooProcessTimes_new(double user, double system, double r
 }
 
 struct FooArray* FooArray_alloc(size_t size) {
+  struct FooArray* array = foo_alloc(sizeof(struct FooArray) + size*sizeof(struct Foo));
+  array->gc = true;
+  array->size = size;
+  return array;
+}
+
+struct FooArray* FooInstance_alloc(size_t size) {
   struct FooArray* array = foo_alloc(sizeof(struct FooArray) + size*sizeof(struct Foo));
   array->gc = true;
   array->size = size;


### PR DESCRIPTION
Use separate codepath for instance allocation and marking instead of piggybagging on arrays - better backtraces from ASAN this way.
