### PR TITLE
loosen type-restrictions on block in transpiler primitives

### DIFF
--- a/foo/impl/transpiler/array.foo
+++ b/foo/impl/transpiler/array.foo
@@ -64,7 +64,7 @@ for (size_t i = 0; i < self->size; i++) \{
 }
 return (struct Foo)\{ .class = &FooClass_Array, .datum = \{ .ptr = new } };"},
       #do:
-          -> {signature: [Closure], vars: 0,
+          -> {signature: [Any], vars: 0,
               body: "struct FooArray* self = PTR(FooArray, ctx->receiver.datum);
                      for (size_t i = 0; i < self->size; i++) \{
                          foo_send(ctx, &FOO_value_, ctx->frame[0], 1, self->data[i]);

--- a/foo/impl/transpiler/boolean.foo
+++ b/foo/impl/transpiler/boolean.foo
@@ -8,21 +8,21 @@ return ctx->receiver;" } }!
 
 define InstanceMethods
     { #ifTrue:ifFalse:
-          -> { signature: [Closure, Closure], vars: 0,
+          -> { signature: [Any, Any], vars: 0,
                body: "if (ctx->receiver.datum.boolean) \{
     return foo_send(ctx, &{Name mangleSelector: #value}, ctx->frame[0], 0);
 } else \{
     return foo_send(ctx, &{Name mangleSelector: #value}, ctx->frame[1], 0);
 }" },
  #ifTrue:
-          -> { signature: [Closure], vars: 0,
+          -> { signature: [Any], vars: 0,
                body: "if (ctx->receiver.datum.boolean) \{
     return foo_send(ctx, &{Name mangleSelector: #value}, ctx->frame[0], 0);
 } else \{
     return FooGlobal_False;
 }" },
  #ifFalse:
-          -> { signature: [Closure], vars: 0,
+          -> { signature: [Any], vars: 0,
                body: "if (ctx->receiver.datum.boolean) \{
     return FooGlobal_True;
 } else \{

--- a/foo/impl/transpiler/closure.foo
+++ b/foo/impl/transpiler/closure.foo
@@ -30,13 +30,13 @@ return PTR(FooClosure, ctx->receiver.datum)->function(closure_ctx);"},
               body: "struct FooContext* closure_ctx = foo_context_new_closure(ctx);
 return PTR(FooClosure, ctx->receiver.datum)->function(closure_ctx);"},
       #whileFalse:
-          -> {signature: [Closure], vars: 0,
+          -> {signature: [Any], vars: 0,
               body: "while (foo_eq(FooGlobal_False, foo_send(ctx, &FOO_value, ctx->receiver, 0))) \{
     foo_send(ctx, &FOO_value, ctx->frame[0], 0);
 };
 return FooGlobal_False;"},
       #whileTrue:
-          -> {signature: [Closure], vars: 0,
+          -> {signature: [Any], vars: 0,
               body: "while (foo_eq(FooGlobal_True, foo_send(ctx, &FOO_value, ctx->receiver, 0))) \{
     foo_send(ctx, &FOO_value, ctx->frame[0], 0);
 };

--- a/foo/impl/transpiler/integer.foo
+++ b/foo/impl/transpiler/integer.foo
@@ -44,7 +44,7 @@ else
           -> { signature: [Integer], vars: 0,
                body: "return foo_Integer_new(ctx->receiver.datum.int64 - ctx->frame[0].datum.int64);" },
       #to:do:
-          -> { signature: [Integer, Closure], vars: 0,
+          -> { signature: [Integer, Any], vars: 0,
                body: "int64_t from = ctx->receiver.datum.int64;
                       int64_t to = ctx->frame[0].datum.int64;
                       for (int64_t i = from; i <= to; i++) \{

--- a/foo/impl/transpiler/string.foo
+++ b/foo/impl/transpiler/string.foo
@@ -53,7 +53,7 @@ return (struct Foo)\{ .class = &FooClass_String, .datum = \{ .ptr = b3 } };"},
 return ctx->receiver;"},
 
     #do:
-        -> {signature: [Closure], vars: 1,
+        -> {signature: [Any], vars: 1,
             body: "struct Foo block = ctx->frame[0];
 struct FooBytes* s = PTR(FooBytes, ctx->receiver.datum);
 for (size_t i = 0; i < s->size; i++) \{


### PR DESCRIPTION
  Need to be able to pass in an AstBlockClosures to these,
  and all they really expect is being able to send #value.
