### PR TITLE
compiler: double the stack size by default

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -622,7 +622,7 @@ struct Foo foo_activate(struct FooContext* context) {
   assert(home);
   uint32_t depth = context->depth;
 
-  if (depth > 1000) {
+  if (depth > 2000) {
     foo_panicf(context, "Stack blew up!");
   }
 

--- a/foo/impl/compiler.foo
+++ b/foo/impl/compiler.foo
@@ -40,9 +40,10 @@ class Compiler { source target system prelude stackSize addressSanitizer }
              target: system files / target
              system: system
              prelude: ["lang", "prelude"]
-             -- 4MiB, default tends to be 1MiB, which is too
-             -- little for self-compilation.
-             stackSize: 0x400000
+             -- 8MiB, default tends to be 1MiB, which is too
+             -- little for self-compilation, let alone a metacircular
+             -- REPL.
+             stackSize: 0x800000
              addressSanitizer: False)
         compile!
 


### PR DESCRIPTION
  This allows running the repl inside the interpreter.

