### PR TITLE
CTranspiler: consistenter order for generated declarations

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -240,7 +240,7 @@ interface AstDefinition
         self!
 end
 
-class AstDefine { global body frameSize compilerInfo }
+class AstDefine { global body frameSize }
     is AstDefinition
 
     direct method name: name
@@ -250,13 +250,15 @@ class AstDefine { global body frameSize compilerInfo }
         let global = env global: name.
         let theDefine = self global: global
                              body: body
-                             frameSize: frameSize
-                             compilerInfo: List new.
+                             frameSize: frameSize.
         global define: theDefine.
         theDefine!
 
     method name
         global name!
+
+    method compilerInfo
+        global compilerInfo!
 
     method isDynamic
         global isDynamic!
@@ -277,7 +279,7 @@ class AstDefine { global body frameSize compilerInfo }
 end
 
 class AstInterface { name _interfaces _directMethods _instanceMethods _allInterfaces
-                     global _env compilerInfo }
+                     global _env }
     is AstDefinition
     is AstMethodHome
 
@@ -292,8 +294,7 @@ class AstInterface { name _interfaces _directMethods _instanceMethods _allInterf
                                _instanceMethods: False
                                _allInterfaces: False
                                global: global
-                               _env: env
-                               compilerInfo: List new.
+                               _env: env.
         global define: theInterface.
         theInterface!
 
@@ -308,6 +309,9 @@ class AstInterface { name _interfaces _directMethods _instanceMethods _allInterf
           _env classes at: result put: self.
           global value: result }
         finally: { _env = False }!
+
+    method compilerInfo
+        global compilerInfo!
 
     method _interfaces
         _interfaces!
@@ -346,8 +350,7 @@ end
 
 class AstClass { name superclass _slots
                  _interfaces _directMethods _instanceMethods
-                 _allInterfaces global _env
-                 compilerInfo }
+                 _allInterfaces global _env }
     is AstDefinition
     is AstMethodHome
 
@@ -365,8 +368,7 @@ class AstClass { name superclass _slots
                            _instanceMethods: False
                            _allInterfaces: False
                            global: global
-                           _env: env
-                           compilerInfo: List new.
+                           _env: env.
         global define: theClass.
         theClass!
 
@@ -384,10 +386,12 @@ class AstClass { name superclass _slots
                            _instanceMethods: False
                            _allInterfaces: False
                            global: global
-                           _env: env
-                           compilerInfo: List new.
+                           _env: env.
         global define: theClass.
         theClass!
+
+    method compilerInfo
+        global compilerInfo!
 
     method ifSuperclass: then ifNot: else
         superclass is False
@@ -698,7 +702,8 @@ interface AstGlobalVariable
             _value: False
             _state: _Unevaluated
             _definition: False
-            sources: List new!
+            sources: List new
+            compilerInfo: List new!
 
     direct method name: name definition: definition
         self
@@ -707,7 +712,8 @@ interface AstGlobalVariable
             _value: False
             _state: _Unevaluated
             _definition: definition
-            sources: List new!
+            sources: List new
+            compilerInfo: List new!
 
     method isBuiltin
         self isDefined
@@ -791,7 +797,8 @@ class AstGlobal { name::String
                   _value
                   _state
                   _definition
-                  sources }
+                  sources
+                  compilerInfo }
     is AstGlobalVariable
 
     method isDynamic
@@ -868,7 +875,8 @@ class AstDynamic { name::String
                    _value
                    _state
                    _definition
-                   sources }
+                   sources
+                   compilerInfo }
     is AstGlobalVariable
 
     method isDynamic

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -351,6 +351,11 @@ class CompilerDictionary { table }
         table put: value at: key!
 end
 
