### PR TITLE
System#command: on target 

### DIFF
--- a/foo/impl/transpiler/character.foo
+++ b/foo/impl/transpiler/character.foo
@@ -6,9 +6,8 @@ define DirectMethods {
 
 define InstanceMethods {
     #==
-        -> { signature: [Character], vars: 0,
-             body: "return FOO_BOOLEAN(
-                        ctx->receiver.datum.int64 == ctx->frame[0].datum.int64);" },
+        -> { signature: [Any], vars: 0,
+             body: "return FOO_BOOLEAN(foo_eq(ctx->receiver, ctx->frame[0]));" },
     #<
         -> { signature: [Character], vars: 0,
              body: "return FOO_BOOLEAN(

--- a/foo/impl/transpiler/system.foo
+++ b/foo/impl/transpiler/system.foo
@@ -5,6 +5,13 @@ define InstanceMethods {
     #clock
     -> { signature: [], vars: 0,
          body: "return FOO_INSTANCE(Clock, NULL);" },
+    #_command:
+    -> { signature: [String], vars: 0,
+         body: "struct FooBytes* bytes = PTR(FooBytes, ctx->frame[0].datum);
+                char* command = (char*)bytes->data;
+                // FIXME: capture output and exit code!
+                int result = system(command);
+                return FOO_BOOLEAN(result == 0);" },
     #files
     -> { signature: [], vars: 0,
          body: "struct FooBytes* root = FooBytes_from(\"\");

--- a/foo/lang/prelude.foo
+++ b/foo/lang/prelude.foo
@@ -36,6 +36,7 @@ import .record_ext.Record
 import .selector_ext.Selector
 import .string.String
 import .stringOutput.StringOutput
+import .system_ext
 import .test.TestSuite
 import .time.Time
 

--- a/foo/lang/system_ext.foo
+++ b/foo/lang/system_ext.foo
@@ -1,0 +1,9 @@
+extend System
+    method command: command
+        -- The target _command: doesn't capture output, because
+        -- I wanted to work on the compiler instead of writing
+        -- that stuff for both POSIX and Windows...
+        { ok: self _command: command,
+          stdout: "<<System#command stdout not captured!>>",
+          stderr: "<<System#command stderr not captured!>>" }!
+end


### PR DESCRIPTION
A quick and dirty version that doesn't capture output.