### PR TITLE
big transpiler evolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   bootstrap-and-test:
     name: "Bootstrap and test"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -852,7 +852,7 @@ class AstDynamic { name::String _id _value _state _definition sources }
         _state = new!
 
     method bind: newValue in: block
-        let oldValue = _value.
+        let oldValue = self eval.
         _value = newValue.
         { block value }
             finally: { _value = oldValue }!

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -91,7 +91,7 @@ class AstExtend { type interfaces directMethods instanceMethods }
         -- FIXME: Does this mean we should resolve name in env instead
         -- of the way it is now done?
         let target = type definition.
-        interfaces do: { |each| target __addInterface: each }.
+        interfaces do: { |each| target __addInterface: each eval }.
         directMethods do: { |each| target __addDirectMethod: each }.
         instanceMethods do: { |each| target __addInstanceMethod: each }.
         target!

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -690,24 +690,24 @@ interface AstGlobalVariable
         self isUndefined not!
 
     method definition
-        self assertDefined: True in: "#definition".
+        self assertDefined: True.
         self _definition!
 
     method define: definition
-        self assertDefined: False in: "#define:".
+        self assertDefined: False.
         self _definition: definition.
         self isDefined assert: "invalid definition for global".
         definition!
 
-    method assertDefined: wanted in: where
+    method assertDefined: wanted
         self isDefined is wanted
             ifFalse: { wanted
-                           ifTrue: { Error raise: "{self noteUndefined} (in {where})" }
-                           ifFalse: { Error raise: "Global is already defined: {self name} (in {where})" } }!
+                           ifTrue: { Error raise: self noteUndefined }
+                           ifFalse: { Error raise: "Global is already defined: {self name}" } }!
 
     method eval
         self _state is _Evaluated
