### PR TITLE
fix self-compile on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
 
       - run: mkdir -p bin && cp target/debug/foo ./bin/
 
+      - name: Bootstrap compiler
+        run: ./bin/foo foo/compile.foo -- foo/compile.foo ./bin/bootstrap-fooc
+
+      - name: Self-compile
+        run: ./bin/bootstrap-fooc foo/compile.foo ./bin/fooc
+
       - name: Test Foolang
         run: ./bin/foo foo/impl/test_foolang.foo --use=foo/lib
 
@@ -69,12 +75,6 @@ jobs:
 
       - name: Test Transpile
         run: ./bin/foo foo/impl/test_transpile.foo --use=foo/lib
-
-      - name: Bootstrap compiler
-        run: ./bin/foo foo/compile.foo ./bin/bootstrap-fooc
-
-      - name: Self-compile
-        run: ./bin/bootstrap-fooc foo/compile.foo ./bin/fooc
 
   build-host:
     name: "Build host"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,6 +22,6 @@ echo "$BOOTSTRAP_COMPILER built!"
 
 echo "Building $TARGET_COMPILER..."
 time $BOOTSTRAP_COMPILER foo/compile.foo $TARGET_COMPILER
-rm -f target-c
+rm -rf target-c
 cp -a c target-c
 echo "$TARGET_COMPILER built!"

--- a/c/system.h
+++ b/c/system.h
@@ -8,6 +8,7 @@
 
 bool system_is_unix(void);
 bool system_is_windows(void);
+bool system_is_macos(void);
 double system_time_seconds(void);
 void system_get_process_times(struct FooProcessTimes* times);
 void system_sleep(double seconds);

--- a/c/system_unix.c
+++ b/c/system_unix.c
@@ -16,6 +16,14 @@ bool system_is_unix(void) {
   return true;
 }
 
+bool system_is_macos(void) {
+#ifdef FOO_MACOS
+  return true;
+#else
+  return false;
+#endif
+}
+
 bool system_is_windows(void) {
   return false;
 }

--- a/c/system_windows.c
+++ b/c/system_windows.c
@@ -16,6 +16,10 @@ bool system_is_unix(void) {
   return false;
 }
 
+bool system_is_macos(void) {
+  return false;
+}
+
 bool system_is_windows(void) {
   return true;
 }

--- a/foo/compile.foo
+++ b/foo/compile.foo
@@ -1,71 +1,14 @@
-import .impl.environment.Environment
-import .impl.utils.FileModuleDictionary
-import .impl.cTranspiler.CTranspiler
+import .impl.compiler
 
 class Main {}
     direct method run: command in: system
