### PR TITLE
early binding for known sends to booleans

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -565,6 +565,27 @@ struct Foo foo_send_perform_with(const struct FooMethod* method,
   return result;
 }
 
+struct Foo foo_call_known_method(struct FooContext* sender,
+                                 struct FooClass* home,
+                                 struct FooSelector* selector,
+                                 FooMethodFunction method_function,
+                                 struct Foo receiver,
+                                 size_t nargs, ...) {
+  if (sender->depth > 2000) {
+    foo_panicf(sender, "Stack blew up!");
+  }
+  va_list arguments;
+  va_start(arguments, nargs);
+  struct FooMethod fakeMethod;
+  fakeMethod.selector = selector;
+  fakeMethod.home = home;
+  fakeMethod.function = method_function;
+  struct Foo result
+    = method_function(&fakeMethod, selector, sender, receiver, nargs, arguments);
+  va_end(arguments);
+  return result;
+}
+
 struct Foo foo_call_method(const struct FooMethod* method,
                            const struct FooSelector* selector,
                            struct FooContext* sender,

--- a/foo/impl/ast.foo
+++ b/foo/impl/ast.foo
@@ -724,14 +724,18 @@ class AstArray { entries }
         entries!
 end
 
-class AstTypecheck { value type }
+class AstTypecheck { value assertType }
     is AstNode
+
+    -- FIXME: assertType is not a "type"
+    method type
+        TheUnknownType!
 
     method visitBy: visitor
         visitor visitTypecheck: self!
 
     method parts
-        [value, type]!
+        [value, assertType]!
 end
 
 class AstRecord { name slots values }
@@ -1137,8 +1141,9 @@ end
 class AstSlotRef { slot source }
     is AstNode
 
+    -- FIXME: Could refer to slot type, but that's not a "type".
     method type
-        slot type!
+        TheUnknownType!
 
     method isImmediate
         True!
@@ -1189,8 +1194,9 @@ end
 class AstLexicalRef { variable frameOffset::Integer source }
     is AstNode
 
+    -- FIXME: Could refer to variable type, but that's not a "type"
     method type
-        variable type!
+        TheUnknownType!
 
     method isImmediate
         True!

--- a/foo/impl/astInterpreter.foo
+++ b/foo/impl/astInterpreter.foo
@@ -178,7 +178,7 @@ class AstInterpreter { context process }
 
     method visitTypecheck: aNode
         let value = aNode value visitBy: self.
-        let type = aNode type visitBy: self.
+        let type = aNode assertType visitBy: self.
         type typecheck: value!
 
     method visitConstant: aConstant

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -36,6 +36,8 @@ define CEscapes
 define Tracer NullTracer!
 
 class BuiltinMethod { home selector definition isDirect }
+    is Object
+
     direct method forEach: builtins in: home direct: areDirect
         let dict = Dictionary new.
         builtins
@@ -153,6 +155,13 @@ class CompilerBuiltin { type value markFunction _interfaces
     method _instanceMethods: methods
         (self _instanceMethods is False) assert: "Builtin instance methods already set.".
         _instanceMethods = BuiltinMethod forEach: methods in: self direct: False!
+
+    method findInstanceMethod: selector
+        self instanceMethods
+            do: { |each|
+                  each selector == selector
+                      ifTrue: { return each } }.
+        False!
 
     method visitBy: visitor
         visitor visitBuiltin: self!
@@ -1405,7 +1414,7 @@ class CTranspiler { output selectorMap closureFunctions
 
     method visitTypecheck: aCheck
         -- Tracer visitTypecheck: aCheck.
-        self _generateTypecheck: aCheck type
+        self _generateTypecheck: aCheck assertType
              _for: aCheck value!
 
     method visitIs: anIs
@@ -1474,9 +1483,38 @@ class CTranspiler { output selectorMap closureFunctions
     method visitCascadeReceiver: _
         output print: $CascadeReceiverTemp!
 
+    method generateKnownSend: aSend using: aMethod
+        -- These are never #perform:with: or object methods, thanks to #findMethod:in:
+        let methodFunction = Name mangleMethod: aMethod.
+        let selector = self selectorCName: aMethod selector.
+        output print: "(\{ ".
+        let receiver = self _visitTemp: aSend receiver.
+        let args = aSend arguments
+                       collect: { |each| self _visitTemp: each }.
+        output
+            ; print: "foo_call_known_method(ctx, &"
+            ; print: aMethod methodHomeName
+            ; print: ", &"
+            ; print: selector
+            ; print: ", "
+            ; print: aMethod methodFunctionName
+            ; print: ", "
+            ; print: receiver
+            ; print: ", "
+            ; print: args size.
+        args do: { |each|
+                   output
+                       ; print: ", "
+                       ; print: each }.
+        output print: "); })"!
+
     method visitSend: aSend
         -- Tracer visitSend: aSend selector.
-        -- Debug println: "rcv: {aSend receiver type}".
+        Debug println: "rcv: {aSend receiver} is {aSend receiver type}".
+        (aSend receiver type findMethod: aSend selector in: env)
+            => { |aMethod|
+                 Debug println: "found: {aMethod}".
+                 return self generateKnownSend: aSend using: aMethod }.
         output print: "(\{ ".
         let receiver = self _visitTemp: aSend receiver.
         let args = aSend arguments

--- a/foo/impl/syntaxTranslator.foo
+++ b/foo/impl/syntaxTranslator.foo
@@ -84,7 +84,7 @@ class SyntaxTranslator { env currentMethod methodEnv }
         -- Tracer trace: #visitValueTypeDeclaration.
         AstTypecheck
             value: (aNode value visitBy: self)
-            type: (aNode type visitBy: self)!
+            assertType: (aNode type visitBy: self)!
 
     method visitArray: anArray
         -- Tracer trace: #visitArray:.

--- a/foo/impl/types.foo
+++ b/foo/impl/types.foo
@@ -3,7 +3,7 @@ import .utils.Debug
 interface Type
     is Object
 
-    method findMethod: selector for: compiler
+    method findMethod: selector in: env
         False!
 end
 
@@ -12,25 +12,6 @@ class EqType { value }
 
     method displayOn: stream
         stream writeString: "#<EqType {value classOf name}>"!
-
-    method findMethod: selector for: compiler
-        (Record includes: value)
-            ifTrue: { let recordClass =  compiler _recordClassFromRecord: value.
-                      return recordClass findInstanceMethod: selector }.
-        let isClass = (Class includes: value) or: (Interface includes: value).
-        let hostClass = isClass
-                            ifTrue: { value }
-                            ifFalse: { value classOf }.
-        let targetClass = compiler env classes
-                              at: hostClass
-                              ifNone: { let builtin
-                                            = compiler _findBuiltinFor: hostClass
-                                                       _ifNone: { Debug println: "!!! could not map {hostClass}".
-                                                                  return False }.
-                                        builtin definition }.
-        isClass
-            ifTrue: { targetClass findDirectMethod: selector }
-            ifFalse: { targetClass findInstanceMethod: selector }!
 end
 
 class UnknownType {}
@@ -57,8 +38,10 @@ end
 class BooleanType {}
     is Type
 
-    method findMethod: selector for: compiler
-        let boolean = compiler env global: "Boolean".
+    -- FIXME: I _really_ mislike this. Should represent the type
+    -- directly with the right object.
+    method findMethod: selector in: env
+        let boolean = env global: "Boolean".
         boolean definition findInstanceMethod: selector!
 
     method displayOn: stream
@@ -67,10 +50,6 @@ end
 
 class ClosureType { argumentTypes returnType }
     is Type
-
-    method findMethod: selector for: compiler
-        let closure = compiler env global: "Closure".
-        closure definition findInstanceMethod: selector!
 
     method displayOn: stream
         stream writeString: "#<ClosureType {argumentTypes} -> {returnType}>"!


### PR DESCRIPTION
  Also delete superfluous #findMethod... stuff from types.foo,
  which came along for the ride earlier when I added types.foo
  from another commit to the point where it was missing from.