-            ifFalse: { self assertDefined: True in: "#eval".
+            ifFalse: { self assertDefined: True.
                        self _state is _BeingEvaluated
                            ifTrue: { Error raise: "Cyclic definition: {self name}" }.
                        self _state: _BeingEvaluated.

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -10,17 +10,19 @@ interface Ast
         False!
 end
 
-class AstBuiltin { value }
+class AstBuiltin { global value }
     is Object
 
     method eval
-        value!
+        global hasValue
+            ifTrue: { global eval }
+            ifFalse: { global value: value }!
 
     method isBuiltin
         True!
 
     method ownInterfaces
-        value interfaces collect: { |each| { eval: each } }!
+        value interfaces collect: { |each| { value: each } }!
 
     method visitBy: visitor
         visitor visitBuiltin: self!
@@ -35,79 +37,26 @@ class AstBuiltin { value }
         value __addInstanceMethod: anInstanceMethod!
 end
 
-interface AstDefinition
+interface AstToplevel
     is Object
-
-    method eval
-        Error raise: "{self classOf name}#eval -- should not happend!"!
-
-    method defineIn: env
-        Error raise: "{self classOf name}#defineIn: -- should not happen!"!
 
     method isBuiltin
         False!
 
     method isDynamic
         False!
-
-    method allocGlobal
-        let name = self name.
-        self isDynamic
-            ifTrue: { AstDynamic name: name }
-            ifFalse: { AstGlobal name: name }!
-end
-
-class AstDefinitionList { list }
-    is AstDefinition
-
-    direct method new: list
-        self
-            list: list!
-
-    method allocGlobal
-        panic "No global for AstDefinitionList"!
-
-    method defineIn: env
-        list do: { |each| each defineIn: env }!
-end
-
-class AstDefine { name body frameSize isDynamic env }
-    is AstDefinition
-
-    direct method name: name
-                  body: body
-                  frameSize: frameSize
-                  isDynamic: isDynamic
-        self name: name
-             body: body
-             frameSize: frameSize
-             isDynamic: isDynamic
-             env: False!
-
-    method defineIn: defEnv
-        env = defEnv.
-        defEnv define: name as: self!
-
-    method eval
-        AstInterpreter evalDefine: body frameSize: frameSize!
-
-    method toString
-        "#<AstDefine {self name}>"!
-
-    method visitBy: visitor
-        visitor visitDefine: self!
 end
 
 -- FIXME: Would it be better to have ImportDescription and
 -- compose that into both AstImport and SyntaxImport?
 class AstImport { syntax }
-    is AstDefinition
+    is AstToplevel
 
     method defineIn: env
         let name = self name.
         name is False
             => { return env import: self module
-                                 relative: self relative }.
+                            relative: self relative }.
         name == "*"
             => { return env importAll: self module
                             relative: self relative }.
@@ -133,7 +82,7 @@ class AstImport { syntax }
 end
 
 class AstExtend { type interfaces directMethods instanceMethods }
-    is AstDefinition
+    is AstToplevel
 
     method defineIn: env
         -- FIXME: This should use a mirror for host, or
@@ -188,8 +137,7 @@ interface AstMethodHome
         -- Order is important, so these must be kept in a list!
         let interfaces = self _interfaces.
         (interfaces contains: anInterface)
-            ifTrue: { -- Debug println: "FOO: {self name} already {anInterface}".
-                      return False }.
+            ifTrue: { return False }.
         self _interfaces push: anInterface!
 
     method directMethods: methods
@@ -211,13 +159,13 @@ interface AstMethodHome
         self _interfaces!
 
     method interfaceDefinitions
-        self allInterfaces collect: #definition!
+        self allInterfaces collect: #definition as: Array!
 
     method interfaceGlobals
-        self allInterfaces collect: #yourself!
+        self allInterfaces collect: #yourself as: Array!
 
     method interfaceObjects
-        self allInterfaces collect: #eval!
+        self allInterfaces collect: #eval as: Array!
 
     method _ownDirectMethods
         let dict = Dictionary new.
@@ -274,25 +222,85 @@ interface AstMethodHome
             values: methods!
 end
 
-class AstInterface { name _interfaces _directMethods _instanceMethods _allInterfaces }
+interface AstDefinition
+    is AstToplevel
+
+    method idOr: block
+        self global idOr: block!
+
+    method defineIn: env
+        self global isDefined assert: "undefined global: {self}"!
+
+    method definition
+        self!
+end
+
+class AstDefine { global body frameSize }
+    is AstDefinition
+
+    direct method name: name
+                  body: body
+                  frameSize: frameSize
+                  env: env
+        let global = env global: name.
+        let theDefine = self global: global
+                             body: body
+                             frameSize: frameSize.
+        global define: theDefine.
+        theDefine!
+
+    method name
+        global name!
+
+    method isDynamic
+        global isDynamic!
+
+    method eval
+        global hasValue
+            ifTrue: { return global eval }.
+        let result = AstInterpreter
+                         evalDefine: body
+                         frameSize: frameSize.
+        global value: result!
+
+    method toString
+        "#<AstDefine {self name}>"!
+
+    method visitBy: visitor
+        visitor visitDefine: self!
+end
+
+class AstInterface { name _interfaces _directMethods _instanceMethods _allInterfaces
+                     global _env }
     is AstDefinition
     is AstMethodHome
 
     direct method name: name
                   interfaces: interfaces
-        self
-            name: name
-            _interfaces: interfaces
-            _directMethods: False
-            _instanceMethods: False
-            _allInterfaces: False!
+                  env: env
+        let global = env global: name.
+        let theInterface = self
+                               name: name
+                               _interfaces: interfaces
+                               _directMethods: False
+                               _instanceMethods: False
+                               _allInterfaces: False
+                               global: global
+                               _env: env.
+        global define: theInterface.
+        theInterface!
 
     method eval
-        Interface
-            new: name
-            interfaces: self interfaceObjects asArray
-            directMethods: self ownDirectMethods
-            instanceMethods: self ownInstanceMethods!
+        global hasValue
+            ifTrue: { return global eval }.
+        { let result = Interface
+                           new: name
+                           interfaces: self interfaceObjects
+                           directMethods: self ownDirectMethods
+                           instanceMethods: self ownInstanceMethods.
+          _env classes at: result put: self.
+          global value: result }
+        finally: { _env = False }!
 
     method _interfaces
         _interfaces!
@@ -322,9 +330,6 @@ class AstInterface { name _interfaces _directMethods _instanceMethods _allInterf
     method _instanceMethods: methods
         _instanceMethods = methods!
 
-    method defineIn: env
-        env define: name as: self!
-
     method visitBy: visitor
         visitor visitInterfaceDefinition: self!
 
@@ -332,33 +337,47 @@ class AstInterface { name _interfaces _directMethods _instanceMethods _allInterf
         "#<AstInterface {name}>"!
 end
 
-class AstClass { name superclass _slots _interfaces _directMethods _instanceMethods _allInterfaces }
+class AstClass { name superclass _slots
+                 _interfaces _directMethods _instanceMethods
+                 _allInterfaces global _env }
     is AstDefinition
     is AstMethodHome
 
     direct method name: name
                   slots: slots
                   interfaces: interfaces
-        self
-            name: name
-            superclass: False
-            _slots: slots
-            _interfaces: interfaces
-            _directMethods: False
-            _instanceMethods: False
-            _allInterfaces: False!
+                  env: env
+        let global = env global: name.
+        let theClass = self
+                           name: name
+                           superclass: False
+                           _slots: slots
+                           _interfaces: interfaces
+                           _directMethods: False
+                           _instanceMethods: False
+                           _allInterfaces: False
+                           global: global
+                           _env: env.
+        global define: theClass.
+        theClass!
 
     direct method name: name
                   superclass: superclass
                   interfaces: interfaces
-        self
-            name: name
-            superclass: superclass
-            _slots: False
-            _interfaces: ([superclass] append: interfaces)
-            _directMethods: False
-            _instanceMethods: False
-            _allInterfaces: False!
+                  env: env
+        let global = env global: name.
+        let theClass = self
+                           name: name
+                           superclass: superclass
+                           _slots: False
+                           _interfaces: ([superclass] append: interfaces)
+                           _directMethods: False
+                           _instanceMethods: False
+                           _allInterfaces: False
+                           global: global
+                           _env: env.
+        global define: theClass.
+        theClass!
 
     method ifSuperclass: then ifNot: else
         superclass is False
@@ -409,30 +428,34 @@ class AstClass { name superclass _slots _interfaces _directMethods _instanceMeth
                  collect: { |each|
                             AstReaderMethod home: self slot: each })!
 
-    method defineIn: env
-        env define: name as: self!
-
     method eval
-        Foolang isSelfHosted
-            ifTrue: { let layout = Layout new: (self slots size).
-                      let metaclass = Class subclass: "{name} class"
-                                            interfaces: [] -- FIXME
-                                            methods: self ownDirectMethods asArray.
-                      metaclass new: name
-                                layout: layout
-                                interfaces: [] -- FIXME
-                                methods: [] -- FIXME
-                      }
-            ifFalse: { Class
-                           new: name
-                           slots: (self slots
-                                       collect: { |each|
-                                                  { name: each name,
-                                                    type: each type } }
-                                       as: Array)
-                           interfaces: self interfaceObjects asArray
-                           directMethods: self ownDirectMethods
-                           instanceMethods: self ownInstanceMethods }!
+        global hasValue
+            ifTrue: {
+                return global eval }.
+        { let result
+              = Foolang isSelfHosted
+                  ifTrue: { let layout = Layout new: (self slots size).
+                            let metaclass = Class subclass: "{name} class"
+                                                  interfaces: [] -- FIXME
+                                                  methods: self ownDirectMethods asArray.
+                            -- FIXME interfaces and methods below
+                            metaclass new: name
+                                      layout: layout
+                                      interfaces: []
+                                      methods: [] }
+                  ifFalse: { Class
+                                 new: name
+                                 slots: (self slots
+                                             collect: { |each|
+                                                        { name: each name,
+                                                          type: each type } }
+                                             as: Array)
+                                 interfaces: self interfaceObjects
+                                 directMethods: self ownDirectMethods
+                                 instanceMethods: self ownInstanceMethods }.
+          _env classes put: self at: result.
+          global value: result }
+        finally: { _env = False }!
 
     method constructor
         self slots
@@ -622,34 +645,35 @@ class AstDictionary { entries }
         entries!
 end
 
-class AstValueMarker { string }
-    is Object
-    method toString
-        string!
-end
-
-define AstUndefined AstValueMarker string: "<undefined>"!
-define AstPending AstValueMarker string: "<pending>"!
-define AstInProgress AstValueMarker string: "<in-progress>"!
+define _Unevaluated { name: "<unevaluated>" }!
+define _BeingEvaluated { name: "<being-evaluated>" }!
+define _Evaluated { name: "<evaluated>" }!
 
 interface AstGlobalVariable
     is AstNode
 
     direct method name: name
-        -- Debug println: "{self name}#name: {name}".
         self
             name: name
-            _value: AstUndefined
+            _id: False
+            _value: False
+            _state: _Unevaluated
             _definition: False
             sources: List new!
 
     direct method name: name definition: definition
-        -- Debug println: "{self name}#name: {name} (defined)".
         self
             name: name
-            _value: AstPending
+            _id: False
+            _value: False
+            _state: _Unevaluated
             _definition: definition
             sources: List new!
+
+    method isBuiltin
+        self isDefined
+            ifTrue: { self _definition isBuiltin }
+            ifFalse: { False }!
 
     method isImmediate
         True!
@@ -661,39 +685,43 @@ interface AstGlobalVariable
         self isUndefined not!
 
     method definition
-        self assertDefined: True.
+        self assertDefined: True in: "#definition".
         self _definition!
 
     method define: definition
-        -- Debug println: "AstGlobalVariable#define: {name}".
-        self assertDefined: False.
-        self _value: AstPending.
+        self assertDefined: False in: "#define:".
         self _definition: definition.
-        self isDefined assert!
+        self isDefined assert: "invalid definition for global".
+        definition!
 
-    method assertDefined: wanted
+    method assertDefined: wanted in: where
         self isDefined is wanted
             ifFalse: { wanted
-                           ifTrue: { Error raise: self noteUndefined }
-                           ifFalse: { Error raise: "Global is already defined: {self name}" } }!
+                           ifTrue: { Error raise: "{self noteUndefined} (in {where})" }
+                           ifFalse: { Error raise: "Global is already defined: {self name} (in {where})" } }!
 
-    method value
-        self assertDefined: True.
-        self _value is AstInProgress
-            ifTrue: { Error raise: "Cyclic definition: {self name}" }.
-        self _value is AstPending
-            ifTrue: { self _value: AstInProgress.
-                      self _value: self _definition eval }.
+    method eval
+        self _state is _Evaluated
+            ifFalse: { self assertDefined: True in: "#eval".
+                       self _state is _BeingEvaluated
+                           ifTrue: { Error raise: "Cyclic definition: {self name}" }.
+                       self _state: _BeingEvaluated.
+                       self _definition eval.
+                       self _state is _Evaluated
+                           assert: "Evaluating definition did not set global" }.
         self _value!
 
+    method value: value
+        self hasValue not
+            assert: "Cannot set value of global: already has value".
+        self isDefined
+            assert: "Cannot set value of global: undefined".
+        self _value: value.
+        self _state: _Evaluated.
+        value!
+
     method hasValue
-        self _value is AstUndefined
-            ifTrue: { return False }.
-        self _value is AstInProgress
-            ifTrue: { return False }.
-        self _value is AstPending
-            ifTrue: { return False }.
-        return True!
+        self _state is _Evaluated!
 
     method isConstant
         True!
@@ -702,12 +730,7 @@ interface AstGlobalVariable
         self!
 
     method toString
-        "#<{self classOf name} {self name}: {self _info}>"!
-
-    method _info
-        self isUndefined
-            ifTrue: { "<undefined>" }.
-        self _value!
+        "#<{self classOf name} {self name} {self _state name} ({self _id})>"!
 
     method noteUndefined
         self sources
@@ -724,14 +747,37 @@ interface AstGlobalVariable
         self!
 end
 
-class AstGlobal { name::String _value _definition sources }
+class AstGlobal { name::String _id _value _state _definition sources }
     is AstGlobalVariable
+
+    method isDynamic
+        False!
+
+    method _id
+        _id!
+
+    method idOr: block
+        -- A bit of a KLUDGE: builtin globals have definitions
+        -- in main.c, and we want their names to be consistent.
+        --
+        -- See also: CompilerBuiltin#idOr:
+        self isBuiltin
+            ifTrue: { _id = "" }.
+        _id is False
+            ifTrue: { _id = block value }
+            ifFalse: { _id }!
 
     method _value: new
         _value = new!
 
     method _value
         _value!
+
+    method _state: new
+        _state = new!
+
+    method _state
+        _state!
 
     method _definition: new
         _definition = new!
@@ -742,17 +788,8 @@ class AstGlobal { name::String _value _definition sources }
     method visitBy: visitor
         visitor visitGlobal: self!
 
-    method isDynamic
-        False!
-
-    method isBuiltin
-        _definition isBuiltin!
-
     method ownInterfaces
         self definition ownInterfaces!
-
-    method eval
-        self value!
 
     method assign: value
         panic "Cannot assign to global! {name} = {value}"!
@@ -760,28 +797,41 @@ class AstGlobal { name::String _value _definition sources }
     -- KLUDGE: Currently types are either Any or AstGlobals. This is marginally
     -- than the previous mess, but still not nice.
     method typecheck: object
-        self value typecheck: object!
+        self eval typecheck: object!
 
     method redefine: newDefinition
+        self hasValue not
+            assert: "Cannot redefine a materialized global".
         -- FIXME: This is a bit dodgy: the usage is currently for replacing
         -- host definitions of builtins in transpiler, but it seems to me that
         -- value should be updated too if it has been materialized...
         --
         -- (See #redefineUsing:)
-        _definition = newDefinition!
+        _definition = newDefinition.
+        newDefinition global: self.
+        newDefinition!
 
     method redefineUsing: global
         _definition = global definition.
         sources = global sources.
-        self hasValue
-                ifTrue: { global hasValue
-                              ifTrue: { _value = global value }
-                              ifFalse: { _value =  AstPending } }!
+        global hasValue
+            ifTrue: { self value: global eval }!
 
 end
 
-class AstDynamic { name::String _value _definition sources }
+class AstDynamic { name::String _id _value _state _definition sources }
     is AstGlobalVariable
+
+    method isDynamic
+        True!
+
+    method _id
+        _id!
+
+    method idOr: block
+        _id is False
+            ifTrue: { _id = block value }
+            ifFalse: { _id }!
 
     method _definition
         _definition!
@@ -795,6 +845,12 @@ class AstDynamic { name::String _value _definition sources }
     method _value: new
         _value = new!
 
+    method _state
+        _state!
+
+    method _state: new
+        _state = new!
+
     method bind: newValue in: block
         let oldValue = _value.
         _value = newValue.
@@ -803,12 +859,9 @@ class AstDynamic { name::String _value _definition sources }
 
     method visitBy: visitor
         visitor visitDynamic: self!
-
-    method isDynamic
-        True!
 end
 
-class AstConstantRef { value env }
+class AstConstantRef { value source }
     is AstNode
 
     method isImmediate

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -87,11 +87,16 @@ class AstExtend { type interfaces directMethods instanceMethods }
     method defineIn: env
         -- FIXME: This should use a mirror for host, or
         -- existing metaobjects for self-hosted classes.
-        --
-        -- FIXME: Does this mean we should resolve name in env instead
-        -- of the way it is now done?
         let target = type definition.
-        interfaces do: { |each| target __addInterface: each eval }.
+        -- KLUDGE: in case of adding interfaces to AstMethodHome
+        -- we want to have the definition instead of the interface
+        -- object. Consider this more fallout from lack of
+        -- mirrors / reflective capabilities.
+        (AstMethodHome includes: target)
+            ifTrue: { interfaces
+                          do: { |each| target __addInterface: each } }
+            ifFalse: { interfaces
+                          do: { |each| target __addInterface: each eval } }.
         directMethods do: { |each| target __addDirectMethod: each }.
         instanceMethods do: { |each| target __addInstanceMethod: each }.
         target!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -196,10 +196,10 @@ class AstInterpreter { context process }
         theDictionary!
 
     method visitGlobal: aVar
-        aVar value!
+        aVar eval!
 
     method visitDynamic: aVar
-        aVar value!
+        aVar eval!
 
     method visitIs: anIs
         (anIs left visitBy: self) is (anIs right visitBy: self)!
@@ -220,7 +220,7 @@ class AstInterpreter { context process }
         let arguments = aSend arguments collect: { |arg| arg visitBy: self }.
         let $context = context.
         let $process = process.
-        -- Debug println: "<- {selector}".
+        -- Debug println: "{object} {selector}".
         { selector sendTo: object with: arguments asArray }
             on: DoesNotUnderstand
             do: { |ex|

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -71,8 +71,9 @@ end
 define DatumClasses
     [Boolean, Character, Integer, Float]!
 
-class CompilerBuiltin { type value markFunction _interfaces
-                _directMethods _instanceMethods _allInterfaces }
+class CompilerBuiltin { type value markFunction _id _interfaces
+                        _directMethods _instanceMethods _allInterfaces
+                        _global }
     is AstMethodHome
 
     direct method type: type
@@ -84,16 +85,38 @@ class CompilerBuiltin { type value markFunction _interfaces
                            type: type
                            value: value
                            markFunction: mark
+                           _id: False
                            _interfaces: List new
                            _directMethods: False
                            _instanceMethods: False
-                           _allInterfaces: False.
+                           _allInterfaces: False
+                           _global: False.
         theClass _directMethods: directMethods.
         theClass _instanceMethods: instanceMethods.
         theClass!
 
     method slots
         []!
+
+    method idOr: block
+        -- A bit of a KLUDGE: builtin globals have definitions
+        -- in main.c, and we want their names to be consistent.
+        --
+        -- See also: AstGlobal#idOr:
+        ""!
+
+    method eval
+        _global hasValue
+            ifTrue: { _global eval }
+            ifFalse: { _global value: value }!
+
+    method global: global
+        global definition is self
+            assert: "Bad global for CompilerBuiltin".
+        _global = global!
+
+    method definition
+        self!
 
     method _interfaces
         _interfaces!
@@ -115,9 +138,11 @@ class CompilerBuiltin { type value markFunction _interfaces
         _allInterfaces = list asArray!
 
     method _directMethods: methods
+        (self _directMethods is False) assert: "Builtin direct methods already set.".
         _directMethods = BuiltinMethod forEach: methods in: self direct: True!
 
     method _instanceMethods: methods
+        (self _instanceMethods is False) assert: "Builtin instance methods already set.".
         _instanceMethods = BuiltinMethod forEach: methods in: self direct: False!
 
     method visitBy: visitor
@@ -125,9 +150,6 @@ class CompilerBuiltin { type value markFunction _interfaces
 
     method name
         value name!
-
-    method eval
-        value!
 
     method isBuiltin
         True!
@@ -292,11 +314,20 @@ define AlwaysEmittedSelectors
      #writeString:]!
 
 define $home
-    False!
+        False!
+
+class Counter { value }
+    direct method new
+        self value: 0!
+    method increment
+        value = value + 1!
+end
 
 class CTranspiler { output selectorMap closureFunctions
                     constants variables tmpCounter
-                    globals generatedMethods env }
+                    globals globalsCounter
+                    recordClasses
+                    generatedMethods env builtins visited }
 
     direct method transpile: string in: env with: prelude
         env removeBuiltins: [
@@ -308,13 +339,15 @@ class CTranspiler { output selectorMap closureFunctions
             "StringOutput",
             "TypeError"
         ].
-        env replaceBuiltins: CompilerBuiltins all.
+        let builtins = CompilerBuiltins all.
+        env replaceBuiltins: builtins.
+        -- FIXME: move "target class map" to environment?
         prelude is False
             ifFalse: { env importPrelude: prelude }.
         env load: string.
-        self transpileMain: (env global: "Main") in: env!
+        self transpileMainIn: env with: builtins!
 
-    direct method transpileMain: main in: env
+    direct method transpileMainIn: env with: builtins
         let visitor = CTranspiler
                           output: StringOutput new
                           selectorMap: SelectorMap new
@@ -323,16 +356,23 @@ class CTranspiler { output selectorMap closureFunctions
                           variables: Dictionary new
                           tmpCounter: 0
                           globals: Dictionary new
+                          globalsCounter: Counter new
+                          recordClasses: Dictionary new
                           generatedMethods: Dictionary new
-                          env: env.
+                          env: env
+                          builtins: (Dictionary
+                                         keys: (builtins collect: #value)
+                                         values: builtins)
+                          visited: Dictionary new.
         visitor output println: "#include \"foo.h\"".
         -- KLUDGE: ensure selectors with references from C code
         AlwaysEmittedSelectors
             do: { |each| visitor selectorMap map: each }.
         let builtins = visitor generateBuiltins.
+        let main = env global: "Main".
         visitor declare: main.
         visitor writeDefinitions.
-        visitor writeMain.
+        visitor writeMain: main.
         { main: visitor output,
           builtins: builtins,
           closures: visitor generateClosures,
@@ -342,6 +382,15 @@ class CTranspiler { output selectorMap closureFunctions
 
     method addTemp
         $home addTemp!
+
+    method mangleGlobal: global
+        let id = global idOr: { globalsCounter increment }.
+        -- Debug println: "{id}: {global}".
+        Name mangleGlobal: global
+             id: id!
+
+    method mangleMetaclass: aClass
+        Name mangleMetaclass: aClass!
 
     method _visitWithOutputToString: value
         let oldOutput = output.
@@ -361,8 +410,7 @@ class CTranspiler { output selectorMap closureFunctions
         "ctx->frame[{tmp}]"!
 
     method declare: global
-        -- Debug println: "#declare: {global}".
-        globals at: (global name)
+        globals at: global
                 ifNonePut: { global definition }!
 
     method declareDynamic: var
@@ -386,7 +434,7 @@ class CTranspiler { output selectorMap closureFunctions
         aGlobal isDynamic
             ifTrue: { self declareDynamic: aGlobal.
                       output println: "struct Foo {Name mangleDynamic: aGlobal};" }
-            ifFalse: {  output println: "struct Foo {Name mangleGlobal: aGlobal};" }!
+            ifFalse: {  output println: "struct Foo {self mangleGlobal: aGlobal};" }!
 
     method _classDeclarations: aClass
         output println: "struct FooClass {Name mangleMetaclass: aClass};".
@@ -420,13 +468,13 @@ class CTranspiler { output selectorMap closureFunctions
         { globals isEmpty }
             whileFalse: { let old = globals.
                           globals = Dictionary new.
-                          old do: { |name def|
-                                    allGlobals at: name
-                                               ifNone: { allGlobals put: def at: name.
+                          old do: { |global def|
+                                    allGlobals at: global
+                                               ifNone: { allGlobals put: def at: global.
                                                          def visitBy: self } } }.
         globals = allGlobals!
 
-    method writeMain
+    method writeMain: main
         output println: "int main".
         output println: "    (int argc, char** argv)".
         output println: "\{".
@@ -439,13 +487,12 @@ class CTranspiler { output selectorMap closureFunctions
                   output print: (Name mangleDynamic: var).
                   output println: ";" }.
         output println: "    struct FooContext* ctx = foo_context_new_main(vars);".
-        let main = Name mangleGlobal: {name: "Main"}.
         output println: "    struct FooArray* array = FooArray_alloc(argc-1);".
         output println: "    for (size_t i = 0; i < array->size; i++)".
         output println: "        array->data[i] = foo_String_new_from(argv[i+1]);".
         output println: "    struct Foo args = \{ .class = &FooClass_Array, .datum = \{ .ptr = array } };".
         output println: "    struct Foo system = \{ .class = &FooClass_System, .datum = \{ .ptr = NULL } };".
-        output println: "    foo_send(ctx, &{Name mangleSelector: #run:in:}, {main}, 2, args, system);".
+        output println: "    foo_send(ctx, &{Name mangleSelector: #run:in:}, {self mangleGlobal: main}, 2, args, system);".
         output println: "    return 0;".
         output println: "}"!
 
@@ -475,8 +522,12 @@ class CTranspiler { output selectorMap closureFunctions
                                  variables: variables
                                  tmpCounter: tmpCounter
                                  globals: globals
+                                 globalsCounter: globalsCounter
+                                 recordClasses: recordClasses
                                  generatedMethods: generatedMethods
-                                 env: env.
+                                 env: env
+                                 builtins: builtins
+                                 visited: visited.
         builtinVisitor output println: "#include \"foo.h\"".
         -- FIXME: visit only referenced builtins
         self compilerBuiltins
@@ -492,9 +543,9 @@ class CTranspiler { output selectorMap closureFunctions
 
     method compilerBuiltins
         -- Filter out module definitions
-        let globals = env builtins values
+        let builtinGlobals = env builtins values
                           select: { |each| AstGlobal includes: each }.
-        (globals collect: #definition)
+        (builtinGlobals collect: #definition)
             select: { |each| CompilerBuiltin includes: each }!
 
     method generateBuiltins
@@ -508,8 +559,12 @@ class CTranspiler { output selectorMap closureFunctions
                                  variables: variables
                                  tmpCounter: tmpCounter
                                  globals: globals
+                                 globalsCounter: globalsCounter
+                                 recordClasses: recordClasses
                                  generatedMethods: generatedMethods
-                                 env: env.
+                                 env: env
+                                 builtins: builtins
+                                 visited: visited.
         builtinVisitor output println: "#include \"foo.h\"".
         -- FIXME: used builtins only
         self compilerBuiltins
@@ -530,28 +585,30 @@ class CTranspiler { output selectorMap closureFunctions
 
     method generateConstantsOn: out
         constants do: { |each| out println: each declaration }.
-        constants do: { |each| out println: each definition }.
+        constants do: { |each|
+                        out println: each definition }.
         out!
 
     method selectorCName: selector
         self selectorMap map: selector!
 
-    method constantCName: value in: env
+    method constantCName: value
         -- Tracer constantCName: value.
         (Selector includes: value)
             ifTrue: { return self selectorCName: value }.
         (Object includes: value)
             ifTrue: { constants
                           do: { |each|
+                                -- Debug println: "constantCName == {each}".
                                 value == each value
                                     ifTrue: { return each cname } } }
             ifFalse: { constants
                            do: { |each|
+                                -- Debug println: "constantCName is {each}".
                                 value is each value
                                    ifTrue: { return each cname } } }.
         ((Class includes: value) or: (Interface includes: value))
-            ifTrue: { self declare: (self _targetClassOf: value
-                                         _in: env).
+            ifTrue: { self declare: (self _astClassOf: value).
                       let cname = Name mangleClass: value.
                       constants add: { value: value,
                                        cname: cname,
@@ -564,7 +621,6 @@ class CTranspiler { output selectorMap closureFunctions
                        constants add: { value: value, cname: cname }.
                        constants at: index
                                  put: (self _constantDefinition: value
-                                            _in: env
                                             _called: cname).
                        return cname }!
 
@@ -574,10 +630,10 @@ class CTranspiler { output selectorMap closureFunctions
             ifTrue: { return False }.
         True!
 
-    method _writeDatum: value _in: env _to: out
+    method _writeDatum: value _to: out
         -- Tracer visitDatum: value.
         (self _isPtr: value)
-            ifTrue: { return out print: ".ptr = &{self constantCName: value in: env}" }.
+            ifTrue: { return out print: ".ptr = &{self constantCName: value}" }.
         (Boolean includes: value)
             ifTrue: { let bit = value ifTrue: { 1 } ifFalse: { 0 }.
                       return out print: ".boolean = {bit}" }.
@@ -589,14 +645,29 @@ class CTranspiler { output selectorMap closureFunctions
             ifTrue: { return out print: ".int64 = {value}" }.
         Error raise: "Don't know how to transpile constant `{value}` into C."!
 
-    method _targetClassOf: value _in: env
-        -- Tracer _targetClassOf: value.
+    method _astClassOf: value
         (Record includes: value)
             ifTrue: { return self _recordClassFromRecord: value }.
-        -- This seems wrong, but is needed. Why?
-        ((Class includes: value) or: (Interface includes: value))
-            ifTrue: { return env global: value name }.
-        env global: value classOf name!
+        -- KLUDGE: Dictionary is builtin on bootstrap host, so
+        -- _env classes don't know about it. Instead of this
+        -- should somehow include it it compiler builtins,
+        -- maybe with a "redefined: True" flag?
+        (Dictionary includes: value)
+            ifTrue: { return env global: "Dictionary" }.
+        -- FIXME: WTF? Why?
+        let theClass = ((Class includes: value) or: (Interface includes: value))
+                         ifTrue: { value }
+                         ifFalse: { value classOf }.
+        return env classes
+            at: theClass
+            ifNone: { builtins
+                          at: theClass
+                          ifNone: {
+                              Debug println: "looking for: {value} ({theClass})".
+                              env classes keys
+                                  do: { |each|
+                                        Debug println: "- {each} ({each is theClass})" }.
+                              panic "No AstClass for: {value} ({theClass})\nenv classes: {env classes keys}\nbuiltins: {builtins keys}" } }!
 
     method _recordClassFromRecord: aRecord
         let keys = (Record keysIn: aRecord) sorted.
@@ -607,15 +678,15 @@ class CTranspiler { output selectorMap closureFunctions
         self _ensureRecordClass: { name: name,
                                    slots: keys }!
 
-    method _writeValue: value _in: env _to: out
+    method _writeValue: value _to: out
         -- Tracer _writeValue: value.
         ((Class includes: value) or: (Interface includes: value))
-            ifTrue: { out print: "(struct Foo)\{ .class = &{Name mangleMetaclass: (self _targetClassOf: value _in: env)}, .datum = \{ " }
-            ifFalse: { out print: "(struct Foo)\{ .class = &{Name mangleClass: (self _targetClassOf: value _in: env)}, .datum = \{ " }.
-        self _writeDatum: value _in: env _to: out.
+            ifTrue: { out print: "(struct Foo)\{ .class = &{Name mangleMetaclass: (self _astClassOf: value)}, .datum = \{ " }
+            ifFalse: { out print: "(struct Foo)\{ .class = &{Name mangleClass: (self _astClassOf: value)}, .datum = \{ " }.
+        self _writeDatum: value _to: out.
         out println: " } }"!
 
-    method _constantDefinition: value _in: env _called: cname
+    method _constantDefinition: value _called: cname
         -- Tracer _constantDefinition: value.
         (Array includes: value)
             ifTrue: { return
@@ -623,7 +694,6 @@ class CTranspiler { output selectorMap closureFunctions
                             cname: cname,
                             declaration: "struct FooArray {cname};",
                             definition: (self _arrayDefinition: value
-                                              _in: env
                                               _called: cname) } }.
         (Record includes: value)
             ifTrue: { return
@@ -631,7 +701,6 @@ class CTranspiler { output selectorMap closureFunctions
                             cname: cname,
                             declaration: "struct FooArray {cname};",
                             definition: (self _recordDefinition: value
-                                              _in: env
                                               _called: cname) } }.
         (String includes: value)
             ifTrue: { return
@@ -644,10 +713,9 @@ class CTranspiler { output selectorMap closureFunctions
           cname: cname,
           declaration: "struct FooArray {cname};",
           definition: (self _instanceDefinition: value
-                            _in: env
                             _called: cname) }!
 
-    method _arrayDefinition: value _in: env _called: cname
+    method _arrayDefinition: value _called: cname
         StringOutput
             with: { |out|
                     out println: "struct FooArray {cname} =".
@@ -657,16 +725,14 @@ class CTranspiler { output selectorMap closureFunctions
                     out print: "    .data = \{ ".
                     value do: { |each|
                                 self _writeValue: each
-                                     _in: env
                                      _to: out.
                                 out print: "," }.
                     out println: " }".
                     out println: "};" }!
 
-    method _instanceDefinition: value _in: env _called: cname
-        -- Tracer _instanceDefinition: value _in: env.
-        -- Debug println: "XXX: {value} IN:\n {env globals}".
-        let theClass = self _targetClassOf: value _in: env.
+    method _instanceDefinition: value _called: cname
+        -- Tracer _instanceDefinition: value _called: cname
+        let theClass = self _astClassOf: value.
         self declare: theClass.
         let slots = theClass definition slots.
         StringOutput
@@ -680,13 +746,12 @@ class CTranspiler { output selectorMap closureFunctions
                         do: { |each|
                               self _writeValue: ((Selector intern: each name)
                                                      sendTo: value)
-                                   _in: env
                                    _to: out.
                               out print: "," }.
                     out println: " }".
                     out println: "};" }!
 
-    method _recordDefinition: value _in: env _called: cname
+    method _recordDefinition: value _called: cname
         StringOutput
             with: { |out|
                     out println: "struct FooArray {cname} =".
@@ -695,7 +760,8 @@ class CTranspiler { output selectorMap closureFunctions
                     out println: "    .size = {Record sizeOf: value},".
                     out print: "    .data = \{ ".
                     value do: { |each|
-                                self _writeValue: each _in: env _to: out.
+                                self _writeValue: each
+                                     _to: out.
                                 out print: "," }.
                     out println: " }".
                     out println: "};" }!
@@ -757,8 +823,12 @@ class CTranspiler { output selectorMap closureFunctions
                                variables: variables
                                tmpCounter: tmpCounter
                                globals: globals
+                               globalsCounter: globalsCounter
+                               recordClasses: recordClasses
                                generatedMethods: generatedMethods
-                               env: env.
+                               env: env
+                               builtins: builtins
+                               visited: visited.
         closureVisitor _generateTypecheck: closure returnType
                      _for: closure body.
         output println: ";\n}".
@@ -772,28 +842,36 @@ class CTranspiler { output selectorMap closureFunctions
         self!
 
     method visitDefine: aDefine
+        (visited has: aDefine)
+            ifTrue: { return False }.
+        visited put: True at: aDefine.
         Tracer visitDefine: aDefine.
         aDefine isDynamic
             ifTrue: { output println: "struct Foo {Name mangleDynamic: aDefine} = " }
-            ifFalse: { output println: "struct Foo {Name mangleGlobal: aDefine} = " }.
-        -- FIXME: harmonize #eval vs #value
-        self _writeValue: aDefine eval _in: aDefine env _to: output.
+            ifFalse: { output println: "struct Foo {self mangleGlobal: aDefine} = " }.
+        Debug println: "eval define: {aDefine}".
+        self _writeValue: aDefine eval _to: output.
         output println: ";".
         output newline!
 
     method _ensureRecordClass: aRecord
-        globals at: aRecord name name -- Selector don't play nice in tables yet!
-                ifNonePut: { self _createRecordClass: aRecord }!
+        let aRecordClass = recordClasses
+            at: aRecord name name -- Selector don't play nice in bootstrap host dictionary!
+            ifNonePut: { self _createRecordClass: aRecord }.
+        globals at: aRecordClass
+                ifNonePut: { aRecordClass }!
 
     method _createRecordClass: aRecord
+        let name = String concat: ["Record_", aRecord name name replace: ":" with: "$"].
         let theClass = AstClass
-                           name: (String concat: ["Record_", aRecord name name replace: ":" with: "$"])
+                           name: name
                            slots: (aRecord slots
                                        collectWithIndex: { |each index|
                                                            AstSlot name: each
                                                                    index: index
                                                                    type: Any })
-                           interfaces: [env global: "Record"].
+                           interfaces: [env global: "Record"]
+                           env: env.
         theClass directMethods: [].
         theClass instanceMethods: [].
         theClass!
@@ -806,7 +884,7 @@ class CTranspiler { output selectorMap closureFunctions
                        collect: { |each| self _visitTemp: each }.
         output print: "foo_send(ctx".
         output print: ", &{Name mangleSelector: aRecord name}".
-        output print: ", {Name mangleGlobal: recordClass}".
+        output print: ", {self mangleGlobal: recordClass}".
         output print: ", ".
         output print: args size.
         args
@@ -831,6 +909,7 @@ class CTranspiler { output selectorMap closureFunctions
         output print: "ctx->frame[{dict}]; })"!
 
     method _generateLayout: aClass
+        -- Tracer _generateLayout: aClass.
         aClass isBuiltin
             ifTrue: { return "NULL" }. -- FIXME: proper builtin layouts
         -- FIXME: Since user doesn't have access to these layouts,
@@ -868,25 +947,26 @@ class CTranspiler { output selectorMap closureFunctions
         inheritance!
 
     method visitInterfaceDefinition: anInterface
+        (visited has: anInterface)
+            ifTrue: { return False }.
+        visited put: True at: anInterface.
         Tracer visitInterfaceDefinition: anInterface name.
-        -- Debug println: "interface: {anInterface name}".
         output println: "/**
 * {anInterface name} (an interface)
 *
 */".
         let metaclassName = Name mangleMetaclass: anInterface.
         let className = Name mangleClass: anInterface.
-        let globalName = Name mangleGlobal: anInterface.
-        -- Augmented with #includes:
+        let globalName = self mangleGlobal: anInterface.
+        -- Augmented with #includes: and #name
         let directMethods = (anInterface directMethods reject: #isRequired) asList.
         directMethods
-            do: { |each| self _writeMethod: each _for: anInterface name }.
-        -- FIXME: Currently Any has it's own definition
-        (directMethods find: { |each| each selector == #includes: }) is False
-            ifTrue: { directMethods add: (self _generateClassIncludes: anInterface) }.
+            do: { |each| self _writeMethod: each _for: anInterface }.
+        self _generateDefaultDirectMethodsFor: anInterface
+            _in: directMethods.
         let instanceMethods = anInterface instanceMethods reject: #isRequired.
         instanceMethods
-            do: { |each| self _writeMethod: each _for: anInterface name }.
+            do: { |each| self _writeMethod: each _for: anInterface }.
         -- Interface metaclass
         -- FIXME: name says 'Foo interface', should be 'Foo class'!
         let metaclassInheritance
@@ -897,7 +977,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "struct FooClass {metaclassName} = ".
         output println: "\{".
         output println: "    .header = \{ .allocation = STATIC },".
-        output println: "    .name = &{self constantCName: metaclassNameString in: env}, // {metaclassNameString}".
+        output println: "    .name = &{self constantCName: metaclassNameString}, // {metaclassNameString}".
         output println: "    .metaclass = &FooClass_Class,".
         output println: "    .inherited = &{metaclassInheritance},".
         output println: "    .layout = &TheClassLayout,".
@@ -920,7 +1000,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "struct FooClass {className} = ".
         output println: "\{".
         output println: "    .header = \{ .allocation = STATIC },".
-        output println: "    .name = &{self constantCName: anInterface name in: env}, // {anInterface name}".
+        output println: "    .name = &{self constantCName: anInterface name}, // {anInterface name}".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = NULL,". -- FIXME
@@ -974,21 +1054,29 @@ class CTranspiler { output selectorMap closureFunctions
         output newline.
         ctor!
 
-    method _generateClassIncludes: aClass
+    method _generateDefaultDirectMethodsFor: aClass _in: table
+        (table find: { |each| each selector == #includes: }) is False
+            ifTrue: { table add: (self _generateDirectMethod_includes: aClass) }.
+        (table find: { |each| each selector == #classOf: }) is False
+            ifTrue: { table add: (self _generateDirectMethod_classOf: aClass) }.
+        (table find: { |each| each selector == #name }) is False
+            ifTrue: { table add: (self _generateDirectMethod_name: aClass) }!
+
+    method _generateDirectMethod_includes: aClass
         { selector: #includes:,
           arity: 1,
           frameSize: 1,
           methodHomeName: (Name mangleMetaclass: aClass),
           methodFunctionName: "foo_method_includes_" }!
 
-    method _generateClassName: aClass
+    method _generateDirectMethod_name: aClass
         { selector: #name,
           arity: 0,
           frameSize: 0,
           methodHomeName: (Name mangleMetaclass: aClass),
           methodFunctionName: "foo_method_name" }!
 
-    method _generateClassClassOf: aClass
+    method _generateDirectMethod_classOf: aClass
         { selector: #classOf,
           arity: 0,
           frameSize: 0,
@@ -1003,35 +1091,40 @@ class CTranspiler { output selectorMap closureFunctions
           methodFunctionName: "foo_method_classOf" }!
 
     method visitClassDefinition: aClass
+        (visited has: aClass)
+            ifTrue: { return False }.
+        visited put: True at: aClass.
         Tracer visitClassDefinition: aClass name.
-        -- Debug println: "class: {aClass name}".
         let classNote = aClass isBuiltin
                        ifTrue: { "{aClass name} (builtin)" }
                        ifFalse: { aClass name }.
         output println: "/**
- * {classNote}
+ * {aClass name}
  *
  */".
         let isTheClass = aClass isBuiltin and: aClass name == "Class".
         let className = Name mangleClass: aClass.
         let metaclassName = Name mangleMetaclass: aClass.
-        let globalName = Name mangleGlobal: aClass.
+        let globalName = self mangleGlobal: aClass.
         -- Augmented later with: constructor (aka ctor), #includes:, and #name
         let directMethods = aClass directMethods asList.
+        -- Debug println: "{aClass name} direct methods:".
+        -- directMethods do: { |each| Debug println: "- {each selector}" }.
         directMethods
-            do: { |each| self _writeMethod: each _for: aClass name }.
+            do: { |each| self _writeMethod: each _for: aClass }.
         -- Augmented later with #classOf.
         let instanceMethods = aClass instanceMethods asList.
+        -- Debug println: "{aClass name} methods:".
+        -- instanceMethods do: { |each| Debug println: "- {each selector}" }.
         instanceMethods
-            do: { |each| self _writeMethod: each _for: aClass name }.
+            do: { |each| self _writeMethod: each _for: aClass }.
         aClass isBuiltin
             ifFalse: { directMethods add: (self _generateClassConstructor: aClass) }.
         let classMethods = isTheClass
                                ifTrue: { instanceMethods }
                                ifFalse:{ directMethods }.
-        classMethods add: (self _generateClassIncludes: aClass).
-        classMethods add: (self _generateClassClassOf: aClass).
-        classMethods add: (self _generateClassName: aClass).
+        self _generateDefaultDirectMethodsFor: aClass
+            _in: classMethods.
         instanceMethods add: (self _generateInstanceClassOf: aClass).
         isTheClass
             ifFalse: { -- Class metaclass, not needed for Class which
@@ -1042,7 +1135,7 @@ class CTranspiler { output selectorMap closureFunctions
                        output println: "struct FooClass {metaclassName} = ".
                        output println: "\{".
                        output println: "    .header = \{ .allocation = STATIC },".
-                       output println: "    .name = &{self constantCName: metaclassNameString in: env}, // {metaclassNameString}".
+                       output println: "    .name = &{self constantCName: metaclassNameString}, // {metaclassNameString}".
                        output println: "    .metaclass = &FooClass_Class,".
                        output println: "    .inherited = &{metaclassInheritance},".
                        output println: "    .layout = &TheClassLayout,".
@@ -1069,7 +1162,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "struct FooClass {className} = ".
         output println: "\{".
         output println: "    .header = \{ .allocation = STATIC },".
-        output println: "    .name = &{self constantCName: aClass name in: env}, // {aClass name}".
+        output println: "    .name = &{self constantCName: aClass name}, // {aClass name}".
         output println: "    .metaclass = &{metaclassName},".
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = {layout},".
@@ -1100,21 +1193,21 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .class = &{metaclassName},".
         output println: "    .datum = \{ .ptr = &{className} }".
         output println: "};".
-        output newline!
+        output newline.
+        True!
 
-    method _writeMethod: aMethod _for: type
+    method _writeMethod: aMethod _for: aClass
         -- Tracer _writeMethod: aMethod _for: type.
-        -- Debug println: "_writeMethod: {aMethod}".
         let name = Name mangleMethod: aMethod.
         generatedMethods
             at: name
-            ifNonePut: { self _actuallyGenerateMethod: aMethod _as: name _for: type }!
+            ifNonePut: { self _actuallyGenerateMethod: aMethod _as: name _for: aClass }!
 
-    method _actuallyGenerateMethod: aMethod _as: name _for: type
+    method _actuallyGenerateMethod: aMethod _as: name _for: aClass
         -- Tracer _actuallyGenerateMethod: aMethod _as: name _for: type.
         -- Debug println: "_actuallyGenerateMethod: {aMethod}".
         aMethod isRequired
-            ifTrue: { Error raise: "Cannot generate required method: {aMethod} for: {type}." }.
+            ifTrue: { Error raise: "Cannot generate required method: {aMethod} for: {aClass}." }.
         let $home = aMethod.
         output print: "struct Foo ".
         output println: name.
@@ -1156,9 +1249,9 @@ class CTranspiler { output selectorMap closureFunctions
         output print: ")"!
 
     method visitGlobal: aVar
-        -- Tracer visitGlobal: aVar name.
+        -- Tracer visitGlobal: aVar.
         self declare: aVar.
-        output print: (Name mangleGlobal: aVar)!
+        output print: (self mangleGlobal: aVar)!
 
     method visitDynamic: aVar
         -- Tracer trace: #visitDynamic:.
@@ -1210,7 +1303,7 @@ class CTranspiler { output selectorMap closureFunctions
 
     method visitConstant: aConstant
         -- Tracer visitConstant: aConstant.
-        self _writeValue: aConstant value _in: aConstant env _to: output!
+        self _writeValue: aConstant value _to: output!
 
     method visitSend: aSend
         -- Tracer visitSend: aSend selector.

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -849,7 +849,6 @@ class CTranspiler { output selectorMap closureFunctions
         aDefine isDynamic
             ifTrue: { output println: "struct Foo {Name mangleDynamic: aDefine} = " }
             ifFalse: { output println: "struct Foo {self mangleGlobal: aDefine} = " }.
-        Debug println: "eval define: {aDefine}".
         self _writeValue: aDefine eval _to: output.
         output println: ";".
         output newline!

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -176,7 +176,12 @@ class Environment { parent
     direct method modules: modules
         self
             builtins: BuiltinDictionary new
-            modules: (ModuleDictionary new: modules)
+            modules: (ModuleDictionary new: modules)!
+
+    direct method builtins: builtins modules: modules
+        self
+            builtins: builtins
+            modules: modules
             classes: Dictionary new!
 
     direct method builtins: builtins modules: modules classes: classes

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -21,10 +21,10 @@ class BuiltinDictionary { dictionary }
 
     method _define: builtin
         let name = builtin name.
-        let global = AstGlobal
-                         name: name
-                         definition: (AstBuiltin value: builtin).
-        global value. -- finalize
+        let global = AstGlobal name: name.
+        global define: (AstBuiltin
+                            global: global
+                            value: builtin).
         dictionary
             put: global
             at: name!
@@ -44,6 +44,7 @@ class BuiltinDictionary { dictionary }
         self _define: List.
         self _define: Object.
         self _define: Output.
+        self _define: Record.
         self _define: Selector.
         self _define: String.
         self _define: StringOutput.
@@ -116,7 +117,8 @@ class ModuleDictionary { available translated }
         let $CurrentModulePath = path.
         { (Environment
                builtins: env builtins
-               modules: self)
+               modules: self
+               classes: env classes)
           load: source }
             on: Error
             do: { |e|
@@ -149,8 +151,18 @@ class Environment { parent
                     depth
                     globals
                     builtins
-                    modules }
+                    modules
+                    classes }
     is Object
+
+    method describe
+        Debug println: "---".
+        Debug println: "bindings = {bindings}".
+        Debug println: "globals = {globals}".
+        Debug println: "modules = {modules}".
+        Debug println: "depth = {depth}".
+        parent is False
+            ifFalse: { parent describe }!
 
     direct method new
         self
@@ -164,9 +176,10 @@ class Environment { parent
     direct method modules: modules
         self
             builtins: BuiltinDictionary new
-            modules: (ModuleDictionary new: modules)!
+            modules: (ModuleDictionary new: modules)
+            classes: Dictionary new!
 
-    direct method builtins: builtins modules: modules
+    direct method builtins: builtins modules: modules classes: classes
         Environment
             parent: False
             bindings: []
@@ -174,7 +187,8 @@ class Environment { parent
             depth: 1
             globals: Dictionary new
             builtins: builtins
-            modules: modules!
+            modules: modules
+            classes: classes!
 
     method addGlobals: bindings
         self checkToplevel.
@@ -193,7 +207,8 @@ class Environment { parent
             depth: depth + 1
             globals: globals
             builtins: builtins
-            modules: modules!
+            modules: modules
+            classes: classes!
 
     method augment: bindings
         Environment
@@ -203,16 +218,22 @@ class Environment { parent
             depth: depth
             globals: globals
             builtins: builtins
-            modules: modules!
+            modules: modules
+            classes: classes!
 
     method removeBuiltins: names
         builtins removeAll: names!
+
+    method makeGlobal: name
+        (name startsWith: "$")
+            ifTrue: { AstDynamic name: name }
+            ifFalse: { AstGlobal name: name }!
 
     method replaceBuiltins: newBuiltins
         newBuiltins do: { |each|
                           let global = builtins
                                            at: each name
-                                           ifNonePut: { AstGlobal name: each name }.
+                                           ifNonePut: { self makeGlobal: each name }.
                           global redefine: each }!
 
     method import: moduleName relative: relative
@@ -346,6 +367,9 @@ class Environment { parent
     method checkGlobals
         globals doValues: #warnIfUndefined!
 
+    method builtin: name
+        builtins at: name!
+
     method global: name
         -- Debug println: "Environment#global: {name}".
         -- Debug println: "has builtins:\n{builtins}".
@@ -354,23 +378,8 @@ class Environment { parent
             at: name
             ifNone: { globals
                           at: name
-                          ifNonePut: { AstGlobal name: name } }!
-
-    method dynamic: name
-        -- Debug println: "Environment#dynamic: {name}".
-        globals
-            at: name
-            ifNonePut: { AstDynamic name: name }!
-
-    method define: name as: definition
-        -- Debug println: "Environment#define:as: {name}".
-        (builtins has: name)
-            ifTrue: { Error raise: "Cannot redefine a builtin: {name}" }.
-        let global = globals
-                         at: name
-                         ifNonePut: { definition allocGlobal }.
-        let res = global define: definition.
-        -- Debug println: "--".
-        res!
-
+                          ifNonePut: { name == "AstValueMarker"
+                                           ifTrue: { Debug println: "XXX: AstValueMarker ({Foolang isSelfHosted})".
+                                                     self describe }.
+                                       self makeGlobal: name } }!
 end

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -75,7 +75,10 @@ class TokenString { string first last }
         whileTrue: { next = self _scanCharFrom: next into: literal }.
 
         from is next
-            ifFalse: { parts add: (SyntaxLiteral value: literal content) }.
+            ifFalse: { parts
+                           add: (SyntaxLiteral
+                                     value: literal content
+                                     source: False) }.
         next!
 
     method _interpolatedFrom: next into: parts
@@ -91,7 +94,9 @@ class TokenString { string first last }
     method parseAsPrefixWith: parser atPrecedence: _precedence
         -- Debug println: "parse string: '{string}'".
         string size is 2 -- just ""
-            ifTrue: { return SyntaxLiteral value: "" }.
+            ifTrue: { return SyntaxLiteral
+                          value: ""
+                          source: (parser sourceFrom: first to: last)}.
         let parts = List new.
         let next = 2.
         { next < string size }
@@ -109,7 +114,8 @@ class TokenFloat { string first last }
     method parseAsPrefixWith: parser atPrecedence: _precedence
         SyntaxFloatLiteral
             string: string
-            value: (Float parse: string)!
+            value: (Float parse: string)
+            source: (parser sourceFrom: first to: last)!
 end
 
 class TokenDecimalInteger { string first last }
@@ -122,7 +128,9 @@ class TokenDecimalInteger { string first last }
         1 to: string size
           do: { |pos|
                 n = n * 10 + (string at: pos) digit }.
-        SyntaxLiteral value: n!
+        SyntaxLiteral
+            value: n
+            source: (parser sourceFrom: first to: last)!
 end
 
 class TokenHexInteger { string first last }
@@ -136,7 +144,10 @@ class TokenHexInteger { string first last }
           do: { |pos|
                 n = n * 16 + ((string at: pos) digit: 16) }.
         -- Want to retain the format info, hence not SyntaxLiteral.
-        SyntaxHexLiteral string: string value: n!
+        SyntaxHexLiteral
+            string: string
+            value: n
+            source: (parser sourceFrom: first to: last)!
 end
 
 class TokenBinaryInteger { string first last }
@@ -150,7 +161,10 @@ class TokenBinaryInteger { string first last }
           do: { |pos|
                 n = n * 2 + ((string at: pos) digit: 2) }.
         -- Want to retain the format info, hence not SyntaxLiteral.
-        SyntaxBinaryLiteral string: string value: n!
+        SyntaxBinaryLiteral
+            string: string
+            value: n
+            source: (parser sourceFrom: first to: last)!
 end
 
 class TokenEof { position }
@@ -618,12 +632,15 @@ interface MethodToken
     method _parseMethodSignatureWith: parser
         let selector = StringOutput new.
         let parameters = List new.
-        let returnType = parser nextToken
-            parseAsMethodSignatureWith: parser
-            selector: selector
-            parameters: parameters.
+        let returnType
+            = parser nextToken
+                parseAsMethodSignatureWith: parser
+                selector: selector
+                parameters: parameters.
         MethodSignature
-            selector: (SyntaxSelector name: selector content)
+            selector: (SyntaxSelector
+                           name: selector content
+                           source: False)
             parameters: parameters
             returnType: returnType!
 end
@@ -842,17 +859,23 @@ class TokenSigil { precedence string first last }
         UnknownOperatorPrecedence!
 
     method parseAsPrefixWith: parser atPrecedence: _precedence
+        let source = parser sourceFrom: first to: last.
         SyntaxPrefix
             receiver: (parser parseAtPrecedence: MaxPrecedence)
-            selector: (SyntaxSelector name: string)
-            source: (parser sourceFrom: first to: last)!
+            selector: (SyntaxSelector
+                           name: string
+                           source: source)
+            source: source!
 
     method parseAsSuffixOf: prefix with: parser
+        let source = parser sourceFrom: first to: last.
         SyntaxBinary
             receiver: prefix
-            selector: (SyntaxSelector name: string)
+            selector: (SyntaxSelector
+                           name: string
+                           source: source)
             argument: (parser parseAtPrecedence: precedence)
-            source: (parser sourceFrom: first to: last)!
+            source: source!
 
     method parseAsMethodSignatureWith: parser selector: selector parameters: parameters
         -- Debug println: "TokenSigil#parseAsMethodSignatureWith:selector:parameters:".
@@ -864,7 +887,9 @@ class TokenSigil { precedence string first last }
         Any!
 
     method parseAsLiteralWith: parser
-        SyntaxSelector name: string!
+        SyntaxSelector
+            name: string
+            source: (parser sourceFrom: first to: last)!
 
 end
 
@@ -902,10 +927,13 @@ class TokenWord { precedence string first last }
             source: (parser sourceFrom: first to: last)!
 
     method parseAsSuffixOf: prefix with: parser
+        let source = parser sourceFrom: first to: last.
         SyntaxUnary
             receiver: prefix
-            selector: (SyntaxSelector name: string)
-            source: (parser sourceFrom: first to: last)!
+            selector: (SyntaxSelector
+                           name: string
+                           source: source)
+            source: source!
 
     method parseAsMethodSignatureWith: parser selector: selector parameters: parameters
         -- Debug println: "TokenWord#parseAsMethodSignatureWith:selector:parameters:".
@@ -921,7 +949,9 @@ class TokenWord { precedence string first last }
         Any!
 
     method parseAsLiteralWith: parser
-        SyntaxSelector name: string!
+        SyntaxSelector
+            name: string
+            source: (parser sourceFrom: first to: last)!
 end
 
 class TokenKeyword { string first last }
@@ -945,11 +975,14 @@ class TokenKeyword { string first last }
                         selector print: token string.
                         True } }
         whileTrue.
+        let source = parser sourceFrom: first to: last.
         SyntaxKeyword
             receiver: prefix
-            selector: (SyntaxSelector name: selector content)
+            selector: (SyntaxSelector
+                           name: selector content
+                           source: source)
             arguments: arguments
-            source: (parser sourceFrom: first to: last)!
+            source: source!
 
     method parseAsMethodSignatureWith: parser selector: selector parameters: parameters
         -- Debug println: "TokenKeyord#parseAsMethodSignatureWith:selector:parameters:".
@@ -969,7 +1002,9 @@ class TokenKeyword { string first last }
         let selector = StringOutput new: string.
         { TokenKeyword includes: parser lookahead }
             whileTrue: { selector print: parser nextToken string }.
-        SyntaxSelector name: selector content!
+        SyntaxSelector
+            name: selector content
+            source: (parser sourceFrom: first to: last)!
 end
 
 define SpecialCharacters

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -88,6 +88,10 @@ end
 class SyntaxLiteral { value source }
     is Literal
 
+    direct method value: value
+        self value: value
+             source: False!
+
     method valueDisplayString
         value displayString!
 end

--- a/foo/impl/syntax.foo
+++ b/foo/impl/syntax.foo
@@ -60,17 +60,7 @@ interface Syntax
         10!
 
     method displayOn: stream
-        stream print: "#<{self classOf name} ".
-        { SyntaxPrinter print: self to: stream }
-            on: Error
-            do: { |e|
-                  { stream print: "<error printing: {e description}>>".
-                    return self }
-                      on: Error
-                      do: { |e|
-                            stream print: "<error printing>>".
-                            return self } }.
-        stream print: ">"!
+        stream print: "#<{self classOf name} {self descriptor}>"!
 end
 
 interface Literal
@@ -88,18 +78,21 @@ interface Literal
     method weight
         0!
 
+    method descriptor
+        self valueDisplayString!
+
     method parts
         [self value]!
 end
 
-class SyntaxLiteral { value }
+class SyntaxLiteral { value source }
     is Literal
 
     method valueDisplayString
         value displayString!
 end
 
-class SyntaxFloatLiteral { string value }
+class SyntaxFloatLiteral { string value source }
     is Literal
 
     method valueDisplayString
@@ -107,14 +100,14 @@ class SyntaxFloatLiteral { string value }
 end
 
 
-class SyntaxHexLiteral { string value }
+class SyntaxHexLiteral { string value source }
     is Literal
 
     method valueDisplayString
         string!
 end
 
-class SyntaxBinaryLiteral { string value }
+class SyntaxBinaryLiteral { string value source }
     is Literal
 
     method valueDisplayString
@@ -134,6 +127,9 @@ class SyntaxStringInterpolation { parts }
 
     method visitBy: visitor
         visitor visitStringInterpolation: self!
+
+    method descriptor
+        parts size!
 end
 
 class SyntaxValueTypeDeclaration { value type }
@@ -147,6 +143,9 @@ class SyntaxValueTypeDeclaration { value type }
 
     method parts
         [value, type]!
+
+    method descriptor
+        "{value descriptor} :: {type name}"!
 end
 
 interface SyntaxCollection
@@ -154,6 +153,9 @@ interface SyntaxCollection
 
     method parts
         self entries!
+
+    method descriptor
+        self size!
 end
 
 class SyntaxArray { entries }
@@ -201,6 +203,9 @@ class SyntaxSeq { first then }
 
     method parts
         [first, then]!
+
+    method descriptor
+        "{first descriptor}..."!
 end
 
 class SyntaxReturn { value }
@@ -214,9 +219,12 @@ class SyntaxReturn { value }
 
     method parts
         [value]!
+
+    method descriptor
+        value descriptor!
 end
 
-class SyntaxSelector { name }
+class SyntaxSelector { name source }
     is Syntax
 
     method visitBy: visitor
@@ -230,6 +238,9 @@ class SyntaxSelector { name }
 
     method parts
         [name]!
+
+    method descriptor
+        name!
 end
 
 class SyntaxPanic { value }
@@ -243,6 +254,9 @@ class SyntaxPanic { value }
 
     method parts
         [value]!
+
+    method descriptor
+        value descriptor!
 end
 
 class SyntaxPrefixComment { comment value source fence }
@@ -267,6 +281,9 @@ class SyntaxPrefixComment { comment value source fence }
 
     method displayString
         "#<SyntaxPrefixComment value: {value}>"!
+
+    method descriptor
+        value descriptor!
 end
 
 class SyntaxSuffixComment { comments value source }
@@ -354,6 +371,8 @@ class SyntaxUnary { receiver selector source }
         -- Source left out intentionally, since it doesn't need to compere equal.
         [receiver, selector]!
 
+    method descriptor
+        "{receiver descriptor} {selector name}"!
 end
 
 class SyntaxBinary { receiver selector argument source }
@@ -368,6 +387,9 @@ class SyntaxBinary { receiver selector argument source }
     method parts
         -- Source left out intentionally, since it doesn't need to compere equal.
         [receiver, selector, argument]!
+
+    method descriptor
+        "{receiver descriptor} + {argument descriptor}"!
 end
 
 -- FIXME: Currently multi-keyword syntax gets as source the first
@@ -388,6 +410,9 @@ class SyntaxKeyword { receiver selector arguments source }
 
     method displayOn: stream
         stream print: "#<{Self} {selector}>"!
+
+    method descriptor
+        "{receiver descriptor} {selector name}"!
 end
 
 class SyntaxImport { name module relative source }
@@ -425,6 +450,9 @@ class SyntaxExternalRef { module name source }
     method parts
         -- Source ignored, since that can change with pretty-printing.
         [module, name]!
+
+    method descriptor
+        "{module}.{name}"!
 end
 
 class SyntaxIs { left right }
@@ -463,6 +491,9 @@ class SyntaxSelfInstance {}
 
     method parts
         []!
+
+    method descriptor
+        "self"!
 end
 
 class SyntaxSelfClass {}
@@ -476,6 +507,9 @@ class SyntaxSelfClass {}
 
     method parts
         []!
+
+    method descriptor
+        "Self"!
 end
 
 class SyntaxVariable { name::String source }
@@ -496,6 +530,9 @@ class SyntaxVariable { name::String source }
     method parts
         -- Source ignored, since that can change with pretty-printing.
         [name]!
+
+    method descriptor
+        name!
 end
 
 -- FIXME: missing source, could probably unify with SyntaxVariable
@@ -514,6 +551,9 @@ class SyntaxTypedVariable { name type }
 
     method parts
         [name]!
+
+    method descriptor
+        "{name} :: {type name}"!
 end
 
 class SyntaxDynamicVariable { name::String source }
@@ -534,6 +574,9 @@ class SyntaxDynamicVariable { name::String source }
     method parts
         -- Source ignored, since that can change with pretty-printing.
         [name]!
+
+    method descriptor
+        "{name}"!
 end
 
 class SyntaxAssign { variable value }
@@ -547,6 +590,9 @@ class SyntaxAssign { variable value }
 
     method parts
         [variable, value]!
+
+    method descriptor
+        "{variable name} = {value descriptor}"!
 end
 
 class SyntaxParens { body }
@@ -560,6 +606,9 @@ class SyntaxParens { body }
 
     method parts
         [body]!
+
+    method descriptor
+        "({body descriptor})"!
 end
 
 class SyntaxBlock { parameters returnType body }
@@ -573,6 +622,20 @@ class SyntaxBlock { parameters returnType body }
 
     method parts
         [parameters, returnType, body]!
+
+    method descriptor
+        StringOutput
+            with: { |output|
+                    output print: "\{ ".
+                    parameters
+                        ifNotEmpty: { output print: "|".
+                                      parameters
+                                          do: { |each|
+                                                output print: each name }
+                                          interleaving: { output print: " " }.
+                                      output print: "| " }.
+                    output print: body descriptor.
+                    output print: " }" }!
 end
 
 class SyntaxDefine { variable body }
@@ -583,6 +646,9 @@ class SyntaxDefine { variable body }
 
     method parts
         [variable, body]!
+
+    method descriptor
+        variable name!
 end
 
 class SyntaxClass { name superclass slots interfaces directMethods instanceMethods }
@@ -614,6 +680,9 @@ class SyntaxClass { name superclass slots interfaces directMethods instanceMetho
 
     method parts
         [name, superclass, slots, interfaces, directMethods, instanceMethods]!
+
+    method descriptor
+        name!
 end
 
 class SyntaxInterface { name interfaces directMethods instanceMethods }
@@ -634,6 +703,9 @@ class SyntaxInterface { name interfaces directMethods instanceMethods }
 
     method parts
         [name, interfaces, directMethods, instanceMethods]!
+
+    method descriptor
+        name!
 end
 
 class SyntaxExtend { name interfaces directMethods instanceMethods }
@@ -654,6 +726,9 @@ class SyntaxExtend { name interfaces directMethods instanceMethods }
 
     method parts
         [name, interfaces, directMethods, instanceMethods]!
+
+    method descriptor
+        name!
 end
 
 interface DefinitionPart
@@ -714,6 +789,9 @@ interface SyntaxMethod
 
     method parts
         [self signature, self body]!
+
+    method descriptor
+        self selector name!
 end
 
 class SyntaxInstanceMethod { comments signature body }
@@ -724,7 +802,6 @@ class SyntaxInstanceMethod { comments signature body }
 
     method comment: aSpec
         comments add: aSpec!
-
 end
 
 class SyntaxDirectMethod { comments signature body }

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -33,12 +33,15 @@ class SyntaxTranslator { env currentMethod }
         self child: (env addVariable: name type: type)!
 
     method visitSelector: aSelector
-        AstConstantRef value: (Selector intern: aSelector name)
-                       env: env!
+        AstConstantRef
+            value: (Selector intern: aSelector name)
+            source: aSelector source!
 
     method visitLiteral: aLiteral
         -- Tracer trace: #visitLiteral:.
-        AstConstantRef value: aLiteral value env: env!
+        AstConstantRef
+            value: aLiteral value
+            source: aLiteral source!
 
     method visitStringInterpolation: anInterpolation
         let parts
@@ -191,8 +194,8 @@ class SyntaxTranslator { env currentMethod }
             withSource: aVariable source!
 
     method visitDynamicVariable: aVariable
-        -- Tracer trace: #visitDynamicVariable:.
-        (env dynamic: aVariable name)
+        -- Tracer visitDynamicVariable: aVariable.
+        (env global: aVariable name)
             withSource: aVariable source!
                 
     method visitInterfaceRef: aRef
@@ -200,7 +203,7 @@ class SyntaxTranslator { env currentMethod }
         aRef name visitBy: self!
 
     method visitAssign: anAssign
-        Tracer visitAssign: anAssign.
+        -- Tracer visitAssign: anAssign.
         (anAssign variable visitBy: self)
             assign: (anAssign value visitBy: self)!
 
@@ -223,13 +226,14 @@ class SyntaxTranslator { env currentMethod }
             frameSize: bodyEnv frame size!
 
     method visitDefine: aDefine
-        Tracer visitDefine: aDefine variable name.
+        Tracer visitDefine: aDefine.
+        let name = aDefine variable name.
         let bodyVisitor = self child: env newFrame.
         AstDefine
-            name: aDefine variable name
+            name: name
             body: (aDefine body visitBy: bodyVisitor)
             frameSize: bodyVisitor env frame size
-            isDynamic: aDefine variable isDynamic!
+            env: env!
 
     method visitImport: anImport
         AstImport syntax: anImport!
@@ -279,7 +283,7 @@ class SyntaxTranslator { env currentMethod }
             ifFalse: { self _visitSubClass: aClass }!
 
     method _visitNewClass: aClass
-        Tracer _visitNewClass: aClass name.
+        -- Tracer _visitNewClass: aClass.
         let n = 0.
         let slots = aClass slots collect: { |each::Syntax|
                                             n = n + 1.
@@ -290,7 +294,8 @@ class SyntaxTranslator { env currentMethod }
         let theClass = AstClass
                            name: aClass name
                            slots: slots
-                           interfaces: (self _visitEach: aClass interfaces).
+                           interfaces: (self _visitEach: aClass interfaces)
+                           env: env.
         let $MethodHome = theClass.
         theClass directMethods: (self _visitEach: aClass directMethods).
         let instanceMethodVisitor = self child: (env addSlots: slots).
@@ -298,30 +303,31 @@ class SyntaxTranslator { env currentMethod }
         theClass!
 
     method _visitSubClass: aClass
-        Tracer _visitSubClass: aClass name.
+        -- Tracer _visitSubClass: aClass.
         let theClass = AstClass
                            name: aClass name
                            superclass: (aClass superclass visitBy: self)
-                           interfaces: (self _visitEach: aClass interfaces).
+                           interfaces: (self _visitEach: aClass interfaces)
+                           env: env.
         let $MethodHome = theClass.
         theClass directMethods: (self _visitEach: aClass directMethods).
         let instanceMethodVisitor = self child: env.
         theClass instanceMethods: (instanceMethodVisitor _visitEach: aClass instanceMethods).
         theClass!
 
-
     method visitInterface: anInterface
-        Tracer visitInterface: anInterface name.
+        Tracer visitInterface: anInterface.
         let theInterface = AstInterface
                                name: anInterface name
-                               interfaces: (self _visitEach: anInterface interfaces).
+                               interfaces: (self _visitEach: anInterface interfaces)
+                               env: env.
         let $MethodHome = theInterface.
         theInterface directMethods: (self _visitEach: anInterface directMethods).
         theInterface instanceMethods: (self _visitEach: anInterface instanceMethods).
         theInterface!
 
     method visitExtend: anExtend
-        Tracer trace: #visitExtend:.
+        Tracer visitExtend: anExtend.
         let type = env reference: anExtend name.
         let $MethodHome = type definition.
         AstExtend

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -926,7 +926,21 @@ class TestTranspileGlobals { assert system }
                      MyValue value debug.
                      MyValue x debug!
              end"
-            expect: "#<Integer 1242>#<Integer 40>"!
+                expect: "#<Integer 1242>#<Integer 40>"!
+
+    method test0_Define_depends_on_class_defined_after
+        self transpile: "define A_Definition A_Class status: \"yes!\"!
+                         class A_Class \{ status }
+                             method ok status!
+                         end
+                         class Main \{}
+                             direct method run: command in: system
+                                 system output
+                                     writeString: (self ok: A_Definition)!
+                             direct method ok: x
+                                 x ok!
+                         end"
+            expect: "yes!"!
 
     method test_Define_global_float
         self transpile: "define MyFloat 12.34!

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1147,11 +1147,7 @@ end
                      system output print: defs!
 
              end"
-                expect: "[#<SyntaxLiteral 123>][#<SyntaxInterface interface X
-    method y
-        42!
-end
->]"!
+                expect: "[#<SyntaxLiteral 123>][#<SyntaxInterface X>]"!
 
     method test_Transpiled_SyntaxPrinter
         self transpileWithPrelude:

--- a/foo/impl/transpiler/name.foo
+++ b/foo/impl/transpiler/name.foo
@@ -83,7 +83,11 @@ class Name { out }
         out print: aVar name!
 
     method _mangleMetaclass: aClass
+        -- KLUDGE: Class is its own metaclass.
+        aClass name == "Class"
+            ifTrue: { return out print: "FooClass_Class" }.
         -- XXX: Why do I need a distinct mangling for metaclasses?
+        -- Why not just FooClass_MyClass$class?
         out print: "FooMetaclass_".
         self _mangleName: aClass name!
 

--- a/foo/impl/transpiler/name.foo
+++ b/foo/impl/transpiler/name.foo
@@ -59,9 +59,9 @@ class Name { out }
         s _mangleName: name.
         s content!
 
-    direct method mangleGlobal: aVar
+    direct method mangleGlobal: aVar id: n
         let s = self _new.
-        s _mangleGlobal: aVar.
+        s _mangleGlobal: aVar id: n.
         s content!
 
     direct method mangleDynamic: aVar
@@ -76,15 +76,16 @@ class Name { out }
         out print: "FooDynamic_".
         out print: aVar name!
 
-    method _mangleGlobal: aVar
-        out print: "FooGlobal_".
+    method _mangleGlobal: aVar id: n
+        out print: "FooGlobal".
+        out print: n.
+        out print: "_".
         out print: aVar name!
 
     method _mangleMetaclass: aClass
-        (aClass isBuiltin and: aClass name == "Class")
-            ifTrue: { out print: "FooClass_Class" }
-            ifFalse: { out print: "FooMetaclass_".
-                       self _mangleName: aClass name }!
+        -- XXX: Why do I need a distinct mangling for metaclasses?
+        out print: "FooMetaclass_".
+        self _mangleName: aClass name!
 
     method _mangleClass: aClass
         out print: "FooClass_".

--- a/foo/impl/utils.foo
+++ b/foo/impl/utils.foo
@@ -31,17 +31,24 @@ class Debug {}
         self println: message!
 end
 
+define ColonCharacter ":" character!
+
 class DebugTracer { name }
     direct method trace: thing
         Debug println: thing!
+    direct method _splitName: name
+        let parts = name toString splitBy: ColonCharacter.
+        parts size > 1
+            ifTrue: { parts = parts butlast
+                          collect: { |each| each append: ":" }}.
+        parts!
+
     direct method perform: selectorName with: arguments
-        (Selector intern: selectorName) parts
+        (DebugTracer _splitName: selectorName)
             doWithIndex: { |each index|
-                           index > 1
-                               ifTrue: { Debug print: " #" }
-                               ifFalse: { Debug print: "#" }.
-                           Debug print: each.
                            Debug print: " ".
+                           Debug print: each.
+                           Debug print: ": ".
                            Debug print: (arguments at: index) }.
         Debug newline!
     method trace: thing
@@ -49,11 +56,9 @@ class DebugTracer { name }
         Debug println: thing!
     method perform: selectorName with: arguments
         Debug print: name.
-        (Selector intern: selectorName) parts
+        (DebugTracer _splitName: selectorName)
             doWithIndex: { |each index|
-                           index > 1
-                               ifTrue: { Debug print: " #" }
-                               ifFalse: { Debug print: "#" }.
+                           Debug print: " ".
                            Debug print: each.
                            Debug print: " ".
                            Debug print: (arguments at: index) }.

--- a/src/classes/class.rs
+++ b/src/classes/class.rs
@@ -230,9 +230,8 @@ pub fn generic_class_add_instance_method_(receiver: &Object, args: &[Object], en
     Ok(receiver.clone())
 }
 
-pub fn generic_class_add_interface_(receiver: &Object, args: &[Object], env: &Env) -> Eval {
-    // We get the interface definition here, #value gives us the object.a
-    receiver.add_interface_object(&args[0].send("value", &[], env)?)?;
+pub fn generic_class_add_interface_(receiver: &Object, args: &[Object], _env: &Env) -> Eval {
+    receiver.add_interface_object(&args[0])?;
     Ok(receiver.clone())
 }
 


### PR DESCRIPTION
 - Different globals with same name in different modules
   get their own definitions: identify globals by identity,
   and number them to uniquefy their names in C code.

 - 1:1 relationship between AST definitions and globals.

 - Keep track of visited definitions to avoid revisiting them.

 - Generate direct #name and #classOf methods
   for both interfaces and classes.
