### PR TITLE
Object#=> instead of Boolean#=>

### DIFF
--- a/foo/lang/boolean_ext.foo
+++ b/foo/lang/boolean_ext.foo
@@ -6,10 +6,6 @@ extend Boolean
     direct method default
         False!
 
-    method => block
-        self
-            ifTrue: block!
-
     method assert: what
         self ifFalse: { panic "{ what } assertion failed!" }!
 

--- a/foo/lang/object.foo
+++ b/foo/lang/object.foo
@@ -22,6 +22,10 @@ interface Object
         stream writeString: Self name.
         stream writeString: ">"!
 
+    method => block
+        self is False
+            ifFalse: { block cull: self }!
+
     method == other
         (Self includes: other)
             ifTrue: { self isEquivalent: other }!


### PR DESCRIPTION
  Works just like a logical implication, considers anything not
  False to be True.

  Closes #318, as I was getting fed up of the

    X is False
        ifFalse: ...

  idiom in my own code, but don't have the spoons to still decide
  about generalized booleans and none and such.

