### PR TITLE
Fix assignments to arguments

### DIFF
--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -70,17 +70,18 @@ class TokenString { string first last }
     method _literalFrom: next into: parts
         let literal = StringOutput new.
         let from = next.
+        let nextPos = next.
 
-        { next < string size
-              ifTrue: { (self _isInterpolationStart: next) not } }
-        whileTrue: { next = self _scanCharFrom: next into: literal }.
+        { nextPos < string size
+              ifTrue: { (self _isInterpolationStart: nextPos) not } }
+        whileTrue: { nextPos = self _scanCharFrom: nextPos into: literal }.
 
-        from is next
+        from is nextPos
             ifFalse: { parts
                            add: (SyntaxLiteral
                                      value: literal content
                                      source: False) }.
-        next!
+        nextPos!
 
     method _interpolatedFrom: next into: parts
         (next < string size)

--- a/foo/impl/parser.foo
+++ b/foo/impl/parser.foo
@@ -55,13 +55,14 @@ class TokenString { string first last }
             ifNone: { panic "Unknown escape character: {char}" }!
 
     method _scanCharFrom: next into: literal
-        let char = string from: next to: next.
-        next = next + 1.
+        let nextPos = next.
+        let char = string from: nextPos to: nextPos.
+        nextPos = nextPos + 1.
         char == "\\"
-            ifTrue: { literal print: (self _escapeChar: (string from: next to: next)).
-                      next = next + 1 }
+            ifTrue: { literal print: (self _escapeChar: (string from: nextPos to: nextPos)).
+                      nextPos = nextPos + 1 }
             ifFalse: { literal print: char }.
-        next!
+        nextPos!
 
     method _isInterpolationStart: next
         "\{" == (string from: next to: next)!

--- a/foo/lang/filestream_ext.foo
+++ b/foo/lang/filestream_ext.foo
@@ -62,16 +62,18 @@ extend FileStream
             ifFalse: { panic "Could not write { n } bytes to { self }." }!
 
     method tryWrite: n bytesFrom: buffer at: index
+        let bytesLeft = n.
+        let nextIndex = index.
         let total = 0.
-        { n > 0 }
-            whileTrue: { let did = self tryWriteOnce: n
+        { bytesLeft > 0 }
+            whileTrue: { let did = self tryWriteOnce: bytesLeft
                                         bytesFrom: buffer
-                                        at: index.
+                                        at: nextIndex.
                          did == 0
                              ifTrue: { return total }.
                          total = total + did.
-                         n = n - did.
-                         index = index + did }.
+                         bytesLeft = bytesLeft - did.
+                         nextIndex = nextIndex + did }.
         total!
 
     method size

--- a/foo/lang/filestream_ext.foo
+++ b/foo/lang/filestream_ext.foo
@@ -26,16 +26,18 @@ extend FileStream
             ifFalse: { panic "Could not read { n } bytes from { self }." }!
 
     method tryRead: n bytesInto: buffer at: index
+        let bytesLeft = n.
+        let nextIndex = index.
         let total = 0.
-        { n > 0 }
-            whileTrue: { let did = self tryReadOnce: n
+        { bytesLeft > 0 }
+            whileTrue: { let did = self tryReadOnce: bytesLeft
                                         bytesInto: buffer
-                                        at: index.
+                                        at: nextIndex.
                          did == 0
                              ifTrue: { return total }.
                          total = total + did.
-                         n = n - did.
-                         index = index + did }.
+                         bytesLeft = bytesLeft - did.
+                         nextIndex = nextIndex + did }.
         total!
 
     method print: object

--- a/foo/lang/iterable.foo
+++ b/foo/lang/iterable.foo
@@ -225,14 +225,15 @@ interface Iterable
         result!
 
     method with: iterable inject: value into: block ifExhausted: exhaustedBlock
+        let result = value.
         self with: iterable
              do: { |each1 each2|
-                   value = block
-                               value: value
+                   result = block
+                               value: result
                                value: each1
                                value: each2 }
              ifExhausted: exhaustedBlock.
-        value!
+        result!
 
     method isEmpty
         self iterator hasNext not!

--- a/foo/lang/iterable.foo
+++ b/foo/lang/iterable.foo
@@ -215,13 +215,14 @@ interface Iterable
         result!
 
     method with: iterable inject: value into: block
+        let result = value.
         self with: iterable
              do: { |each1 each2|
-                   value = block
-                               value: value
+                   result = block
+                               value: result
                                value: each1
                                value: each2 }.
-        value!
+        result!
 
     method with: iterable inject: value into: block ifExhausted: exhaustedBlock
         self with: iterable

--- a/foo/lang/iterable.foo
+++ b/foo/lang/iterable.foo
@@ -207,11 +207,12 @@ interface Iterable
                           self anySatisfy: { |each2| each1 == each2 } }!
 
     method inject: value into: block
+        let result = value.
         self do: { |each|
-                   value = block
-                               value: value
+                   result = block
+                               value: result
                                value: each }.
-        value!
+        result!
 
     method with: iterable inject: value into: block
         self with: iterable


### PR DESCRIPTION
System does not currently enforce it, but it will. Arguments are supposed to be read-only.
