### PR TITLE
explicit -lm (asan causes it to be silently linked)

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -8,17 +8,15 @@ fi
 
 set -euo pipefail
 
-# This tricks clang into using the internal symbolizer, leaving path
-# empty leaves the addresses unsymbolized.
-export ASAN_SYMBOLIZER_PATH=0
+export ASAN_SYMBOLIZER_PATH=llvm-symbolizer
 
 rm -f tmp_transpile_test.exe
 
 function stacksize_options() {
     # 4MB stack: the parser is highly recursive!
     local size=0x400000
-    if [ -z "$WINDIR" ]; then
-        echo -Wl,-stack-size -W,$size
+    if [ $ostype = "unix" ]; then
+        echo -Wl,-z,-stack-size=$size
     else
         echo -Wl,/STACK:$size
     fi
@@ -28,7 +26,7 @@ clang \
     -o tmp_transpile_test.exe \
     $(stacksize_options) \
     -fsanitize=address -fsanitize=undefined \
-    -fno-omit-frame-pointer -g -Wall --std=c11 \
+    -lm -fno-omit-frame-pointer -g -Wall --std=c11 \
     c/main.c c/system_$ostype.c ext/dtoa.c
 echo "Built, running!"
 time ./tmp_transpile_test.exe "$@"

--- a/foo/impl/compiler.foo
+++ b/foo/impl/compiler.foo
@@ -68,6 +68,9 @@ Command: {buildCmd}
 {build stderr}" }!
 
     method linkerOptions
+        " -lm{self stackSizeOptions}"!
+
+    method stackSizeOptions
         stackSize is False
             ifTrue: { return "" }.
         system isWindows


### PR DESCRIPTION
  Plus fixing debug.sh for Linux