-        let sourceFile = command first.
-        let targetFile = command size > 1
-                             ifTrue: { command second }
-                             ifFalse: { "a.exe" }.
-        let path = system files / sourceFile.
-        let mods = FileModuleDictionary
-                       new: { "lang" -> system files / "foo/lang",
-                              "impl" -> system files / "foo/impl",
-                              "lib" -> system files / "foo/lib" }.
-        let c = CTranspiler
-                    transpile: path readString
-                    in: (Environment modules: mods)
-                    with: ["lang", "prelude"] asList.
-        let files = system files / "c".
-        (files / "generated_selectors.h")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c selectors }.
-        (files / "generated_declarations.h")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c declarations }.
-        (files / "generated_constants.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c constants }.
-        (files / "generated_closures.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c closures }.
-        (files / "generated_main.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c main }.
-        (files / "generated_builtins.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c builtins }.
-
-        let exe = system currentDirectory / targetFile.
-        exe ifExists: #deleteFile.
-
-        let stackSize = 0x400000. -- 4MiB
-        let linkerOptions
-            = system isUnix
-                ifTrue: { " -Wl,-z,stack-size={stackSize}" }
-                ifFalse: { " -Wl,/STACK:{stackSize}" }.
-        let sanitizerOptions = " -fsanitize=address -fsanitize=undefined".
-        let buildOptions
-            = " -fno-omit-frame-pointer -g -Wall -Werror --std=c11".
-        let system_c
-            = system isUnix
-                ifTrue: { " c/system_unix.c" }
-                ifFalse: { " c/system_windows.c" }.
-        let buildCmd = StringOutput
-                           with: { |out|
-                                   out print: "clang -o {exe}".
-                                   out print: linkerOptions.
-                                   out print: sanitizerOptions.
-                                   out print: buildOptions.
-                                   out print: " c/main.c".
-                                   out print: " ext/dtoa.c".
-                                   out print: system_c }.
-        let build = system command: buildCmd.
-        build stderr
-            ifNotEmpty: { system output println: "---stderr---".
-                          system output println: build stderr.
-                          system output println: "---" }.
-        build ok
-	  ifFalse: { system exit: 1 }!
+        (compiler.Compiler
+             source: (system files / command first) readString
+             target: system currentDirectory / command second
+             system: system
+             prelude: ["lang", "prelude"]
+             -- 4MiB, default tends to be 1MiB, which is too
+             -- little for self-compilation.
+             stackSize: 0x400000)
+        compile!
 end

--- a/foo/impl/compiler.foo
+++ b/foo/impl/compiler.foo
@@ -1,0 +1,99 @@
+import .environment.Environment
+import .utils.FileModuleDictionary
+import .cTranspiler.CTranspiler
+
+-- FIXME: POA: doesn't need hole system, just files and
+-- OS type.
+class Compiler { source target system prelude stackSize }
+    direct method source: source
+                  target: target
+                  system: system
+                  prelude: prelude
+        self source: source
+             target: target
+             system: system
+             prelude: prelude
+             stackSize: False!
+
+    method compile
+        let modules = FileModuleDictionary
+                       new: { "lang" -> system files / "foo/lang",
+                              "impl" -> system files / "foo/impl",
+                              "lib" -> system files / "foo/lib" }.
+        let c = CTranspiler
+                    transpile: source
+                    in: (Environment modules: modules)
+                    with: prelude.
+        let files = system files / "c".
+        (files / "generated_selectors.h")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c selectors }.
+        (files / "generated_declarations.h")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c declarations }.
+        (files / "generated_constants.c")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c constants }.
+        (files / "generated_closures.c")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c closures }.
+        (files / "generated_main.c")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c main }.
+        (files / "generated_builtins.c")
+            forWrite truncateExisting
+                createOrOpen: { |f| f print: c builtins }.
+
+        target ifExists: #deleteFile.
+
+        let buildOptions
+            = " -fno-omit-frame-pointer -g -Wall -Werror --std=c11".
+        let buildCmd = StringOutput
+                           with: { |out|
+                                   out print: "clang -o ".
+                                   out print: target pathname.
+                                   out print: self linkerOptions.
+                                   out print: self sanitizerOptions.
+                                   out print: buildOptions.
+                                   out print: " c/main.c".
+                                   out print: " ext/dtoa.c".
+                                   out print: self systemC }.
+        let build = system command: buildCmd.
+        build ok
+            ifFalse: { Error raise: "External build failed!
+Command: {buildCmd}
+---stdout---
+{build stdout}
+--stderr---
+{build stderr}" }!
+
+    method linkerOptions
+        stackSize is False
+            ifTrue: { return "" }.
+        system isWindows
+            => { return " -Wl,/STACK:{stackSize}" }.
+        system isMacOS
+            => { -- MacOS linker defaults to 8MB the manpage says,
+                 -- setting the option requires giving the number
+                 -- as hexadecimal.
+                 stackSize <= 0x800000
+                     assert: "Setting stacksize > 8MiB for MacOS not implemented".
+                 return "" }.
+        -- GNU linker as fallback
+        " -Wl,-z,stack-size={stackSize}"!
+
+    method sanitizerOptions
+        -- KLUDGE: Windows CI host linker cannot find the sanitizer libraries,
+        -- so we conditionalize on the environment and host.
+        (system isUnix or: (system getenv: "GITHUB_ACTION") is False)
+            ifTrue: { " -fsanitize=address -fsanitize=undefined" }
+            ifFalse: { "" }!
+
+    method systemC
+        system isWindows
+            => { return " c/system_windows.c" }.
+        system isMacOS
+            => { return " -DFOO_MACOS c/system_unix.c" }.
+        " c/system_unix.c"!
+
+end

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -2057,6 +2057,16 @@ end
 class TestTranspileSystem { assert system }
     is TranspilerTest
 
+    method test_System_getenv
+        self transpile: "class Main \{}
+                             direct method run: command in: system
+                                 (system getenv: \"no such variable\") is False
+                                     ifTrue: \{ system output writeString: \"undef, \" }.
+                                 (String includes: (system getenv: \"PATH\"))
+                                     ifTrue: \{ system output writeString: \"path\" }!
+                        end"
+            expect: "undef, path"!
+
     method testClock
         self transpile: "class Main \{}
                              -- Just a small smoketest

--- a/foo/impl/test_transpile.foo
+++ b/foo/impl/test_transpile.foo
@@ -1,8 +1,4 @@
-import .cTranspiler.CTranspiler
-import .environment.Environment
-import .parser.Parser
-import .syntaxTranslator.SyntaxTranslator
-
+import .compiler
 import .utils.Debug
 
 import lib.assert.Assert
@@ -24,53 +20,19 @@ interface TranspilerTest
         TestTranspileWrapper test: self system: system!
 
     method prelude: prelude transpile: string
-        let env = Environment
-                      modules: { "impl" -> system files / "foo/impl",
-                                 "lang" -> system files / "foo/lang",
-                                 "lib" -> system files / "foo/lib", }
-                      asFileModules.
-        let c = CTranspiler transpile: string in: env with: prelude.
-        (system files / "c/generated_selectors.h")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c selectors }.
-        (system files / "c/generated_declarations.h")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c declarations }.
-        (system files / "c/generated_constants.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c constants }.
-        (system files / "c/generated_closures.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c closures }.
-        (system files / "c/generated_main.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c main }.
-        (system files / "c/generated_builtins.c")
-            forWrite truncateExisting
-                createOrOpen: { |f| f print: c builtins }.
-        let path = system currentDirectory / "tmp_transpile_test.exe".
-        path ifExists: #deleteFile.
-        path exists not assert: "executable cleared".
-        -- KLUDGE: Windows CI host linker cannot find the sanitizer libraries,
-        -- so we conditionalize on the environment and host.
-        let sanitizerOptions
-            = (((system getenv: "GITHUB_ACTION") is False) or: system isUnix)
-                ifTrue: { "-fsanitize=address -fsanitize=undefined" }
-                ifFalse: { "" }.
-        let target
-            = system isUnix
-                ifTrue: { "unix" }
-                ifFalse: { "windows" }.
-        let buildCmd = "clang -o {path} {sanitizerOptions} -fno-omit-frame-pointer -g -Wall -Werror --std=c11 c/main.c c/system_{target}.c ext/dtoa.c".
-        let build = system command: buildCmd.
-        self _reportStderr: build.
-        build ok
-            ifFalse: { Error raise: "Build failed: {buildCmd}" }.
-        path exists assert: "executable created".
-        let exec = system command: path toString.
-        self _reportStderr: exec!
-
-    method _reportStderr: cmd
+        let target = system currentDirectory / "tmp_transpile_test.exe".
+        target ifExists: #deleteFile.
+        target exists not
+            assert: "executable cleared".
+        (compiler.Compiler
+             source: string
+             target: target
+             system: system
+             prelude: prelude)
+            compile.
+        target exists
+            assert: "executable created".
+        let cmd = system command: target pathname.
         cmd stderr isEmpty
             ifFalse: { Debug println: "---stderr---".
                        Debug println: cmd stderr.

--- a/foo/impl/transpiler/system.foo
+++ b/foo/impl/transpiler/system.foo
@@ -49,6 +49,10 @@ define InstanceMethods {
     -> { signature: [], vars: 0,
          body: "return FOO_BOOLEAN(system_is_windows());" },
 
+    #isMacOS
+    -> { signature: [], vars: 0,
+         body: "return FOO_BOOLEAN(system_is_macos());" },
+
     #output
     -> { signature: [], vars: 0,
          body: "return FOO_INSTANCE(Output, stdout);" },

--- a/foo/impl/transpiler/system.foo
+++ b/foo/impl/transpiler/system.foo
@@ -41,6 +41,15 @@ define InstanceMethods {
                 foo_gc(ctx);
                 gc_verbose = old_verbose;
                 return FOO_BOOLEAN(true);" },
+    #getenv:
+    -> { signature: [String], vars: 0,
+         body: "struct FooBytes* bytes = PTR(FooBytes, ctx->frame[0].datum);
+                char* var = getenv((char*)bytes->data);
+                if (var) \{
+                    return foo_String_new_from(var);
+                } else \{
+                    return FOO_BOOLEAN(false);
+                }" },
     #isUnix
     -> { signature: [], vars: 0,
          body: "return FOO_BOOLEAN(system_is_unix());" },

--- a/src/classes/system.rs
+++ b/src/classes/system.rs
@@ -21,6 +21,7 @@ pub fn vtable() -> Vtable {
     vt.add_primitive_method_or_panic("input", system_input);
     vt.add_primitive_method_or_panic("isWindows", system_is_windows);
     vt.add_primitive_method_or_panic("isUnix", system_is_unix);
+    vt.add_primitive_method_or_panic("isMacOS", system_is_macos);
     vt.add_primitive_method_or_panic("output", system_output);
     vt.add_primitive_method_or_panic("output:", system_output_arg);
     vt.add_primitive_method_or_panic("random", system_random);
@@ -100,6 +101,10 @@ fn system_is_unix(_receiver: &Object, _args: &[Object], env: &Env) -> Eval {
 
 fn system_is_windows(_receiver: &Object, _args: &[Object], env: &Env) -> Eval {
     Ok(env.foo.make_boolean(cfg!(target_family = "windows")))
+}
+
+fn system_is_macos(_receiver: &Object, _args: &[Object], env: &Env) -> Eval {
+    Ok(env.foo.make_boolean(cfg!(target_os = "macos")))
 }
 
 fn system_output(receiver: &Object, _args: &[Object], env: &Env) -> Eval {


### PR DESCRIPTION

     - Fix the compile.foo commandline in CI.

     - Fix the clearing of old target C in bootstrap.sh.

     - Add System#isMacOS so we can choose the right linker option
       for stacksize.

     - Refactor the CTranspiler invocations from test_transpile.foo and
       compile.foo into a single Compiler class.
