### PR TITLE
indirect method tables

### DIFF
--- a/c/foo.h
+++ b/c/foo.h
@@ -198,6 +198,18 @@ struct FooLayout {
   size_t size;
 };
 
+struct FooMethodTable {
+  struct FooHeader header;
+  size_t size;
+  struct FooMethod methods[];
+};
+
+/** Plan is to replace class pointers with class IDs, and
+ *  spread the class members across global tables.
+ *
+ *  As a first step towards doing this all accesses should
+ *  be given the same treatment as method tables.
+ */
 struct FooClass {
   struct FooHeader header;
   struct FooBytes* name;
@@ -205,9 +217,11 @@ struct FooClass {
   struct FooClassList* inherited;
   struct FooLayout* layout;
   FooMarkFunction mark;
-  size_t size;
-  struct FooMethod methods[];
+  struct FooMethodTable* method_table;
 };
+
+#define FOO_GET_METHODS(class) ((class)->method_table)
+#define FOO_SET_METHODS(class, table) ((class)->method_table = (table))
 
 struct FooClassList {
   struct FooHeader header;

--- a/c/main.c
+++ b/c/main.c
@@ -386,8 +386,9 @@ const struct FooMethod* foo_class_find_method_in(const struct FooClass* class,
     FOO_XXX("foo_class_find_method_in(%s, #%s)",
             class->name->data, selector->name->data);
   }
-  for (size_t i = 0; i < class->size; ++i) {
-    const struct FooMethod* method = &class->methods[i];
+  struct FooMethodTable* table = FOO_GET_METHODS(class);
+  for (size_t i = 0; i < table->size; ++i) {
+    const struct FooMethod* method = &table->methods[i];
     if (trace)
       FOO_XXX("  ? %s", method->selector->name->data);
     if (method->selector == selector) {
@@ -437,8 +438,9 @@ const struct FooMethod* foo_class_find_method(struct FooContext* ctx,
   }
 
   if (false) {
-    for (size_t i = 0; i < class->size; i++) {
-      const struct FooMethod* method = &class->methods[i];
+    const struct FooMethodTable* table = FOO_GET_METHODS(class);
+    for (size_t i = 0; i < table->size; i++) {
+      const struct FooMethod* method = &table->methods[i];
       printf("- %s\n", method->selector->name->data);
     }
   }
@@ -765,12 +767,12 @@ struct Foo foo_method_doSelectors_(const struct FooMethod* method,
   (void)method;
   (void)selector;
   (void)nargs;
-  struct FooClass* vt = receiver.class;
+  struct FooMethodTable* table = FOO_GET_METHODS(receiver.class);
   struct Foo block = va_arg(arguments, struct Foo);
-  for (size_t i = 0; i < vt->size; i++) {
+  for (size_t i = 0; i < table->size; i++) {
     foo_send(sender, &FOO_value_, block, 1,
              (struct Foo){ .class = &FooClass_Selector,
-                           .datum = { .ptr = vt->methods[i].selector } });
+                           .datum = { .ptr = table->methods[i].selector } });
   }
   return receiver;
 }

--- a/c/mark-and-sweep.c
+++ b/c/mark-and-sweep.c
@@ -189,6 +189,18 @@ void foo_mark_class_list(void* ptr) {
   EXIT_TRACE();
 }
 
+void foo_mark_method_table(struct FooMethodTable* table) {
+  ENTER_TRACE("mark_method_table %p", table);
+  if (table->header.allocation == HEAP && foo_mark_live(table)) {
+    for (size_t i = 0; i < table->size; i++) {
+      struct FooMethod* method = &table->methods[i];
+      if (method->object.class)
+        foo_mark_object(method->object);
+    }
+  }
+  EXIT_TRACE();
+}
+
 void foo_mark_class(void* ptr)
 {
   struct FooClass* class = ptr;
@@ -206,11 +218,7 @@ void foo_mark_class(void* ptr)
       if (other)
         foo_mark_class(other);
     }
-    for (size_t i = 0; i < class->size; i++) {
-      struct FooMethod* method = &class->methods[i];
-      if (method->object.class)
-        foo_mark_object(method->object);
-    }
+    foo_mark_method_table(FOO_GET_METHODS(class));
   }
   EXIT_TRACE();
 }

--- a/foo/impl/cTranspiler.foo
+++ b/foo/impl/cTranspiler.foo
@@ -1093,6 +1093,22 @@ class CTranspiler { output selectorMap closureFunctions
         output newline.
         inheritance!
 
+    method _generateMethodTable: methods for: classCName
+        let name = "FooMethodTable_{classCName}".
+        output println: "struct FooMethodTable {name} = \{".
+        output println: "    .header = \{ .allocation = STATIC, .identity_hash = {self hash: classCName} \},".
+        output println: "    .size = {methods size},".
+        output println: "    .methods = \{".
+        methods
+            do: { |each|
+                  output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
+                  output println: "                             .home = &{self mangleMethodHome: each},".
+                  output println: "                             .function = &{self mangleMethod: each},".
+                  output println: "                             .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL } } }," }.
+        output println: "    }".
+        output println: "};".
+        return name!
+
     method visitInterfaceDefinition: anInterface
         (anInterface compilerInfo tag is self)
             ifTrue: { return False }.
@@ -1115,11 +1131,15 @@ class CTranspiler { output selectorMap closureFunctions
         instanceMethods
             do: { |each| self _writeMethod: each _for: anInterface }.
         -- Interface metaclass
-        -- FIXME: name says 'Foo interface', should be 'Foo class'!
         let metaclassInheritance
             = self _generateInheritance: anInterface forMetaclass: True.
         let classInheritance
             = self _generateInheritance: anInterface forMetaclass: False.
+        let directMethodTable
+            = self _generateMethodTable: directMethods for: metaclassName.
+        let instanceMethodTable
+            = self _generateMethodTable: instanceMethods for: className.
+        -- FIXME: name says 'Foo interface', should be 'Foo classOf'!
         let metaclassNameString = "{anInterface name} interface".
         output println: "struct FooClass {metaclassName} = ".
         output println: "\{".
@@ -1130,15 +1150,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .inherited = &{metaclassInheritance},".
         output println: "    .layout = &TheClassLayout,".
         output println: "    .mark = foo_mark_class,".
-        output println: "    .size = {directMethods size},".
-        output println: "    .methods = \{".
-        directMethods
-            do: { |each|
-                  output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
-                  output println: "                            .home = &{self mangleMethodHome: each},".
-                  output println: "                            .function = &{self mangleMethod: each},".
-                  output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL } } }," }.
-        output println: "    }".
+        output println: "    .method_table = &{directMethodTable}".
         output println: "};".
         output newline.
         -- Interface class (empty, used for identity only)!
@@ -1152,15 +1164,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = NULL,". -- FIXME
         output println: "    .mark = foo_mark_class,".
-        output println: "    .size = {instanceMethods size},".
-        output println: "    .methods = \{".
-        instanceMethods
-            do: { |each|
-                  output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
-                  output println: "                            .home = &{self mangleMethodHome: each},".
-                  output println: "                            .function = &{self mangleMethod: each},".
-                  output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL \}\}\}," }.
-        output println: "    }".
+        output println: "    .method_table = &{instanceMethodTable}".
         output println: "};".
         output newline.
         -- Interface object
@@ -1231,6 +1235,8 @@ class CTranspiler { output selectorMap closureFunctions
                        -- is its own metaclass.
                        let metaclassInheritance
                            = self _generateInheritance: aClass forMetaclass: True.
+                       let directMethodTable
+                           = self _generateMethodTable: directMethods for: metaclassName.
                        let metaclassNameString = "{aClass name} classOf".
                        output println: "struct FooClass {metaclassName} = ".
                        output println: "\{".
@@ -1241,19 +1247,13 @@ class CTranspiler { output selectorMap closureFunctions
                        output println: "    .inherited = &{metaclassInheritance},".
                        output println: "    .layout = &TheClassLayout,".
                        output println: "    .mark = foo_mark_class,".
-                       output println: "    .size = {directMethods size},".
-                       output println: "    .methods = \{".
-                       directMethods
-                           do: { |each|
-                                 output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
-                                 output println: "                            .home = &{self mangleMethodHome: each},".
-                                 output println: "                            .function = &{self mangleMethod: each},".
-                                 output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL } } }," }.
-                       output println: "    }".
+                       output println: "    .method_table = &{directMethodTable}".
                        output println: "};".
                        output newline }.
         -- Instance Class
         let classInheritance = self _generateInheritance: aClass forMetaclass: False.
