### PR TITLE
fix keyword literal parsing on both bootstrap host and target

### DIFF
--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -1000,8 +1000,10 @@ class TokenKeyword { string first last }
 
     method parseAsLiteralWith: parser
         let selector = StringOutput new: string.
-        { TokenKeyword includes: parser lookahead }
-            whileTrue: { selector print: parser nextToken string }.
+        { parser atWhitespace
+              ifTrue: { False }
+              ifFalse: { TokenKeyword includes: parser lookahead } }
+        whileTrue: { selector print: parser nextToken string }.
         SyntaxSelector
             name: selector content
             source: (parser sourceFrom: first to: last)!

--- a/foo/impl/test_foolang.foo
+++ b/foo/impl/test_foolang.foo
@@ -79,6 +79,11 @@ define XYZ 42!
         self parse: "[ext.Name1, ext.Name2]"
             expect: "[ext.Name1, ext.Name2]"!
 
+    method test_Parse_literal_keyword_argument_to_keyword_message
+        self parse: "List collectUsing: #doSelectors: from: self"
+             expect: "List collectUsing: #doSelectors:
+     from: self"!
+
     method test_Parse_bad_external_reference
         self parse: "[ext.1Name1, ext.Name2]"
              expectError: Error

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -636,7 +636,14 @@ fn literal_prefix(parser: &Parser) -> Parse {
         (Token::KEYWORD, span) => {
             parser.next_token()?;
             selector.push_str(parser.slice_at(span.clone()));
+            let mut end = span.end;
             while let (Token::KEYWORD, span) = parser.lookahead()? {
+                // No whitespace in between!
+                if span.start == end {
+                    end = span.end;
+                } else {
+                    break;
+                }
                 parser.next_token()?;
                 selector.push_str(parser.slice_at(span.clone()));
             }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -315,6 +315,19 @@ fn test_comments1() {
 }
 
 #[test]
+fn test_parse_keyword_literal_as_argument_to_keyword_message() {
+    assert_eq!(
+        parse_expr("List collectUsing: #doSelectors: from: self"),
+        Ok(keyword(
+            5..43,
+            "collectUsing:from:",
+            var(0..4, "List"),
+            vec![selector(19..32, "doSelectors:"), var(39..43, "self")]
+        ))
+    );
+}
+
+#[test]
 fn test_parse_string1() {
     assert_eq!(parse_expr(r#" "foo" "#), Ok(string(1..6, "foo")))
 }


### PR DESCRIPTION
 Kind of surprising how seldom I have identical bugs on both.

 Closes #411
