### PR TITLE
fix and cleanup Class#new:slots:interfaces:directMethods:instanceMethods:

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -429,7 +429,7 @@ class AstClass { name superclass _slots
 
     method _readerMethods
         self _methodDictionary:
-            ((self slots reject: { |each| each name startsWith: "_" })
+            ((self slots reject: #isPrivate)
                  collect: { |each|
                             AstReaderMethod home: self slot: each })!
 
@@ -475,6 +475,9 @@ class AstSlot { name index type }
 
     method referenceUpwards: offset
         AstSlotRef slot: self!
+
+    method isPrivate
+        name isPrivate!
 end
 
 class AstReaderMethod { home slot }

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -440,11 +440,7 @@ class AstClass { name superclass _slots
         { let result
               = Class
                   new: name
-                  slots: (self slots
-                              collect: { |each|
-                                         { name: each name,
-                                           type: each type } }
-                              as: Array)
+                  slots: self slots asArray
                   interfaces: self interfaceObjects
                   directMethods: self ownDirectMethods
                   instanceMethods: self ownInstanceMethods.

--- a/foo/impl/environment.foo
+++ b/foo/impl/environment.foo
@@ -263,10 +263,9 @@ class Environment { parent
         let module = (modules at: moduleName relative: relative in: self).
         let bindings = List new.
         module globals
-            doKeys: { |name|
-                      (name startsWith: "_")
-                          ifFalse: { -- Debug println: "importing: {name}".
-                                     bindings add: (module global: name) } }.
+            do: { |name global|
+                  name isPrivate
+                      ifFalse: { bindings add: global } }.
         self addGlobals: bindings!
 
     method importPrelude: moduleName
@@ -274,7 +273,7 @@ class Environment { parent
         let module = (modules at: moduleName relative: False in: self).
         module globals
             do: { |name global|
-                      (name startsWith: "_")
+                  name isPrivate
                       ifFalse: { -- Debug println: "prelude: {name}".
                                  (builtins has: name)
                                      ifTrue: { (builtins at: name)

--- a/foo/lang/class2.foo
+++ b/foo/lang/class2.foo
@@ -17,11 +17,11 @@ extend Class
                            raise: value
                            expected: self }!
 
-    direct method new: name
-                  slots: slots
-                  interfaces: interfaces
-                  directMethods: directMethods
-                  instanceMethods: instanceMethods
+    method new: name
+           slots: slots
+           interfaces: interfaces
+           directMethods: directMethods
+           instanceMethods: instanceMethods
         let layout = Layout new: (slots size).
         let metaclass = Class
                             subclass: "{name} classOf"
@@ -38,7 +38,7 @@ extend Class
                                                   layout readerMethod: each name toSelector
                                                          for: each index }))!
 
-    direct method _constructorNameForSlots: slots
+    method _constructorNameForSlots: slots
         slots
             ifEmpty: { return #new }.
         (StringOutput

--- a/foo/lang/class2.foo
+++ b/foo/lang/class2.foo
@@ -3,6 +3,19 @@ import .exception.TypeError
 import .layout_ext.*
 import .stringOutput.StringOutput
 
+class _ConstructorName {}
+    direct method forSlots: slots
+        slots
+            ifEmpty: { return #new }.
+        (StringOutput
+             with: { |out|
+                     slots
+                         do: { |each|
+                               out print: each name.
+                               out print: ":" } })
+        toSelector!
+end
+
 extend Class
     is Object
 
@@ -23,30 +36,18 @@ extend Class
            directMethods: directMethods
            instanceMethods: instanceMethods
         let layout = Layout new: (slots size).
+        let ctor = layout constructorMethod: (_ConstructorName forSlots: slots).
         let metaclass = Class
                             subclass: "{name} classOf"
                             interfaces: (interfaces collect: #classOf)
-                            methods: (directMethods
-                                          append: [layout constructorMethod: (self _constructorNameForSlots: slots)]).
+                            methods: (directMethods append: [ctor]).
+        let readers = (slots reject: { |each| each name startsWith: "_" })
+                          collect: { |each|
+                                     layout readerMethod: each name toSelector
+                                            for: each index }.
         metaclass
             new: name
             layout: layout
             interfaces: interfaces
-            methods: (instanceMethods
-                          append: ((slots reject: { |each| each name startsWith: "_" })
-                                       collect: { |each|
-                                                  layout readerMethod: each name toSelector
-                                                         for: each index }))!
-
-    method _constructorNameForSlots: slots
-        slots
-            ifEmpty: { return #new }.
-        (StringOutput
-             with: { |out|
-                     slots
-                         do: { |each|
-                               out print: each name.
-                               out print: ":" } })
-        toSelector!
-
+            methods: (instanceMethods append: readers)!
 end

--- a/foo/lang/class2.foo
+++ b/foo/lang/class2.foo
@@ -41,7 +41,7 @@ extend Class
                             subclass: "{name} classOf"
                             interfaces: (interfaces collect: #classOf)
                             methods: (directMethods append: [ctor]).
-        let readers = (slots reject: { |each| each name startsWith: "_" })
+        let readers = (slots reject: #isPrivate)
                           collect: { |each|
                                      layout readerMethod: each name toSelector
                                             for: each index }.

--- a/foo/lang/class2.foo
+++ b/foo/lang/class2.foo
@@ -1,5 +1,6 @@
 import .object.Object
 import .exception.TypeError
+import .exception.Error
 import .layout_ext.*
 import .stringOutput.StringOutput
 
@@ -37,6 +38,9 @@ extend Class
            instanceMethods: instanceMethods
         let layout = Layout new: (slots size).
         let ctor = layout constructorMethod: (_ConstructorName forSlots: slots).
+        slots
+            doWithIndex: { |each index|
+                           each index is index assert: "Slot index must match slot position" }.
         let metaclass = Class
                             subclass: "{name} classOf"
                             interfaces: (interfaces collect: #classOf)

--- a/foo/lang/selector.foo
+++ b/foo/lang/selector.foo
@@ -72,6 +72,9 @@ class Selector { name }
     method isUnary
         Self isUnaryName: self name!
 
+    method isPrivate
+        self name startsWith: "_"!
+
     method sendTo: receiver
         name sendTo: receiver
              with: []!

--- a/foo/lang/selector_ext.foo
+++ b/foo/lang/selector_ext.foo
@@ -80,6 +80,9 @@ extend Selector
     method isUnary
         Self isUnaryName: self name!
 
+    method isPrivate
+        self name startsWith: "_"!
+
     method startsWith: part
         self name startsWith: part!
 

--- a/foo/lang/string.foo
+++ b/foo/lang/string.foo
@@ -50,6 +50,10 @@ extend String
     method printOn: stream
         stream writeString: self!
 
+    method isPrivate
+        -- KLUDGE: host uses strings where target uses selectors
+        self startsWith: "_"!
+
     method _escapeOn: stream
         [["\"", "\\\""],
          ["\\", "\\\\"],


### PR DESCRIPTION
- was accidentally direct method instead of instance method
- move class ctor name creation to a separate class to keep the Class namespace clean
- introduce #isPrivate to simplify code and express intention
- check slot indexes