+        let instanceMethodTable
+            = self _generateMethodTable: instanceMethods for: className.
         let layout = isTheClass
                          ifTrue: { "&TheClassLayout" }
                          ifFalse: { self _generateLayout: aClass }.
@@ -1266,15 +1266,7 @@ class CTranspiler { output selectorMap closureFunctions
         output println: "    .inherited = &{classInheritance},".
         output println: "    .layout = {layout},".
         output println: "    .mark = {aClass markFunction},".
-        output println: "    .size = {instanceMethods size},".
-        output println: "    .methods = \{".
-        instanceMethods
-            do: { |each|
-                  output println: "        (struct FooMethod)\{ .selector = &{self selectorCName: each selector},".
-                  output println: "                            .home = &{self mangleMethodHome: each},".
-                  output println: "                            .function = &{self mangleMethod: each},".
-                  output println: "                            .object = (struct Foo)\{ .class = NULL, .datum = \{ .ptr = NULL \}\}\}," }.
-        output println: "    }".
+        output println: "    .method_table = &{instanceMethodTable}".
         output println: "};".
         output newline.
         -- Class object

--- a/foo/impl/transpiler/class.foo
+++ b/foo/impl/transpiler/class.foo
@@ -25,8 +25,9 @@ define InstanceMethods
                  const struct FooSelector* seen[1024];
                  size_t n = 0;
                  // First go through own methods, registering them in seen.
-                 for (size_t i = 0; i < class->size; i++) \{
-                     struct FooSelector* selector = class->methods[i].selector;
+                 const struct FooMethodTable* table = FOO_GET_METHODS(class);
+                 for (size_t i = 0; i < table->size; i++) \{
+                     struct FooSelector* selector = table->methods[i].selector;
 
                      // Skip private selectors.
                      if (selector->name->data[0] == '_') continue;
@@ -44,9 +45,9 @@ define InstanceMethods
                  // Then go through the inherited interfaces
                  const struct FooClassList* interfaces = class->inherited;
                  for (size_t i = 0; i < interfaces->size; i++) \{
-                     const struct FooClass* interface = interfaces->data[i];
-                     for (size_t j = 0; j < interface->size; j++) \{
-                         struct FooSelector* selector = interface->methods[j].selector;
+                     const struct FooMethodTable* table = FOO_GET_METHODS(interfaces->data[i]);
+                     for (size_t j = 0; j < table->size; j++) \{
+                         struct FooSelector* selector = table->methods[j].selector;
 
                          // Skip private selectors.
                          if (selector->name->data[0] == '_') continue;
@@ -100,16 +101,19 @@ define InstanceMethods
                  // Allocate the new class: must use _no_gc since the inherited
                  // class list is not visible to GC yet!
                  struct FooArray* methods = PTR(FooArray, ctx->frame[2].datum);
-                 struct FooClass* newclass
-                   = foo_alloc_no_gc(ctx, sizeof(struct FooClass)
-                                     + methods->size * sizeof(struct FooMethod));
+                 struct FooClass* newclass = foo_alloc_no_gc(ctx, sizeof(struct FooClass));
                  newclass->header.allocation = HEAP;
                  newclass->name = PTR(FooBytes, ctx->frame[0].datum);
                  newclass->metaclass = super->metaclass;
                  newclass->inherited = inherited;
                  newclass->layout = super->layout;
                  newclass->mark = super->mark;
-                 newclass->size = 0;
+                 struct FooMethodTable* table = foo_alloc_no_gc(ctx, sizeof(struct FooMethodTable)
+                                                                + methods->size * sizeof(struct FooMethod));
+                 table->header.allocation = HEAP;
+                 // Hide the uninitialized part from GC.
+                 table->size = 0;
+                 FOO_SET_METHODS(newclass, table);
 
                  /* Make the new class visible to GC. */
                  ctx->frame[3] = (struct Foo)
@@ -124,7 +128,7 @@ define InstanceMethods
                    struct Foo selector_arity = foo_send(ctx, &FOO_arity, method_selector, 0);
                    foo_class_typecheck(ctx, &FooClass_Integer, selector_arity);
 
-                   struct FooMethod* m = &newclass->methods[i];
+                   struct FooMethod* m = &table->methods[i];
                    m->home = newclass;
                    m->selector = PTR(FooSelector, method_selector.datum);
                    m->function = foo_invoke_on;
@@ -132,7 +136,7 @@ define InstanceMethods
 
                    /* Update the size once the method is in place,
                       so GC sees it. */
-                   newclass->size++;
+                   table->size++;
                  }
                  return ctx->frame[3];"
         },
@@ -150,16 +154,19 @@ define InstanceMethods
                  // Allocate the new class: must use _no_gc since the inherited
                  // class list is not visible to GC yet!
                  struct FooArray* methods = PTR(FooArray, ctx->frame[3].datum);
-                 struct FooClass* newclass
-                   = foo_alloc(ctx, sizeof(struct FooClass)
-                               + methods->size * sizeof(struct FooMethod));
+                 struct FooClass* newclass = foo_alloc_no_gc(ctx, sizeof(struct FooClass));
                  newclass->header.allocation = HEAP;
                  newclass->name = PTR(FooBytes, ctx->frame[0].datum);
                  newclass->metaclass = PTR(FooClass, ctx->receiver.datum);
                  newclass->inherited = inherited;
                  newclass->layout = PTR(FooLayout, ctx->frame[1].datum);
                  newclass->mark = newclass->layout->mark;
-                 newclass->size = 0;
+                 struct FooMethodTable* table = foo_alloc_no_gc(ctx, sizeof(struct FooMethodTable)
+                                                                + methods->size * sizeof(struct FooMethod));
+                 table->header.allocation = HEAP;
+                 // Hide the uninitialized part from GC.
+                 table->size = 0;
+                 FOO_SET_METHODS(newclass, table);
 
                  /* Make the new class visible to GC. */
                  ctx->frame[4] = (struct Foo)
@@ -174,7 +181,7 @@ define InstanceMethods
                    struct Foo selector_arity = foo_send(ctx, &FOO_arity, method_selector, 0);
                    foo_class_typecheck(ctx, &FooClass_Integer, selector_arity);
 
-                   struct FooMethod* m = &newclass->methods[i];
+                   struct FooMethod* m = &table->methods[i];
                    m->home = newclass;
                    m->selector = PTR(FooSelector, method_selector.datum);
                    m->function = foo_invoke_on;
@@ -182,7 +189,7 @@ define InstanceMethods
 
                    /* Update the size once the method is in place,
                       so GC sees it. */
-                   newclass->size++;
+                   table->size++;
                  }
                  return ctx->frame[4];"
           }

--- a/foo/impl/transpiler/record.foo
+++ b/foo/impl/transpiler/record.foo
@@ -14,30 +14,32 @@ define InstanceMethods
 define DirectMethods
     { #keysIn:
           -> { signature: [Record], vars: 0,
-               body: "struct FooClass* vt = ctx->frame[0].class;
-// Methods originating in the instance's class are reader methods
-// and correspond to slots, so we can identify them -- except for
-// #classOf.
-size_t n = 0;
-for (size_t i = 0; i < vt->size; i++) \{
-    struct FooSelector* s = vt->methods[i].selector;
-    if (vt == vt->methods[i].home && s != &FOO_classOf)
-   \{
-        n++;
-    }
-}
-struct FooArray* keys = FooArray_alloc(ctx, n);
-size_t j = 0;
-for (size_t i = 0; i < vt->size; i++) \{
-    struct FooSelector* s = vt->methods[i].selector;
-    if (vt == vt->methods[i].home && s != &FOO_classOf)
-   \{
-        const struct FooSelector* selector = vt->methods[i].selector;
-        keys->data[j++] = (struct Foo)\{ .class = &FooClass_Selector,
-                                         .datum = \{ .ptr = (void*)selector }};
-    }
-}
-assert(j == n);
-return (struct Foo)\{ .class = &FooClass_Array,
-                      .datum = \{ .ptr = keys } };"}
+               body: "const struct FooClass* class = ctx->frame[0].class;
+                      const struct FooMethodTable* table = class->method_table;
+                      // Methods originating in the instance's class are reader methods
+                      // and correspond to slots, so we can identify them -- except for
+                      // #classOf.
+                      size_t n = 0;
+                      for (size_t i = 0; i < table->size; i++)
+                      \{
+                          const struct FooSelector* selector = table->methods[i].selector;
+                          if (class == table->methods[i].home && selector != &FOO_classOf)
+                          \{
+                              n++;
+                          }
+                      }
+                      struct FooArray* keys = FooArray_alloc(ctx, n);
+                      size_t j = 0;
+                      for (size_t i = 0; i < table->size; i++)
+                      \{
+                          const struct FooSelector* selector = table->methods[i].selector;
+                          if (class == table->methods[i].home && selector != &FOO_classOf)
+                          \{
+                              keys->data[j++] = (struct Foo)\{ .class = &FooClass_Selector,
+                                                               .datum = \{ .ptr = (void*)selector }};
+                          }
+                      }
+                      assert(j == n);
+                      return (struct Foo)\{ .class = &FooClass_Array,
+                                            .datum = \{ .ptr = keys } };" }
 }!


### PR DESCRIPTION
  Instead of storing methods directly in a variable-length class
  object, link a pointer to a variable-length method table:
  this way new methods can be added without changing the identity
  of the class.

  This is required to be able to materialize classes in interpreter
  that can be extended after the fact. (The other option would be
  a wholly separate object representation in interpreter, which
  seems like more trouble than it is worth right now.)