+class CompilerRecordClass { definition }
+    direct method new: theClass
+        self definition: theClass!
+end
+
 class CTranspiler { output selectorMap closureFunctions
                     constants variables tmpCounter
                     globals globalsCounter
@@ -886,8 +891,8 @@ class CTranspiler { output selectorMap closureFunctions
         let aRecordClass = recordClasses
             at: aRecord name name -- Selector don't play nice in bootstrap host dictionary!
             ifNonePut: { self _createRecordClass: aRecord }.
-        globals at: aRecordClass
-                ifNonePut: { aRecordClass }!
+        self declare: aRecordClass.
+        aRecordClass definition!
 
     method _createRecordClass: aRecord
         let name = String concat: ["Record_", aRecord name name replace: ":" with: "$"].
@@ -902,7 +907,8 @@ class CTranspiler { output selectorMap closureFunctions
                            env: env.
         theClass directMethods: [].
         theClass instanceMethods: [].
-        theClass!
+        CompilerRecordClass
+            new: theClass!
 
     method visitRecord: aRecord
         -- Tracer visitRecord: aRecord.

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -71,7 +71,7 @@ end
 define DatumClasses
     [Boolean, Character, Integer, Float]!
 
-class CompilerBuiltin { type value markFunction _id _interfaces
+class CompilerBuiltin { type value markFunction _interfaces
                         _directMethods _instanceMethods _allInterfaces
                         _global compilerInfo }
     is AstMethodHome
@@ -85,7 +85,6 @@ class CompilerBuiltin { type value markFunction _id _interfaces
                            type: type
                            value: value
                            markFunction: mark
-                           _id: False
                            _interfaces: List new
                            _directMethods: False
                            _instanceMethods: False

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -353,9 +353,10 @@ class CompilerDictionary { list }
                          value: each definition }!
 end
 
-class CompilerRecordClass { definition }
+class CompilerRecordClass { definition compilerInfo }
     direct method new: theClass
-        self definition: theClass!
+        self definition: theClass
+             compilerInfo: List new!
 end
 
 class CTranspiler { output selectorMap closureFunctions

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -574,7 +574,7 @@ class CTranspiler { output selectorMap closureFunctions
         builtinVisitor output println: "#include \"foo.h\"".
         -- FIXME: visit only referenced builtins
         builtins
-            do: { |each| builtinVisitor forwardDeclarationFor: each value }.
+            do: { |each| builtinVisitor forwardDeclarationFor: each }.
         globals
             do: { |each|
                   builtinVisitor forwardDeclarationFor: each definition }.
@@ -604,7 +604,7 @@ class CTranspiler { output selectorMap closureFunctions
         -- FIXME: used builtins only
         builtins
             do: { |each|
-                  builtinVisitor visitClassDefinition: each value }.
+                  builtinVisitor visitClassDefinition: each }.
         output!
 
     method generateClosures

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -331,26 +331,33 @@ class CompilerDictionary { list }
         self list: List new!
 
     method at: global ifNone: block
-        (global compilerInfo contains: self)
+        (global compilerInfo contains: #inCompilerDictionary)
             ifTrue: { global definition }
             ifFalse: block!
 
     method ensure: global
-        (global compilerInfo contains: self)
-            ifFalse: { list add: global }!
+        (global compilerInfo contains: #inCompilerDictionary)
+            ifFalse: { global compilerInfo add: #inCompilerDictionary.
+                       list add: global }!
 
     method isEmpty
         list isEmpty!
 
-    method doValues: block
-        list do: { |each|
-                   block
-                       value: each definition }!
-
     method do: block
-        list do: { |each|
-                   block value: each
-                         value: each definition }!
+        list do: block!
+
+    method takeAll
+        let old = list.
+        list = List new.
+        old!
+
+    method restoreAll: all
+        all do: { |each|
+                  (each compilerInfo contains: #inCompilerDictionary)
+                      assert: "Restoring new things to CompilerDictionary!" }.
+        list isEmpty
+            assert: "CompilerDictionary not empty on restore.".
+        list = all!
 end
 
 class CompilerRecordClass { definition compilerInfo }
@@ -502,15 +509,15 @@ class CTranspiler { output selectorMap closureFunctions
     method writeDefinitions
         -- Processing a definition can produce new global references. Visit
         -- each definition only once, finish with the full collection.
-        let allGlobals = CompilerDictionary new.
+        let allGlobals = List new.
         { globals isEmpty }
-            whileFalse: { let old = globals.
-                          globals = CompilerDictionary new.
-                          old do: { |global def|
-                                    allGlobals at: global
-                                               ifNone: { allGlobals ensure: global.
-                                                         def visitBy: self } } }.
-        globals = allGlobals!
+            whileFalse: { globals takeAll
+                              do: { |global|
+                                    (global compilerInfo contains: #inAllGlobals)
+                                        ifFalse: { global compilerInfo add: #inAllGlobals.
+                                                   allGlobals add: global.
+                                                   global definition visitBy: self } } }.
+        globals restoreAll: allGlobals!
 
     method writeMain: main
         output println: "int main".
@@ -570,8 +577,8 @@ class CTranspiler { output selectorMap closureFunctions
         self compilerBuiltins
             do: { |each| builtinVisitor forwardDeclarationFor: each }.
         globals
-            doValues: { |each|
-                        builtinVisitor forwardDeclarationFor: each }.
+            do: { |each|
+                  builtinVisitor forwardDeclarationFor: each definition }.
         closureFunctions
             do: { |closure|
                   output print: closure declaration.

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -326,29 +326,31 @@ end
 define $CascadeReceiverTemp
     "<<<not in cascade>>>"!
 
-class CompilerDictionary { table }
+class CompilerDictionary { list }
     direct method new
-        self table: Dictionary new!
+        self list: List new!
 
-    method at: key ifNone: block
-        table at: key
-              ifNone: block!
+    method at: global ifNone: block
+        (global compilerInfo contains: self)
+            ifTrue: { global definition }
+            ifFalse: block!
 
-    method at: key ifNonePut: block
-        table at: key
-              ifNonePut: block!
+    method ensure: global
+        (global compilerInfo contains: self)
+            ifFalse: { list add: global }!
 
     method isEmpty
-        table isEmpty!
+        list isEmpty!
 
     method doValues: block
-        table doValues: block!
+        list do: { |each|
+                   block
+                       value: each definition }!
 
     method do: block
-        table do: block!
-
-    method put: value at: key
-        table put: value at: key!
+        list do: { |each|
+                   block value: each
+                         value: each definition }!
 end
 
 class CompilerRecordClass { definition }
@@ -441,8 +443,7 @@ class CTranspiler { output selectorMap closureFunctions
         "ctx->frame[{tmp}]"!
 
     method declare: global
-        globals at: global
-                ifNonePut: { global definition }!
+        globals ensure: global!
 
     method declareDynamic: var
         self declare: var.
@@ -506,7 +507,7 @@ class CTranspiler { output selectorMap closureFunctions
                           globals = CompilerDictionary new.
                           old do: { |global def|
                                     allGlobals at: global
-                                               ifNone: { allGlobals put: def at: global.
+                                               ifNone: { allGlobals ensure: global.
                                                          def visitBy: self } } }.
         globals = allGlobals!
 

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -326,6 +326,31 @@ end
 define $CascadeReceiverTemp
     "<<<not in cascade>>>"!
 
+class CompilerDictionary { table }
+    direct method new
+        self table: Dictionary new!
+
+    method at: key ifNone: block
+        table at: key
+              ifNone: block!
+
+    method at: key ifNonePut: block
+        table at: key
+              ifNonePut: block!
+
+    method isEmpty
+        table isEmpty!
+
+    method doValues: block
+        table doValues: block!
+
+    method do: block
+        table do: block!
+
+    method put: value at: key
+        table put: value at: key!
+end
+
 class CTranspiler { output selectorMap closureFunctions
                     constants variables tmpCounter
                     globals globalsCounter
@@ -357,7 +382,7 @@ class CTranspiler { output selectorMap closureFunctions
                           constants: List new
                           variables: Dictionary new
                           tmpCounter: 0
-                          globals: Dictionary new
+                          globals: CompilerDictionary new
                           globalsCounter: Counter new
                           recordClasses: Dictionary new
                           generatedMethods: Dictionary new
@@ -470,10 +495,10 @@ class CTranspiler { output selectorMap closureFunctions
     method writeDefinitions
         -- Processing a definition can produce new global references. Visit
         -- each definition only once, finish with the full collection.
-        let allGlobals = Dictionary new.
+        let allGlobals = CompilerDictionary new.
         { globals isEmpty }
             whileFalse: { let old = globals.
-                          globals = Dictionary new.
+                          globals = CompilerDictionary new.
                           old do: { |global def|
                                     allGlobals at: global
                                                ifNone: { allGlobals put: def at: global.

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -21,6 +21,7 @@ import .transpiler.system_random
 import .transpiler.time
 import .ast.*
 import .utils.*
+import .environment.ModuleBinding
 
 define CEscapes
     { "'" -> "\\'",
@@ -402,9 +403,7 @@ class CTranspiler { output selectorMap closureFunctions
                           recordClasses: Dictionary new
                           generatedMethods: Dictionary new
                           env: env
-                          builtins: (Dictionary
-                                         keys: (builtins collect: #value)
-                                         values: builtins).
+                          builtins: builtins.
         visitor output println: "#include \"foo.h\"".
         -- KLUDGE: ensure selectors with references from C code
         AlwaysEmittedSelectors
@@ -574,8 +573,8 @@ class CTranspiler { output selectorMap closureFunctions
                                  builtins: builtins.
         builtinVisitor output println: "#include \"foo.h\"".
         -- FIXME: visit only referenced builtins
-        self compilerBuiltins
-            do: { |each| builtinVisitor forwardDeclarationFor: each }.
+        builtins
+            do: { |each| builtinVisitor forwardDeclarationFor: each value }.
         globals
             do: { |each|
                   builtinVisitor forwardDeclarationFor: each definition }.
@@ -584,13 +583,6 @@ class CTranspiler { output selectorMap closureFunctions
                   output print: closure declaration.
                   output println: ";" }.
         output!
-
-    method compilerBuiltins
-        -- Filter out module definitions
-        let builtinGlobals = env builtins values
-                          select: { |each| AstGlobal includes: each }.
-        (builtinGlobals collect: #definition)
-            select: { |each| CompilerBuiltin includes: each }!
 
     method generateBuiltins
         -- Debug println: "      #generateBuiltins:".
@@ -610,9 +602,9 @@ class CTranspiler { output selectorMap closureFunctions
                                  builtins: builtins.
         builtinVisitor output println: "#include \"foo.h\"".
         -- FIXME: used builtins only
-        self compilerBuiltins
+        builtins
             do: { |each|
-                  builtinVisitor visitClassDefinition: each }.
+                  builtinVisitor visitClassDefinition: each value }.
         output!
 
     method generateClosures
@@ -703,14 +695,12 @@ class CTranspiler { output selectorMap closureFunctions
                          ifFalse: { value classOf }.
         return env classes
             at: theClass
-            ifNone: { builtins
-                          at: theClass
-                          ifNone: {
-                              Debug println: "looking for: {value} ({theClass})".
-                              env classes keys
-                                  do: { |each|
-                                        Debug println: "- {each} ({each is theClass})" }.
-                              panic "No AstClass for: {value} ({theClass})\nenv classes: {env classes keys}\nbuiltins: {builtins keys}" } }!
+            ifNone: { self _findBuiltinFor: theClass
+                           _ifNone: { panic "No 'ast class' for: {value} ({theClass})\nenv classes: {env classes keys}\nbuiltins: {builtins}" } }!
+
+    method _findBuiltinFor: value _ifNone: block
+        builtins find: { |each| each value is value }
+                 ifNone: block!
 
     method _recordClassFromRecord: aRecord
         let keys = (Record keysIn: aRecord) sorted


### PR DESCRIPTION
  The resulting declarations between bootstrap and target
  builds are not consistent with this yet, though, but closer.

