### PR TITLE
better type errors

### DIFF
--- a/foo/lang/class.foo
+++ b/foo/lang/class.foo
@@ -1,8 +1,17 @@
 import .object.Object
+import .exception.TypeError
 
 extend Class
     is Object
 
     method displayOn: stream
         stream writeString: self name!
+
+    method typecheck: value
+        -- Output debug println: "{self} typecheck: {value}".
+        (self includes: value)
+            ifTrue: { value }
+            ifFalse: { TypeError
+                           raise: value
+                           expected: self }!
 end

--- a/foo/lang/exception.foo
+++ b/foo/lang/exception.foo
@@ -241,14 +241,6 @@ extend Object
     -- Erg. This gets us a nice error, but loses the source locations I
     -- worked to get right. BLarggkashdaskjhfklajfshd.
 
-    direct method typecheck: value
-        -- Output debug println: "{Self} typecheck: {value}".
-        (Self includes: value)
-            ifTrue: { value }
-            ifFalse: { TypeError
-                           raise: value
-                           expected: Self }!
-
     method perform: selector with: arguments
         DoesNotUnderstand
             raise: selector toSelector

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -227,7 +227,10 @@ impl Error {
 
 impl MessageError {
     pub fn what(&self) -> String {
-        format!("{:?} does not understand: {} {:?}", self.receiver, self.message, self.arguments)
+        format!(
+            "{:?} does not understand: {} {:?} (bootstrap evaluator)",
+            self.receiver, self.message, self.arguments
+        )
     }
 }
 

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -240,7 +240,7 @@ impl SimpleError {
 impl TypeError {
     pub fn what(&self) -> String {
         format!(
-            "{} expected, got {}: {:?}",
+            "{} expected, got {}: {:?} (bootstrap evaluator)",
             self.expected,
             self.value.vtable.name.clone(),
             self.value,

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -323,10 +323,10 @@ fn test_does_not_understand_location() -> Test {
     cmd.arg("foo/tests/test_does_not_understand_location.foo");
     // FIXME: Error points to class
     cmd.assert().failure().code(1).stdout(predicates::str::contains(
-        "ERROR: DoesNotUnderstandError classOf does not understand: noSuchMethod []
+        "ERROR: DoesNotUnderstandError classOf does not understand: noSuchMethod [] (bootstrap evaluator)
 061     direct method oops
 062         self noSuchMethod!
-                 ^^^^^^^^^^^^ DoesNotUnderstandError classOf does not understand: noSuchMethod []
+                 ^^^^^^^^^^^^ DoesNotUnderstandError classOf does not understand: noSuchMethod [] (bootstrap evaluator)
 063 end",
     ));
     Ok(())


### PR DESCRIPTION
 - Mark bootstrap host errors as such to reduce confusion
 - Move Object class#typecheck: becomes Class#typecheck:, and
   loses the incorrect `Self` references.
