### PR TITLE
sort methods in compiler

### DIFF
--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -185,7 +185,7 @@ interface AstMethodHome
         let dict = self _ownDirectMethods.
         self _collectFromInterfaces: #directMethods
             _into: dict.
-        dict values!
+        dict values sort: #selector ascending!
 
     ---
     KLUDGE & FIXME: does not include reader methods, since bootstrap host
@@ -206,7 +206,7 @@ interface AstMethodHome
              _into: dict.
         self _collectFromInterfaces: #instanceMethods
             _into: dict.
-        dict values!
+        dict values sort: #selector ascending!
 
     method _collectFromInterfaces: selector _into: dict
         self interfaceDefinitions :: Ordered


### PR DESCRIPTION
 This gets generated_declarations.h consistent between host
 and target upto first 2087 lines, so WIN.

 However, things become inconsistent after

   FooGlobal211_InvalidToken

 target has

   FooMetaclass_Importoken

 host has

   FooMetaClass_ClassToken

 ...and I don't quite yet understand why.

